### PR TITLE
feat(cache): use vary headers to compare cached response with request headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ db
 .nyc*
 yarn.lock
 .tap
+file:*

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -88,22 +88,19 @@ class CacheHandler extends DecoratorHandler {
 
   onComplete(rawTrailers) {
     if (this.#value) {
+      // get
+      const entries = this.#handler.entries
+      const resHeaders = parseHeaders(this.#value.data.rawHeaders)
+      const reqHeaders = this.#handler.opts
+
+      // set
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size = this.#value.size
         ? this.#value.size + rawTrailers?.reduce((xs, x) => xs + x.length, 0)
         : 0
-
-      const entries = this.#handler.entries
-
-      const reqHeaders = this.#handler.opts
-      const resHeaders = parseHeaders(this.#value.data.rawHeaders)
-
       this.#value.vary = formatVaryData(resHeaders, reqHeaders)
-
       entries.push(this.#value)
-
       sortEntriesByVary(entries)
-
       this.#store.set(this.#key, entries)
     }
     return this.#handler.onComplete(rawTrailers)

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { LRUCache } from 'lru-cache'
+// import { LRUCache } from 'lru-cache'
 import { DecoratorHandler, parseHeaders, parseCacheControl } from '../utils.js'
 
 class CacheHandler extends DecoratorHandler {
@@ -17,18 +17,12 @@ class CacheHandler extends DecoratorHandler {
   }
 
   onConnect(abort) {
-    console.log('onConnect abort')
-    console.log(abort)
-
     this.#value = null
 
     return this.#handler.onConnect(abort)
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusMessage, headers = parseHeaders(rawHeaders)) {
-    console.log('onHeaders')
-    console.log({ statusCode, rawHeaders, resume, statusMessage, headers })
-
     if (statusCode !== 307) {
       return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
     }
@@ -38,22 +32,6 @@ class CacheHandler extends DecoratorHandler {
 
     const contentLength = headers['content-length'] ? Number(headers['content-length']) : Infinity
     const maxEntrySize = this.#store.maxEntrySize ?? Infinity
-
-    console.log({ cacheControl, contentLength, maxEntrySize })
-
-    console.log('onHeaders if statement match:')
-
-    console.log(
-      contentLength < maxEntrySize &&
-        cacheControl &&
-        cacheControl.public &&
-        !cacheControl.private &&
-        !cacheControl['no-store'] &&
-        !cacheControl['no-cache'] &&
-        !cacheControl['must-understand'] &&
-        !cacheControl['must-revalidate'] &&
-        !cacheControl['proxy-revalidate'],
-    )
 
     if (
       contentLength < maxEntrySize &&
@@ -73,8 +51,6 @@ class CacheHandler extends DecoratorHandler {
         ? 31556952 // 1 year
         : Number(maxAge)
 
-      console.log({ ttl, maxAge, cacheControl, contentLength, maxEntrySize })
-
       if (ttl > 0) {
         this.#value = {
           data: {
@@ -91,12 +67,7 @@ class CacheHandler extends DecoratorHandler {
           ttl: ttl * 1e3,
         }
       }
-
-      console.log({ thisvalue: this.#value })
     }
-
-    console.log('onHeaders, finish:')
-    console.log({ statusCode, rawHeaders, resume, statusMessage, headers })
 
     return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
   }
@@ -116,33 +87,24 @@ class CacheHandler extends DecoratorHandler {
   }
 
   onComplete(rawTrailers) {
-    console.log('onComplete this:')
-    console.log({ thisvalue: this.#value })
-    console.log({ thisstore: this.#store }) // CacheStore{}
-    console.log({ thishandler: this.#handler }) // RequestHandler{}
-    console.log({ thishandlervalue: this.#handler.value })
-    console.log({ this: this })
     if (this.#value) {
       this.#value.data.rawTrailers = rawTrailers
-      this.#value.size += rawTrailers?.reduce((xs, x) => xs + x.length, 0) ?? 0
+      this.#value.size = this.#value.size
+        ? this.#value.size + rawTrailers?.reduce((xs, x) => xs + x.length, 0)
+        : 0
 
-      const opts = this.#handler.opts
       const entries = this.#handler.entries
-      console.log('onComplete this:')
-      console.log({ opts, entries })
 
       const reqHeaders = this.#handler.opts
       const resHeaders = parseHeaders(this.#value.data.rawHeaders)
 
-      const vary = formatVaryData(resHeaders, reqHeaders)
+      this.#value.vary = formatVaryData(resHeaders, reqHeaders)
 
-      console.log({ vary })
+      entries.push(this.#value)
 
-      this.#value.vary = vary
+      sortEntriesByVary(entries)
 
-      console.log({ entries })
-
-      this.#store.set(this.#key, entries.push(this.#value))
+      this.#store.set(this.#key, entries)
     }
     return this.#handler.onComplete(rawTrailers)
   }
@@ -153,6 +115,7 @@ function formatVaryData(resHeaders, reqHeaders) {
     ?.split(',')
     .map((key) => key.trim().toLowerCase())
     .map((key) => [key, reqHeaders[key]])
+    .filter(([_key, val]) => val)
 }
 
 // TODO (fix): Async filesystem cache.
@@ -160,11 +123,11 @@ class CacheStore {
   constructor({ maxSize = 1024 * 1024, maxEntrySize = 128 * 1024 }) {
     this.maxSize = maxSize
     this.maxEntrySize = maxEntrySize
-    this.cache = new LRUCache({ maxSize })
+    this.cache = new Map()
   }
 
   set(key, value, opts) {
-    this.cache.set(key, value, opts)
+    this.cache.set(key, value)
   }
 
   get(key) {
@@ -172,26 +135,25 @@ class CacheStore {
   }
 }
 
-function findEntryByHeaders(entries, reqHeaders) {
-  // Sort entries by number of vary headers in descending order, because
-  // we want to compare the most complex response to the request first.
+/*
+  Sort entries by number of vary headers in descending order, because
+  we need to compare the most complex response to the request first.
+  A cached response with an empty ´vary´ field will otherwise win every time.
+*/
+function sortEntriesByVary(entries) {
   entries.sort((a, b) => {
     const lengthA = a.vary ? a.vary.length : 0
     const lengthB = b.vary ? b.vary.length : 0
     return lengthB - lengthA
   })
+}
 
-  console.log('Sort entries')
-  console.log({ entries })
-
-  console.log('reqHeaders')
-  console.log({ reqHeaders })
+function findEntryByHeaders(entries, reqHeaders) {
+  sortEntriesByVary(entries)
 
   return entries?.find(
     (entry) =>
       entry.vary?.every(([key, val]) => {
-        console.log(`reqHeaders[${key}] === ${val}`)
-        console.log({ reqHeadersval: reqHeaders[key] })
         return reqHeaders[key] === val
       }) ?? true,
   )
@@ -200,13 +162,6 @@ function findEntryByHeaders(entries, reqHeaders) {
 const DEFAULT_CACHE_STORE = new CacheStore({ maxSize: 128 * 1024, maxEntrySize: 1024 })
 
 export default (opts) => (dispatch) => (opts, handler) => {
-  console.log('cache dispatcher:')
-  console.log(dispatch)
-  console.log('opts:')
-  console.log(opts)
-  console.log('handler:')
-  console.log(handler)
-
   if (!opts.cache || opts.upgrade) {
     return dispatch(opts, handler)
   }
@@ -235,6 +190,8 @@ export default (opts) => (dispatch) => (opts, handler) => {
   // Dump body...
   opts.body?.on('error', () => {}).resume()
 
+  opts.host = opts.host ?? new URL(opts.origin).host
+
   const store = opts.cache === true ? DEFAULT_CACHE_STORE : opts.cache
 
   if (!store) {
@@ -250,70 +207,10 @@ export default (opts) => (dispatch) => (opts, handler) => {
     entries = store.get(key)
   }
 
-  // testing
-  const rawHeaders = [
-    Buffer.from('Content-Type'),
-    Buffer.from('application/json'),
-    Buffer.from('Content-Length'),
-    Buffer.from('10'),
-    Buffer.from('Cache-Control'),
-    Buffer.from('public'),
-  ]
-  // // cannot get the cache to work inside the test, so I hardcode the entries here
-  entries = [
-    {
-      statusCode: 200,
-      statusMessage: '',
-      rawHeaders,
-      rawTrailers: ['Hello'],
-      body: ['asd1'],
-      vary: [
-        ['Accept', 'application/xml'],
-        ['User-Agent', 'Mozilla/5.0'],
-      ],
-    },
-    {
-      statusCode: 200,
-      statusMessage: '',
-      rawHeaders,
-      rawTrailers: ['Hello'],
-      body: ['asd2'],
-      vary: [
-        ['Accept', 'application/txt'],
-        ['User-Agent', 'Chrome'],
-        ['origin2', 'www.google.com/images'],
-      ],
-    },
-    // {
-    //   statusCode: 200, statusMessage: 'last', rawHeaders, rawTrailers: ['Hello'], body: ['asd3'],
-    //   vary: null },
-    {
-      statusCode: 200,
-      statusMessage: 'first',
-      rawHeaders,
-      rawTrailers: ['Hello'],
-      body: ['asd4'],
-      vary: [
-        ['Accept', 'application/json'],
-        ['User-Agent', 'Mozilla/5.0'],
-        ['host2', 'www.google.com'],
-        ['origin2', 'www.google.com/images'],
-      ],
-    },
-  ]
-
-  // *testing
-
-  // Find an entry that matches the request, if any
   const entry = findEntryByHeaders(entries, opts)
 
-  console.log('Entry found:')
-  console.log({ entry })
-
-  // handler.value.vary = 'foobar'
-
   if (entry) {
-    const { statusCode, statusMessage, rawHeaders, rawTrailers, body } = entry
+    const { statusCode, statusMessage, rawHeaders, rawTrailers, body } = entry.data
     const ac = new AbortController()
     const signal = ac.signal
 
@@ -345,8 +242,8 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
     return true
   } else {
-    // handler.opts = opts
-    // handler.entries = entries
+    handler.opts = opts
+    handler.entries = entries
     return dispatch(opts, new CacheHandler({ handler, store, key }))
   }
 }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -23,6 +23,9 @@ class CacheHandler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusMessage, headers = parseHeaders(rawHeaders)) {
+    // console.log('onHeaders, headers:')
+    // console.log(headers)
+
     if (statusCode !== 307) {
       return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
     }
@@ -58,7 +61,7 @@ class CacheHandler extends DecoratorHandler {
             statusMessage,
             rawHeaders,
             rawTrailers: null,
-            body: [],
+            body: [], // Why is the body emptied? When we cache it again it won't have a body.
           },
           size:
             (rawHeaders?.reduce((xs, x) => xs + x.length, 0) ?? 0) +
@@ -84,15 +87,38 @@ class CacheHandler extends DecoratorHandler {
       }
     }
     return this.#handler.onData(chunk)
+    /* 
+      Is 'this.#handler.onData' the previous dispatcher in the chain, e.g. 'redirect'?
+      And in 'redirect.onData(chunk)' it once again calls 'this.#handler.onData(chunk)'. 
+      Would that be 'responseVerify.onData(chunk)'?
+    */
   }
 
-  onComplete(rawTrailers) {
+  onComplete(rawTrailers, opts) {
+    console.log('onComplete, value: ' + this.#value)
+    console.log('onComplete, opts:')
+    console.log(opts)
+
     if (this.#value) {
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size += rawTrailers?.reduce((xs, x) => xs + x.length, 0) ?? 0
+
+      console.log('OnComplete, cache store is being set to: ')
+      console.log([this.#key, this.#value.data, { ttl: this.#value.ttl, size: this.#value.size }])
+
+      /*
+        Why are we setting the cache with the same data as the entry we fetched earlier 
+        from the very same cache?
+
+        We have the request data in the `opts` variable, but where is the response data that we need to cache?
+        Is the response cached somewhere else?
+
+        We have the headers we need from the request. But we need the response data to know the vary-header
+        and we also need it to store the response.
+      */
       this.#store.set(this.#key, this.#value.data, { ttl: this.#value.ttl, size: this.#value.size })
     }
-    return this.#handler.onComplete(rawTrailers)
+    return this.#handler.onComplete(rawTrailers, opts)
   }
 }
 
@@ -105,6 +131,9 @@ class CacheStore {
   }
 
   set(key, value, opts) {
+    console.log('setting cache with values:')
+    console.log({ key, value, opts })
+
     this.cache.set(key, value, opts)
   }
 
@@ -115,12 +144,46 @@ class CacheStore {
 
 function makeKey(opts) {
   // NOTE: Ignores headers...
-  return `${opts.origin}:${opts.method}:${opts.path}`
+  // return `${opts.origin}:${opts.method}:${opts.path}`
+  return `${opts.method}:${opts.path}`
+}
+
+function varyHeadersMatchRequest(varyHeaders, requestHeaders) {
+  // const headersToString = []
+  // for(const header of cachedRawHeaders){
+  //   headersToString.push(header.toString())
+  // }
+
+  // const varyHeaders = headersToString.reduce((acc, cur, index, arr) => {
+  //   if (index % 2 === 0) {
+  //     acc[cur] = arr[index + 1];
+  //   }
+  //   return acc;
+  // }, {});
+
+  // Early return if `varyHeaders` is null/undefined or an empty object
+  if (!varyHeaders || Object.keys(varyHeaders).length === 0) {
+    return true
+  }
+  const varyKeys = Object.keys(varyHeaders)
+  // All vary headers must match request headers, return true/false.
+  return varyKeys.every((varyKey) => varyHeaders[varyKey] === requestHeaders[varyKey])
+}
+
+function findEntryByHeaders(entries, requestHeaders) {
+  return entries.find((entry) => varyHeadersMatchRequest(entry, requestHeaders))
 }
 
 const DEFAULT_CACHE_STORE = new CacheStore({ maxSize: 128 * 1024, maxEntrySize: 1024 })
 
 export default (opts) => (dispatch) => (opts, handler) => {
+  console.log('cache dispatcher:')
+  console.log(dispatch)
+  console.log('opts:')
+  console.log(opts)
+  console.log('handler:')
+  console.log(handler)
+
   if (!opts.cache || opts.upgrade) {
     return dispatch(opts, handler)
   }
@@ -156,15 +219,24 @@ export default (opts) => (dispatch) => (opts, handler) => {
   }
 
   let key = makeKey(opts)
-  let value = store.get(key)
+  console.log('getting key: ' + key)
+  let entries = store.get(key)
 
-  if (value == null && opts.method === 'HEAD') {
+  console.log('Found entries in cache: ')
+  console.log(entries)
+
+  // if key with method:'HEAD' didn't yield results, retry with method:'GET'
+  if (entries.length === 0 && opts.method === 'HEAD') {
     key = makeKey({ ...opts, method: 'GET' })
-    value = store.get(key)
+    entries = store.get(key)
+    // value = {data: {headers: {vary: {origin: "www.google.com"}}}
   }
 
-  if (value) {
-    const { statusCode, statusMessage, rawHeaders, rawTrailers, body } = value
+  // Find an entry that matches the request, if any
+  const entry = findEntryByHeaders(entries, opts)
+
+  if (entry) {
+    const { statusCode, statusMessage, rawHeaders, rawTrailers, body } = entry
     const ac = new AbortController()
     const signal = ac.signal
 
@@ -186,9 +258,9 @@ export default (opts) => (dispatch) => (opts, handler) => {
             // TODO (fix): back pressure...
           }
         }
-        handler.onComplete(rawTrailers)
+        handler.onComplete(rawTrailers, opts)
       } else {
-        handler.onComplete([])
+        handler.onComplete([], opts)
       }
     } catch (err) {
       handler.onError(err)

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -17,14 +17,17 @@ class CacheHandler extends DecoratorHandler {
   }
 
   onConnect(abort) {
+    console.log('onConnect abort')
+    console.log(abort)
+
     this.#value = null
 
     return this.#handler.onConnect(abort)
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusMessage, headers = parseHeaders(rawHeaders)) {
-    // console.log('onHeaders, headers:')
-    // console.log(headers)
+    console.log('onHeaders')
+    console.log({ statusCode, rawHeaders, resume, statusMessage, headers })
 
     if (statusCode !== 307) {
       return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
@@ -35,6 +38,22 @@ class CacheHandler extends DecoratorHandler {
 
     const contentLength = headers['content-length'] ? Number(headers['content-length']) : Infinity
     const maxEntrySize = this.#store.maxEntrySize ?? Infinity
+
+    console.log({ cacheControl, contentLength, maxEntrySize })
+
+    console.log('onHeaders if statement match:')
+
+    console.log(
+      contentLength < maxEntrySize &&
+        cacheControl &&
+        cacheControl.public &&
+        !cacheControl.private &&
+        !cacheControl['no-store'] &&
+        !cacheControl['no-cache'] &&
+        !cacheControl['must-understand'] &&
+        !cacheControl['must-revalidate'] &&
+        !cacheControl['proxy-revalidate'],
+    )
 
     if (
       contentLength < maxEntrySize &&
@@ -54,6 +73,8 @@ class CacheHandler extends DecoratorHandler {
         ? 31556952 // 1 year
         : Number(maxAge)
 
+      console.log({ ttl, maxAge, cacheControl, contentLength, maxEntrySize })
+
       if (ttl > 0) {
         this.#value = {
           data: {
@@ -61,7 +82,7 @@ class CacheHandler extends DecoratorHandler {
             statusMessage,
             rawHeaders,
             rawTrailers: null,
-            body: [], // Why is the body emptied? When we cache it again it won't have a body.
+            body: [],
           },
           size:
             (rawHeaders?.reduce((xs, x) => xs + x.length, 0) ?? 0) +
@@ -70,7 +91,12 @@ class CacheHandler extends DecoratorHandler {
           ttl: ttl * 1e3,
         }
       }
+
+      console.log({ thisvalue: this.#value })
     }
+
+    console.log('onHeaders, finish:')
+    console.log({ statusCode, rawHeaders, resume, statusMessage, headers })
 
     return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
   }
@@ -87,39 +113,46 @@ class CacheHandler extends DecoratorHandler {
       }
     }
     return this.#handler.onData(chunk)
-    /* 
-      Is 'this.#handler.onData' the previous dispatcher in the chain, e.g. 'redirect'?
-      And in 'redirect.onData(chunk)' it once again calls 'this.#handler.onData(chunk)'. 
-      Would that be 'responseVerify.onData(chunk)'?
-    */
   }
 
-  onComplete(rawTrailers, opts) {
-    console.log('onComplete, value: ' + this.#value)
-    console.log('onComplete, opts:')
-    console.log(opts)
-
+  onComplete(rawTrailers) {
+    console.log('onComplete this:')
+    console.log({ thisvalue: this.#value })
+    console.log({ thisstore: this.#store }) // CacheStore{}
+    console.log({ thishandler: this.#handler }) // RequestHandler{}
+    console.log({ thishandlervalue: this.#handler.value })
+    console.log({ this: this })
     if (this.#value) {
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size += rawTrailers?.reduce((xs, x) => xs + x.length, 0) ?? 0
 
-      console.log('OnComplete, cache store is being set to: ')
-      console.log([this.#key, this.#value.data, { ttl: this.#value.ttl, size: this.#value.size }])
+      const opts = this.#handler.opts
+      const entries = this.#handler.entries
+      console.log('onComplete this:')
+      console.log({ opts, entries })
 
-      /*
-        Why are we setting the cache with the same data as the entry we fetched earlier 
-        from the very same cache?
+      const reqHeaders = this.#handler.opts
+      const resHeaders = parseHeaders(this.#value.data.rawHeaders)
 
-        We have the request data in the `opts` variable, but where is the response data that we need to cache?
-        Is the response cached somewhere else?
+      const vary = formatVaryData(resHeaders, reqHeaders)
 
-        We have the headers we need from the request. But we need the response data to know the vary-header
-        and we also need it to store the response.
-      */
-      this.#store.set(this.#key, this.#value.data, { ttl: this.#value.ttl, size: this.#value.size })
+      console.log({ vary })
+
+      this.#value.vary = vary
+
+      console.log({ entries })
+
+      this.#store.set(this.#key, entries.push(this.#value))
     }
-    return this.#handler.onComplete(rawTrailers, opts)
+    return this.#handler.onComplete(rawTrailers)
   }
+}
+
+function formatVaryData(resHeaders, reqHeaders) {
+  return resHeaders.vary
+    ?.split(',')
+    .map((key) => key.trim().toLowerCase())
+    .map((key) => [key, reqHeaders[key]])
 }
 
 // TODO (fix): Async filesystem cache.
@@ -131,9 +164,6 @@ class CacheStore {
   }
 
   set(key, value, opts) {
-    console.log('setting cache with values:')
-    console.log({ key, value, opts })
-
     this.cache.set(key, value, opts)
   }
 
@@ -142,36 +172,29 @@ class CacheStore {
   }
 }
 
-function makeKey(opts) {
-  // NOTE: Ignores headers...
-  // return `${opts.origin}:${opts.method}:${opts.path}`
-  return `${opts.method}:${opts.path}`
-}
+function findEntryByHeaders(entries, reqHeaders) {
+  // Sort entries by number of vary headers in descending order, because
+  // we want to compare the most complex response to the request first.
+  entries.sort((a, b) => {
+    const lengthA = a.vary ? a.vary.length : 0
+    const lengthB = b.vary ? b.vary.length : 0
+    return lengthB - lengthA
+  })
 
-function varyHeadersMatchRequest(varyHeaders, requestHeaders) {
-  // const headersToString = []
-  // for(const header of cachedRawHeaders){
-  //   headersToString.push(header.toString())
-  // }
+  console.log('Sort entries')
+  console.log({ entries })
 
-  // const varyHeaders = headersToString.reduce((acc, cur, index, arr) => {
-  //   if (index % 2 === 0) {
-  //     acc[cur] = arr[index + 1];
-  //   }
-  //   return acc;
-  // }, {});
+  console.log('reqHeaders')
+  console.log({ reqHeaders })
 
-  // Early return if `varyHeaders` is null/undefined or an empty object
-  if (!varyHeaders || Object.keys(varyHeaders).length === 0) {
-    return true
-  }
-  const varyKeys = Object.keys(varyHeaders)
-  // All vary headers must match request headers, return true/false.
-  return varyKeys.every((varyKey) => varyHeaders[varyKey] === requestHeaders[varyKey])
-}
-
-function findEntryByHeaders(entries, requestHeaders) {
-  return entries.find((entry) => varyHeadersMatchRequest(entry, requestHeaders))
+  return entries?.find(
+    (entry) =>
+      entry.vary?.every(([key, val]) => {
+        console.log(`reqHeaders[${key}] === ${val}`)
+        console.log({ reqHeadersval: reqHeaders[key] })
+        return reqHeaders[key] === val
+      }) ?? true,
+  )
 }
 
 const DEFAULT_CACHE_STORE = new CacheStore({ maxSize: 128 * 1024, maxEntrySize: 1024 })
@@ -218,22 +241,76 @@ export default (opts) => (dispatch) => (opts, handler) => {
     throw new Error(`Cache store not provided.`)
   }
 
-  let key = makeKey(opts)
+  let key = `${opts.method}:${opts.path}`
   console.log('getting key: ' + key)
   let entries = store.get(key)
 
-  console.log('Found entries in cache: ')
-  console.log(entries)
-
-  // if key with method:'HEAD' didn't yield results, retry with method:'GET'
-  if (entries.length === 0 && opts.method === 'HEAD') {
-    key = makeKey({ ...opts, method: 'GET' })
+  if (Array.isArray(entries) && entries.length === 0 && opts.method === 'HEAD') {
+    key = `GET:${opts.path}`
     entries = store.get(key)
-    // value = {data: {headers: {vary: {origin: "www.google.com"}}}
   }
+
+  // testing
+  const rawHeaders = [
+    Buffer.from('Content-Type'),
+    Buffer.from('application/json'),
+    Buffer.from('Content-Length'),
+    Buffer.from('10'),
+    Buffer.from('Cache-Control'),
+    Buffer.from('public'),
+  ]
+  // // cannot get the cache to work inside the test, so I hardcode the entries here
+  entries = [
+    {
+      statusCode: 200,
+      statusMessage: '',
+      rawHeaders,
+      rawTrailers: ['Hello'],
+      body: ['asd1'],
+      vary: [
+        ['Accept', 'application/xml'],
+        ['User-Agent', 'Mozilla/5.0'],
+      ],
+    },
+    {
+      statusCode: 200,
+      statusMessage: '',
+      rawHeaders,
+      rawTrailers: ['Hello'],
+      body: ['asd2'],
+      vary: [
+        ['Accept', 'application/txt'],
+        ['User-Agent', 'Chrome'],
+        ['origin2', 'www.google.com/images'],
+      ],
+    },
+    // {
+    //   statusCode: 200, statusMessage: 'last', rawHeaders, rawTrailers: ['Hello'], body: ['asd3'],
+    //   vary: null },
+    {
+      statusCode: 200,
+      statusMessage: 'first',
+      rawHeaders,
+      rawTrailers: ['Hello'],
+      body: ['asd4'],
+      vary: [
+        ['Accept', 'application/json'],
+        ['User-Agent', 'Mozilla/5.0'],
+        ['host2', 'www.google.com'],
+        ['origin2', 'www.google.com/images'],
+      ],
+    },
+  ]
+
+  // *testing
 
   // Find an entry that matches the request, if any
   const entry = findEntryByHeaders(entries, opts)
+
+  console.log('Entry found:')
+  console.log({ entry })
+
+  // handler.value.vary = 'foobar'
 
   if (entry) {
     const { statusCode, statusMessage, rawHeaders, rawTrailers, body } = entry
@@ -258,9 +335,9 @@ export default (opts) => (dispatch) => (opts, handler) => {
             // TODO (fix): back pressure...
           }
         }
-        handler.onComplete(rawTrailers, opts)
+        handler.onComplete(rawTrailers)
       } else {
-        handler.onComplete([], opts)
+        handler.onComplete([])
       }
     } catch (err) {
       handler.onError(err)
@@ -268,6 +345,8 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
     return true
   } else {
-    return dispatch(opts, new CacheHandler({ handler, store, key: makeKey(opts) }))
+    // handler.opts = opts
+    // handler.entries = entries
+    return dispatch(opts, new CacheHandler({ handler, store, key }))
   }
 }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -124,6 +124,7 @@ export class CacheStore {
   #getQuery
   #purgeQuery
   #database
+  #sizeQuery
   #size = 0
   #maxSize = 128e9
 
@@ -152,6 +153,8 @@ export class CacheStore {
     )
 
     this.#purgeQuery = this.#database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
+
+    this.#sizeQuery = this.#database.prepare('SELECT SUM(size) FROM cacheInterceptor')
   }
 
   set(key, { data, vary, size, expires }) {
@@ -199,9 +202,7 @@ export class CacheStore {
     if (this.#size == null || this.#size > this.#maxSize) {
       this.#purgeQuery.run(Date.now())
 
-      this.#size = Object.values(
-        this.#database.prepare('SELECT SUM(size) FROM cacheInterceptor').get(),
-      )[0]
+      this.#size = Object.values(this.#sizeQuery.get())[0]
 
       // In the case where the cache is full but has no expired entries yet, delete 10% of the cache, ordered by
       // the oldest entries according to the 'expires' column.
@@ -215,6 +216,8 @@ export class CacheStore {
               LIMIT (SELECT ROUND(COUNT(*) * 0.10 + 1) FROM cacheInterceptor)
           );
         `)
+
+        this.#size = Object.values(this.#sizeQuery.get())[0]
       }
     }
   }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -91,12 +91,17 @@ class CacheHandler extends DecoratorHandler {
     if (this.#value) {
       const resHeaders = parseHeaders(this.#value.data.rawHeaders)
 
-      // Early return if vary = *, uncacheable.
+      // Early return if Vary = *, uncacheable.
       if (resHeaders.vary === '*') {
         return this.#handler.onComplete(rawTrailers)
       }
 
       const reqHeaders = this.#opts
+
+      // If Range header present, assume that the response varies based on Range.
+      if (reqHeaders.headers?.range) {
+        resHeaders.vary += ', Range'
+      }
 
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size = this.#value.size
@@ -115,7 +120,7 @@ function formatVaryData(resHeaders, reqHeaders) {
   return resHeaders.vary
     ?.split(',')
     .map((key) => key.trim().toLowerCase())
-    .map((key) => [key, reqHeaders[key]])
+    .map((key) => [key, reqHeaders[key] ?? reqHeaders.headers[key]])
     .filter(([_key, val]) => val)
 }
 
@@ -168,6 +173,13 @@ export class CacheStore {
     rows.map((i) => {
       i.data = JSON.parse(i.data)
       i.vary = JSON.parse(i.vary)
+      i.data = {
+        ...i.data,
+        // JSON.parse doesn't convert a Buffer object back to a Buffer object once it has been stringified.
+        body: this.#convertToBuffer(i.data.body),
+        rawHeaders: this.#convertToBuffer(i.data.rawHeaders),
+        rawTrailers: this.#convertToBuffer(i.data.rawTrailers),
+      }
       return i
     })
 
@@ -182,6 +194,15 @@ export class CacheStore {
   deleteAll() {
     const query = this.database.prepare('DELETE FROM cacheInterceptor')
     query.run()
+  }
+
+  #convertToBuffer(bufferArray) {
+    if (Array.isArray(bufferArray) && bufferArray.length > 0) {
+      return bufferArray.map((ba) => {
+        return typeof ba === 'object' ? Buffer.from(ba.data) : ba
+      })
+    }
+    return []
   }
 }
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { DecoratorHandler, parseHeaders, parseCacheControl } from '../utils.js'
 import { DatabaseSync } from 'node:sqlite' // --experimental-sqlite
+import * as BJSON from 'buffer-json'
 
 class CacheHandler extends DecoratorHandler {
   #handler
@@ -25,7 +26,7 @@ class CacheHandler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusMessage, headers = parseHeaders(rawHeaders)) {
-    if (statusCode !== 307) {
+    if (statusCode !== 307 && statusCode !== 200) {
       return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
     }
 
@@ -76,7 +77,6 @@ class CacheHandler extends DecoratorHandler {
   onData(chunk) {
     if (this.#value) {
       this.#value.size += chunk.bodyLength
-
       const maxEntrySize = this.#store.maxEntrySize ?? Infinity
       if (this.#value.size > maxEntrySize) {
         this.#value = null
@@ -97,11 +97,6 @@ class CacheHandler extends DecoratorHandler {
       }
 
       const reqHeaders = this.#opts
-
-      // If Range header present, assume that the response varies based on Range.
-      if (reqHeaders.headers?.range) {
-        resHeaders.vary += ', Range'
-      }
 
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size = this.#value.size
@@ -128,18 +123,18 @@ export class CacheStore {
   #insertquery
   #getQuery
   #purgeQuery
-  #deleteAllQuery
+  #database
+  #size = 0
+  #maxSize = 128e9
 
-  constructor() {
-    this.database = null
-    this.init()
-  }
+  constructor(location = ':memory:', opts = {}) {
+    this.#maxSize = opts.maxSize ?? this.#maxSize
 
-  init() {
-    this.database = new DatabaseSync(':memory:')
+    this.#database = new DatabaseSync(location)
 
-    this.database.exec(`
+    this.#database.exec(`
       CREATE TABLE IF NOT EXISTS cacheInterceptor(
+        id INTEGER PRIMARY KEY,
         key TEXT,
         data TEXT,
         vary TEXT,
@@ -148,70 +143,80 @@ export class CacheStore {
       ) STRICT
     `)
 
-    this.#insertquery = this.database.prepare(
+    this.#insertquery = this.#database.prepare(
       'INSERT INTO cacheInterceptor (key, data, vary, size, expires) VALUES (?, ?, ?, ?, ?)',
     )
 
-    this.#getQuery = this.database.prepare(
+    this.#getQuery = this.#database.prepare(
       'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ? ',
     )
 
-    this.#purgeQuery = this.database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
-
-    this.#deleteAllQuery = this.database.prepare('DELETE FROM cacheInterceptor')
+    this.#purgeQuery = this.#database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
   }
 
-  set(key, entry) {
-    if (!this.database) {
+  set(key, { data, vary, size, expires }) {
+    if (!this.#database) {
       throw new Error('Database not initialized')
     }
 
-    entry.data = JSON.stringify(entry.data)
-    entry.vary = JSON.stringify(entry.vary)
+    if (expires < Date.now()) {
+      return
+    }
 
-    this.#insertquery.run(key, entry.data, entry.vary, entry.size, entry.expires)
+    this.#insertquery.run(key, BJSON.stringify(data), BJSON.stringify(vary), size, expires)
 
-    this.purge()
+    this.#size += size
+
+    this.#maybePurge()
   }
 
   get(key) {
-    if (!this.database) {
+    if (!this.#database) {
       throw new Error('Database not initialized')
     }
-    this.purge()
 
-    const rows = this.#getQuery.all(key, Date.now())
-    rows.map((i) => {
-      i.data = JSON.parse(i.data)
-      i.vary = JSON.parse(i.vary)
-      i.data = {
-        ...i.data,
-        // JSON.parse doesn't convert a Buffer object back to a Buffer object once it has been stringified.
-        body: this.#convertToBuffer(i.data.body),
-        rawHeaders: this.#convertToBuffer(i.data.rawHeaders),
-        rawTrailers: this.#convertToBuffer(i.data.rawTrailers),
+    const rows = this.#getQuery.all(key, Date.now()).map(({ data, vary, size, expires }) => {
+      return {
+        data: BJSON.parse(data),
+        vary: JSON.parse(vary),
+        size: parseInt(size),
+        expires: parseInt(expires),
       }
-      return i
     })
 
     return rows
   }
 
-  purge() {
-    this.#purgeQuery.run(Date.now())
-  }
-
   deleteAll() {
-    this.#deleteAllQuery.run()
+    this.#database.exec('DELETE FROM cacheInterceptor')
   }
 
-  #convertToBuffer(bufferArray) {
-    if (Array.isArray(bufferArray) && bufferArray.length > 0) {
-      return bufferArray.map((ba) => {
-        return ba?.type === 'Buffer' ? Buffer.from(ba.data) : ba
-      })
+  close() {
+    this.#database.close()
+  }
+
+  #maybePurge() {
+    if (this.#size == null || this.#size > this.#maxSize) {
+      this.#purgeQuery.run(Date.now())
+
+      this.#size = Object.values(
+        this.#database.prepare('SELECT SUM(size) FROM cacheInterceptor').get(),
+      )[0]
+
+      // In the case where the cache is full but has no expired entries yet, delete 10% of the cache, ordered by
+      // the oldest entries according to the 'expires' column.
+      if (this.#size > this.#maxSize) {
+        this.#database.exec(`
+          DELETE FROM cacheInterceptor
+          WHERE id IN (
+              SELECT id
+              FROM cacheInterceptor
+              ORDER BY expires ASC
+              LIMIT (SELECT ROUND(COUNT(*) * 0.10 + 1) FROM cacheInterceptor)
+          );
+        `)
+      }
     }
-    return bufferArray
   }
 }
 
@@ -228,13 +233,13 @@ function sortEntriesByVary(entries) {
   })
 }
 
-function findEntryByHeaders(entries, reqHeaders) {
+function findEntryByHeaders(entries, request) {
   sortEntriesByVary(entries)
 
   return entries?.find(
     (entry) =>
       entry.vary?.every(([key, val]) => {
-        return reqHeaders?.headers[key] === val
+        return request?.headers[key] === val || request[key] === val
       }) ?? true,
   )
 }
@@ -269,7 +274,6 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
   // Dump body...
   opts.body?.on('error', () => {}).resume()
-
   opts.host = opts.host ?? new URL(opts.origin).host
 
   if (!opts.headers) {

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -125,13 +125,18 @@ function formatVaryData(resHeaders, reqHeaders) {
 }
 
 export class CacheStore {
+  #insertquery
+  #getQuery
+  #purgeQuery
+  #deleteAllQuery
+
   constructor() {
     this.database = null
     this.init()
   }
 
   init() {
-    this.database = new DatabaseSync('file:memdb1?mode=memory&cache=shared')
+    this.database = new DatabaseSync(':memory:')
 
     this.database.exec(`
       CREATE TABLE IF NOT EXISTS cacheInterceptor(
@@ -142,6 +147,18 @@ export class CacheStore {
         expires INTEGER
       ) STRICT
     `)
+
+    this.#insertquery = this.database.prepare(
+      'INSERT INTO cacheInterceptor (key, data, vary, size, expires) VALUES (?, ?, ?, ?, ?)',
+    )
+
+    this.#getQuery = this.database.prepare(
+      'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ? ',
+    )
+
+    this.#purgeQuery = this.database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
+
+    this.#deleteAllQuery = this.database.prepare('DELETE FROM cacheInterceptor')
   }
 
   set(key, entry) {
@@ -152,11 +169,7 @@ export class CacheStore {
     entry.data = JSON.stringify(entry.data)
     entry.vary = JSON.stringify(entry.vary)
 
-    const insert = this.database.prepare(
-      'INSERT INTO cacheInterceptor (key, data, vary, size, expires) VALUES (?, ?, ?, ?, ?)',
-    )
-
-    insert.run(key, entry.data, entry.vary, entry.size, entry.expires)
+    this.#insertquery.run(key, entry.data, entry.vary, entry.size, entry.expires)
 
     this.purge()
   }
@@ -166,10 +179,8 @@ export class CacheStore {
       throw new Error('Database not initialized')
     }
     this.purge()
-    const query = this.database.prepare(
-      'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ? ',
-    )
-    const rows = query.all(key, Date.now())
+
+    const rows = this.#getQuery.all(key, Date.now())
     rows.map((i) => {
       i.data = JSON.parse(i.data)
       i.vary = JSON.parse(i.vary)
@@ -187,22 +198,20 @@ export class CacheStore {
   }
 
   purge() {
-    const query = this.database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
-    query.run(Date.now())
+    this.#purgeQuery.run(Date.now())
   }
 
   deleteAll() {
-    const query = this.database.prepare('DELETE FROM cacheInterceptor')
-    query.run()
+    this.#deleteAllQuery.run()
   }
 
   #convertToBuffer(bufferArray) {
     if (Array.isArray(bufferArray) && bufferArray.length > 0) {
       return bufferArray.map((ba) => {
-        return typeof ba === 'object' ? Buffer.from(ba.data) : ba
+        return ba?.type === 'Buffer' ? Buffer.from(ba.data) : ba
       })
     }
-    return []
+    return bufferArray
   }
 }
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import { DecoratorHandler, parseHeaders, parseCacheControl } from '../utils.js'
-import { DatabaseSync } from 'node:sqlite' // --experimental-sqlite
+import Database from 'better-sqlite3'
+
 import * as BJSON from 'buffer-json'
 
 class CacheHandler extends DecoratorHandler {
@@ -120,9 +121,11 @@ function formatVaryData(resHeaders, reqHeaders) {
 }
 
 export class CacheStore {
+  connected = false
   #insertquery
   #getQuery
-  #purgeQuery
+  #purgeExpiredQuery
+  #purgeOldestQuery
   #database
   #sizeQuery
   #size = 0
@@ -133,11 +136,11 @@ export class CacheStore {
     this.#maxSize = opts.maxSize ?? this.#maxSize
     this.#maxTTL = opts.maxTTL ?? this.#maxTTL
 
-    this.#database = new DatabaseSync(location)
+    this.#database = new Database(location)
 
     this.#database.exec(`
       CREATE TABLE IF NOT EXISTS cacheInterceptor(
-        id INTEGER PRIMARY KEY,
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
         key TEXT,
         data TEXT,
         vary TEXT,
@@ -149,14 +152,24 @@ export class CacheStore {
     this.#insertquery = this.#database.prepare(
       'INSERT INTO cacheInterceptor (key, data, vary, size, expires) VALUES (?, ?, ?, ?, ?)',
     )
-
     this.#getQuery = this.#database.prepare(
-      'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ? ',
+      'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ?',
     )
-
-    this.#purgeQuery = this.#database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
-
+    this.#purgeExpiredQuery = this.#database.prepare(
+      'DELETE FROM cacheInterceptor WHERE expires < ?',
+    )
     this.#sizeQuery = this.#database.prepare('SELECT SUM(size) FROM cacheInterceptor')
+    this.#purgeOldestQuery = this.#database.prepare(`
+      DELETE FROM cacheInterceptor
+      WHERE id IN (
+          SELECT id
+          FROM cacheInterceptor
+          ORDER BY expires ASC
+          LIMIT (SELECT CEILING(COUNT(*) * 0.10) FROM cacheInterceptor)
+      );
+    `)
+
+    this.connected = true
   }
 
   set(key, { data, vary, size, expires }) {
@@ -165,18 +178,19 @@ export class CacheStore {
     }
 
     const maxExpires = Date.now() + this.#maxTTL
-
     expires = expires > maxExpires ? maxExpires : expires
 
     this.#insertquery.run(key, BJSON.stringify(data), BJSON.stringify(vary), size, expires)
 
     this.#size += size
-
     this.#maybePurge()
   }
 
   get(key) {
-    const rows = this.#getQuery.all(key, Date.now()).map(({ data, vary, size, expires }) => {
+    const rows = this.#getQuery.all(key, Date.now())
+
+    return rows.map((row) => {
+      const { data, vary, size, expires } = row
       return {
         data: BJSON.parse(data),
         vary: JSON.parse(vary),
@@ -184,53 +198,41 @@ export class CacheStore {
         expires: parseInt(expires),
       }
     })
-
-    return rows
-  }
-
-  deleteAll() {
-    this.#database.exec('DELETE FROM cacheInterceptor')
   }
 
   close() {
     this.#database.close()
+    this.connected = false
   }
 
   #maybePurge() {
     if (this.#size == null || this.#size > this.#maxSize) {
-      this.#purgeQuery.run(Date.now())
-
-      this.#size = Object.values(this.#sizeQuery.get())[0]
+      this.#purgeExpiredQuery.run(Date.now())
+      this.#size = this.#sizeQuery.get()['SUM(size)']
 
       // In the case where the cache is full but has no expired entries yet, delete 10% of the cache, ordered by
       // the oldest entries according to the 'expires' column.
       if (this.#size > this.#maxSize) {
-        this.#database.exec(`
-          DELETE FROM cacheInterceptor
-          WHERE id IN (
-              SELECT id
-              FROM cacheInterceptor
-              ORDER BY expires ASC
-              LIMIT (SELECT ROUND(COUNT(*) * 0.10 + 1) FROM cacheInterceptor)
-          );
-        `)
-
-        this.#size = Object.values(this.#sizeQuery.get())[0]
+        this.#purgeOldestQuery.run()
+        this.#size = this.#sizeQuery.get()['SUM(size)']
       }
     }
   }
 }
 
 function findEntryByHeaders(entries, request) {
-  return entries?.find(
+  const foundEntry = entries?.find(
     (entry) =>
       entry.vary?.every(([key, val]) => {
         return request?.headers[key] === val || request[key] === val
       }) ?? true,
   )
+
+  // if no exact match was found, take the latest added entry
+  return foundEntry ?? entries[0]
 }
 
-const DEFAULT_CACHE_STORE = new CacheStore()
+let cacheInstance = null
 
 export default (opts) => (dispatch) => (opts, handler) => {
   if (!opts.cache || opts.upgrade) {
@@ -266,16 +268,27 @@ export default (opts) => (dispatch) => (opts, handler) => {
     opts.headers = {}
   }
 
-  // idea: use DEFAULT_CACHE_STORE by default if 'cache' not specified, since the cache interceptor was already specified to be used.
-  const store = opts.cache === true ? DEFAULT_CACHE_STORE : opts.cache
+  // Supported opts.cache values: [true, false, 'clear', custom cache]
+  // create new cache instance if none exists
+  if (opts.cache === 'clear' || (!cacheInstance?.connected && opts.cache === true)) {
+    cacheInstance = new CacheStore()
+  }
 
-  if (!store) {
+  // or use provided cache instead
+  if (typeof opts.cache === 'object') {
+    cacheInstance = opts.cache
+  }
+
+  if (!cacheInstance) {
     throw new Error(`Cache store not provided.`)
   }
 
   const key = `${opts.method}:${opts.path}`
 
-  const entries = (store.get(key) ?? opts.method === 'HEAD') ? store.get(`GET:${opts.path}`) : null
+  const entries =
+    (cacheInstance.get(key) ?? opts.method === 'HEAD')
+      ? cacheInstance.get(`GET:${opts.path}`)
+      : null
 
   const entry = findEntryByHeaders(entries, opts)
 
@@ -315,6 +328,6 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
     return true
   } else {
-    return dispatch(opts, new CacheHandler({ handler, store, key, opts }))
+    return dispatch(opts, new CacheHandler({ handler, store: cacheInstance, key, opts }))
   }
 }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -246,14 +246,9 @@ export default (opts) => (dispatch) => (opts, handler) => {
     throw new Error(`Cache store not provided.`)
   }
 
-  let key = `${opts.method}:${opts.path}`
+  const key = `${opts.method}:${opts.path}`
 
-  let entries = store.get(key)
-
-  if (Array.isArray(entries) && entries.length === 0 && opts.method === 'HEAD') {
-    key = `GET:${opts.path}`
-    entries = store.get(key)
-  }
+  const entries = (store.get(key) ?? opts.method === 'HEAD') ? store.get(`GET:${opts.path}`) : null
 
   const entry = findEntryByHeaders(entries, opts)
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -127,9 +127,11 @@ export class CacheStore {
   #sizeQuery
   #size = 0
   #maxSize = 128e9
+  #maxTTL = Infinity
 
   constructor(location = ':memory:', opts = {}) {
     this.#maxSize = opts.maxSize ?? this.#maxSize
+    this.#maxTTL = opts.maxTTL ?? this.#maxTTL
 
     this.#database = new DatabaseSync(location)
 
@@ -158,13 +160,13 @@ export class CacheStore {
   }
 
   set(key, { data, vary, size, expires }) {
-    if (!this.#database) {
-      throw new Error('Database not initialized')
-    }
-
     if (expires < Date.now()) {
       return
     }
+
+    const maxExpires = Date.now() + this.#maxTTL
+
+    expires = expires > maxExpires ? maxExpires : expires
 
     this.#insertquery.run(key, BJSON.stringify(data), BJSON.stringify(vary), size, expires)
 
@@ -174,10 +176,6 @@ export class CacheStore {
   }
 
   get(key) {
-    if (!this.#database) {
-      throw new Error('Database not initialized')
-    }
-
     const rows = this.#getQuery.all(key, Date.now()).map(({ data, vary, size, expires }) => {
       return {
         data: BJSON.parse(data),
@@ -223,22 +221,7 @@ export class CacheStore {
   }
 }
 
-/*
-  Sort entries by number of vary headers in descending order, because
-  we need to compare the most complex response to the request first.
-  A cached response with an empty ´vary´ field will otherwise win every time.
-*/
-function sortEntriesByVary(entries) {
-  entries.sort((a, b) => {
-    const lengthA = a.vary ? a.vary.length : 0
-    const lengthB = b.vary ? b.vary.length : 0
-    return lengthB - lengthA
-  })
-}
-
 function findEntryByHeaders(entries, request) {
-  sortEntriesByVary(entries)
-
   return entries?.find(
     (entry) =>
       entry.vary?.every(([key, val]) => {

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,19 +1,21 @@
 import assert from 'node:assert'
-// import { LRUCache } from 'lru-cache'
 import { DecoratorHandler, parseHeaders, parseCacheControl } from '../utils.js'
+import { DatabaseSync } from 'node:sqlite' // --experimental-sqlite
 
 class CacheHandler extends DecoratorHandler {
   #handler
   #store
   #key
+  #opts
   #value = null
 
-  constructor({ key, handler, store }) {
+  constructor({ key, handler, store, opts = [] }) {
     super(handler)
 
     this.#key = key
     this.#handler = handler
     this.#store = store
+    this.#opts = opts
   }
 
   onConnect(abort) {
@@ -64,11 +66,10 @@ class CacheHandler extends DecoratorHandler {
             (rawHeaders?.reduce((xs, x) => xs + x.length, 0) ?? 0) +
             (statusMessage?.length ?? 0) +
             64,
-          ttl: ttl * 1e3,
+          ttl, // in ms!
         }
       }
     }
-
     return this.#handler.onHeaders(statusCode, rawHeaders, resume, statusMessage, headers)
   }
 
@@ -88,20 +89,16 @@ class CacheHandler extends DecoratorHandler {
 
   onComplete(rawTrailers) {
     if (this.#value) {
-      // get
-      const entries = this.#handler.entries
       const resHeaders = parseHeaders(this.#value.data.rawHeaders)
-      const reqHeaders = this.#handler.opts
+      const reqHeaders = this.#opts
 
-      // set
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size = this.#value.size
         ? this.#value.size + rawTrailers?.reduce((xs, x) => xs + x.length, 0)
         : 0
       this.#value.vary = formatVaryData(resHeaders, reqHeaders)
-      entries.push(this.#value)
-      sortEntriesByVary(entries)
-      this.#store.set(this.#key, entries)
+
+      this.#store.set(this.#key, this.#value)
     }
     return this.#handler.onComplete(rawTrailers)
   }
@@ -115,20 +112,72 @@ function formatVaryData(resHeaders, reqHeaders) {
     .filter(([_key, val]) => val)
 }
 
-// TODO (fix): Async filesystem cache.
+// Can we move this class somewhere else, to the util.js file or its own module?
 class CacheStore {
-  constructor({ maxSize = 1024 * 1024, maxEntrySize = 128 * 1024 }) {
-    this.maxSize = maxSize
-    this.maxEntrySize = maxEntrySize
-    this.cache = new Map()
+  constructor() {
+    this.database = null
+    this.init()
   }
 
-  set(key, value, opts) {
-    this.cache.set(key, value)
+  init() {
+    this.database = new DatabaseSync('file:memdb1?mode=memory&cache=shared')
+
+    this.database.exec(`
+      CREATE TABLE IF NOT EXISTS cacheInterceptor(
+        key TEXT,
+        data TEXT,
+        vary TEXT,
+        size INTEGER,
+        ttl INTEGER,
+        insertTime INTEGER
+      ) STRICT
+    `)
+  }
+
+  set(key, entry, opts) {
+    if (!this.database) {
+      throw new Error('Database not initialized')
+    }
+
+    entry.data = JSON.stringify(entry.data)
+    entry.vary = JSON.stringify(entry.vary)
+
+    const insert = this.database.prepare(
+      'INSERT INTO cacheInterceptor (key, data, vary, size, ttl, insertTime) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+
+    insert.run(key, entry.data, entry.vary, entry.size, entry.ttl, Date.now())
+
+    this.purge()
   }
 
   get(key) {
-    return this.cache.get(key)
+    if (!this.database) {
+      throw new Error('Database not initialized')
+    }
+    this.purge()
+    const query = this.database.prepare('SELECT * FROM cacheInterceptor WHERE key = ?')
+    const rows = query.all(key)
+    rows.map((i) => {
+      i.data = JSON.parse(i.data)
+      i.vary = JSON.parse(i.vary)
+      return i
+    })
+
+    // Just in case purge hasn't finished
+    const nonExpiredRows = rows.filter((i) => i.insertTime + i.ttl > Date.now())
+
+    return nonExpiredRows
+  }
+
+  purge() {
+    const query = this.database.prepare('DELETE FROM cacheInterceptor WHERE insertTime + ttl < ?')
+    query.run(Date.now())
+  }
+
+  deleteAll() {
+    const query = this.database.prepare('DELETE FROM cacheInterceptor')
+    query.run()
   }
 }
 
@@ -151,12 +200,12 @@ function findEntryByHeaders(entries, reqHeaders) {
   return entries?.find(
     (entry) =>
       entry.vary?.every(([key, val]) => {
-        return reqHeaders[key] === val
+        return reqHeaders?.headers[key] === val
       }) ?? true,
   )
 }
 
-const DEFAULT_CACHE_STORE = new CacheStore({ maxSize: 128 * 1024, maxEntrySize: 1024 })
+const DEFAULT_CACHE_STORE = new CacheStore()
 
 export default (opts) => (dispatch) => (opts, handler) => {
   if (!opts.cache || opts.upgrade) {
@@ -189,6 +238,11 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
   opts.host = opts.host ?? new URL(opts.origin).host
 
+  if (!opts.headers) {
+    opts.headers = {}
+  }
+
+  // idea: use DEFAULT_CACHE_STORE by default if 'cache' not specified, since the cache interceptor was already specified to be used.
   const store = opts.cache === true ? DEFAULT_CACHE_STORE : opts.cache
 
   if (!store) {
@@ -196,7 +250,7 @@ export default (opts) => (dispatch) => (opts, handler) => {
   }
 
   let key = `${opts.method}:${opts.path}`
-  console.log('getting key: ' + key)
+
   let entries = store.get(key)
 
   if (Array.isArray(entries) && entries.length === 0 && opts.method === 'HEAD') {
@@ -219,11 +273,14 @@ export default (opts) => (dispatch) => (opts, handler) => {
     try {
       handler.onConnect(abort)
       signal.throwIfAborted()
+
       handler.onHeaders(statusCode, rawHeaders, resume, statusMessage)
       signal.throwIfAborted()
+
       if (opts.method !== 'HEAD') {
         for (const chunk of body) {
           const ret = handler.onData(chunk)
+
           signal.throwIfAborted()
           if (ret === false) {
             // TODO (fix): back pressure...
@@ -239,8 +296,6 @@ export default (opts) => (dispatch) => (opts, handler) => {
 
     return true
   } else {
-    handler.opts = opts
-    handler.entries = entries
-    return dispatch(opts, new CacheHandler({ handler, store, key }))
+    return dispatch(opts, new CacheHandler({ handler, store, key, opts }))
   }
 }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -66,7 +66,7 @@ class CacheHandler extends DecoratorHandler {
             (rawHeaders?.reduce((xs, x) => xs + x.length, 0) ?? 0) +
             (statusMessage?.length ?? 0) +
             64,
-          ttl, // in ms!
+          expires: Date.now() + ttl, // in ms!
         }
       }
     }
@@ -112,8 +112,7 @@ function formatVaryData(resHeaders, reqHeaders) {
     .filter(([_key, val]) => val)
 }
 
-// Can we move this class somewhere else, to the util.js file or its own module?
-class CacheStore {
+export class CacheStore {
   constructor() {
     this.database = null
     this.init()
@@ -128,13 +127,12 @@ class CacheStore {
         data TEXT,
         vary TEXT,
         size INTEGER,
-        ttl INTEGER,
-        insertTime INTEGER
+        expires INTEGER
       ) STRICT
     `)
   }
 
-  set(key, entry, opts) {
+  set(key, entry) {
     if (!this.database) {
       throw new Error('Database not initialized')
     }
@@ -143,10 +141,10 @@ class CacheStore {
     entry.vary = JSON.stringify(entry.vary)
 
     const insert = this.database.prepare(
-      'INSERT INTO cacheInterceptor (key, data, vary, size, ttl, insertTime) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT INTO cacheInterceptor (key, data, vary, size, expires) VALUES (?, ?, ?, ?, ?)',
     )
 
-    insert.run(key, entry.data, entry.vary, entry.size, entry.ttl, Date.now())
+    insert.run(key, entry.data, entry.vary, entry.size, entry.expires)
 
     this.purge()
   }
@@ -156,22 +154,21 @@ class CacheStore {
       throw new Error('Database not initialized')
     }
     this.purge()
-    const query = this.database.prepare('SELECT * FROM cacheInterceptor WHERE key = ?')
-    const rows = query.all(key)
+    const query = this.database.prepare(
+      'SELECT * FROM cacheInterceptor WHERE key = ? AND expires > ? ',
+    )
+    const rows = query.all(key, Date.now())
     rows.map((i) => {
       i.data = JSON.parse(i.data)
       i.vary = JSON.parse(i.vary)
       return i
     })
 
-    // Just in case purge hasn't finished
-    const nonExpiredRows = rows.filter((i) => i.insertTime + i.ttl > Date.now())
-
-    return nonExpiredRows
+    return rows
   }
 
   purge() {
-    const query = this.database.prepare('DELETE FROM cacheInterceptor WHERE insertTime + ttl < ?')
+    const query = this.database.prepare('DELETE FROM cacheInterceptor WHERE expires < ?')
     query.run(Date.now())
   }
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -176,9 +176,7 @@ export class CacheStore {
     if (expires < Date.now()) {
       return
     }
-
-    const maxExpires = Date.now() + this.#maxTTL
-    expires = expires > maxExpires ? maxExpires : expires
+    expires = Math.min(expires, Date.now() + this.#maxTTL)
 
     this.#insertquery.run(key, BJSON.stringify(data), BJSON.stringify(vary), size, expires)
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -90,12 +90,19 @@ class CacheHandler extends DecoratorHandler {
   onComplete(rawTrailers) {
     if (this.#value) {
       const resHeaders = parseHeaders(this.#value.data.rawHeaders)
+
+      // Early return if vary = *, uncacheable.
+      if (resHeaders.vary === '*') {
+        return this.#handler.onComplete(rawTrailers)
+      }
+
       const reqHeaders = this.#opts
 
       this.#value.data.rawTrailers = rawTrailers
       this.#value.size = this.#value.size
         ? this.#value.size + rawTrailers?.reduce((xs, x) => xs + x.length, 0)
         : 0
+
       this.#value.vary = formatVaryData(resHeaders, reqHeaders)
 
       this.#store.set(this.#key, this.#value)

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -14,6 +14,7 @@ class Handler extends DecoratorHandler {
   }
 
   onUpgrade(statusCode, rawHeaders, socket) {
+    console.log('Proxy onUpgrade')
     return this.#handler.onUpgrade(
       statusCode,
       reduceHeaders(
@@ -34,6 +35,7 @@ class Handler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusMessage) {
+    console.log('Proxy onHeaders')
     return this.#handler.onHeaders(
       statusCode,
       reduceHeaders(
@@ -164,6 +166,7 @@ function printIp(address, port) {
 }
 
 export default (opts) => (dispatch) => (opts, handler) => {
+  console.log('Proxy default dispatch')
   if (!opts.proxy) {
     return dispatch(opts, handler)
   }

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -36,6 +36,7 @@ class Handler extends DecoratorHandler {
   }
 
   onConnect(abort) {
+    console.log('Redirect onConnect')
     if (this.#aborted) {
       abort(this.#reason)
     } else {
@@ -48,6 +49,7 @@ class Handler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, rawHeaders, resume, statusText, headers = parseHeaders(rawHeaders)) {
+    console.log('Redirect onHeaders')
     if (redirectableStatusCodes.indexOf(statusCode) === -1) {
       assert(!this.#headersSent)
       this.#headersSent = true
@@ -109,6 +111,7 @@ class Handler extends DecoratorHandler {
   }
 
   onData(chunk) {
+    console.log('Redirect onData')
     if (this.#location) {
       /*
         https://tools.ietf.org/html/rfc7231#section-6.4

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "prepare": "husky",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
-    "test": "tap test",
-    "taprun": "tap run"
+    "test": "tap test"
   },
   "lint-staged": {
     "*.{js,jsx,md,ts}": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prepare": "husky",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
-    "test": "tap test"
+    "test": "tap test",
+    "taprun": "tap run"
   },
   "lint-staged": {
     "*.{js,jsx,md,ts}": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "cache-control-parser": "^2.0.6",
     "cacheable-lookup": "^7.0.0",
     "http-errors": "^2.0.0",
-    "lru-cache": "^11.0.0",
     "undici": "^6.19.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cache-control-parser": "^2.0.6",
     "cacheable-lookup": "^7.0.0",
     "http-errors": "^2.0.0",
+    "sqlite3": "^5.1.7",
     "undici": "^6.19.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib/*"
   ],
   "dependencies": {
+    "buffer-json": "^2.0.0",
     "cache-control-parser": "^2.0.6",
     "cacheable-lookup": "^7.0.0",
     "http-errors": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "lib/*"
   ],
   "dependencies": {
+    "better-sqlite3": "^11.2.1",
     "buffer-json": "^2.0.0",
     "cache-control-parser": "^2.0.6",
     "cacheable-lookup": "^7.0.0",
     "http-errors": "^2.0.0",
-    "sqlite3": "^5.1.7",
     "undici": "^6.19.5"
   },
   "devDependencies": {

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,24 +1,89 @@
 import { test } from 'tap'
+// import { LRUCache } from 'lru-cache'
 import { createServer } from 'node:http'
 import undici from 'undici'
 import { interceptors } from '../lib/index.js'
 
-test('cache request', (t) => {
+// test('cache request', (t) => {
+//   t.plan(1)
+//   const server = createServer((req, res) => {
+//     res.end('asd')
+//   })
+
+//   t.teardown(server.close.bind(server))
+//   server.listen(0, async () => {
+//     const { body } = await undici.request(`http://0.0.0.0:${server.address().port}`, {
+//       dispatcher: new undici.Agent().compose(interceptors.cache()),
+//       cache: true,
+//     })
+//     let str = ''
+//     for await (const chunk of body) {
+//       str += chunk
+//     }
+//     t.equal(str, 'asd')
+//   })
+// })
+
+// class CacheStore {
+//   constructor({ maxSize = 1024 * 1024 }) {
+//     this.maxSize = maxSize
+//     this.cache = new LRUCache({ maxSize })
+//   }
+
+//   set(key, value, opts) {
+//     this.cache.set(key, value, opts)
+//   }
+
+//   get(key) {
+//     return this.cache.get(key)
+//   }
+// }
+
+// Error: "invalid size value (must be positive integer). When maxSize or maxEntrySize is used, sizeCalculation or size must be set."
+//
+// function exampleCache(){
+//   const options = {
+//     max: 500,
+//     maxSize: 5000,
+//     sizeCalculation: (value, key) => {
+//       return 1
+//     },
+//   }
+//   const cache = new CacheStore(options)
+//   cache.set('GET:/', {data: 'dataFromCache', vary: {'origin': 'http://0.0.0.0:54758', 'Accept-Encoding': 'Application/json'}}, {})
+//   cache.set('GET:/foobar', {data: 'dataFromCache'}, {})
+//   cache.set('POST:/foo', {data: 'dataFromCache', vary: {'host': '0.0.0.0:54758'}}, {})
+//   cache.set('GET:/', {data: {
+//     headers: [
+//       'Vary': {'origin': 'http://0.0.0.0:54758', 'Accept-Encoding': 'Application/json'}
+//     ],
+//   }})
+
+//   return cache
+// }
+
+test('cache request, vary:host, populated cache', (t) => {
   t.plan(1)
   const server = createServer((req, res) => {
+    res.writeHead(307, { Vary: 'Host' })
     res.end('asd')
   })
 
   t.teardown(server.close.bind(server))
+
+  // const cache = exampleCache()
   server.listen(0, async () => {
-    const { body } = await undici.request(`http://0.0.0.0:${server.address().port}`, {
+    const response = await undici.request(`http://0.0.0.0:${server.address().port}`, {
       dispatcher: new undici.Agent().compose(interceptors.cache()),
       cache: true,
     })
     let str = ''
-    for await (const chunk of body) {
+    for await (const chunk of response.body) {
       str += chunk
     }
+
+    console.log('response: ')
+    console.log(response)
     t.equal(str, 'asd')
   })
 })

--- a/test/cache.js
+++ b/test/cache.js
@@ -40,7 +40,7 @@ function exampleEntries() {
         ['User-Agent', 'Mozilla/5.0'],
       ],
       size: 100,
-      expires: Date.now() + 31556952001 + Math.floor(Math.random() * 100),
+      expires: Date.now() * 2 + Math.floor(Math.random() * 100),
     },
     {
       data: {
@@ -56,7 +56,7 @@ function exampleEntries() {
         ['origin2', 'www.google.com/images'],
       ],
       size: 100,
-      expires: Date.now() + 31556952002 + Math.floor(Math.random() * 100),
+      expires: Date.now() * 2 + Math.floor(Math.random() * 100),
     },
     {
       data: {
@@ -73,7 +73,7 @@ function exampleEntries() {
         ['origin2', 'www.google.com/images'],
       ],
       size: 100,
-      expires: Date.now() + 31556952003 + Math.floor(Math.random() * 100),
+      expires: Date.now() * 2 + Math.floor(Math.random() * 100),
     },
     {
       data: {
@@ -278,3 +278,83 @@ test('Cache purging based on its maxSize', (t) => {
 
   t.equal(totalSize, 400)
 })
+
+test('Cache #maxTTL overwriting entries ttl', (t) => {
+  t.plan(1)
+
+  const day = 1000 * 60 * 60 * 24
+  const cache = new CacheStore(':memory:', { maxTTL: day })
+  exampleEntries().forEach((i) => cache.set('GET:/', i))
+
+  const row = cache.get('GET:/')[0]
+  const rowExpires = Math.floor(row.expires / 1000)
+  const maxExpires = Math.floor((Date.now() + day) / 1000)
+
+  t.equal(rowExpires, maxExpires)
+})
+
+// test('200-OK, save to cache, fetch from cache', (t) => {
+//   t.plan(4)
+//   const server = createServer((req, res) => {
+//     res.writeHead(307, {
+//       Vary: 'Origin2, User-Agent, Accept',
+//       'Cache-Control': 'public, immutable',
+//       'Content-Length': 4,
+//       'Content-Type': 'text/html',
+//       Connection: 'close',
+//       Location: 'http://www.google.com/',
+//     })
+//     res.end('foob')
+//   })
+
+//   t.teardown(server.close.bind(server))
+
+//   const cache = dbsetup()
+
+//   const cacheLength1 = cache.get('GET:/').length
+
+//   server.listen(0, async () => {
+//     const serverPort = server.address().port
+//     // response not found in cache, response should be added to cache.
+//     const response = await undici.request(`http://0.0.0.0:${serverPort}`, {
+//       dispatcher: new undici.Agent().compose(interceptors.cache()),
+//       cache,
+//     })
+//     let str = ''
+//     for await (const chunk of response.body) {
+//       str += chunk
+//     }
+//     const cacheLength2 = cache.get('GET:/').length
+
+//     // should return the default server response
+//     t.equal(str, 'foob')
+
+//     t.equal(cacheLength2, cacheLength1 + 1)
+
+//     // response found in cache, return cached response.
+//     const response2 = await undici.request(`http://0.0.0.0:${serverPort}`, {
+//       dispatcher: new undici.Agent().compose(interceptors.cache()),
+//       headers: {
+//         Accept: 'application/txt',
+//         'User-Agent': 'Chrome',
+//         origin2: 'www.google.com/images',
+//       },
+//       cache,
+//     })
+//     let str2 = ''
+//     for await (const chunk of response2.body) {
+//       str2 += chunk
+//     }
+
+//     const cacheLength3 = cache.get('GET:/').length
+
+//     // should return the body from the cached entry
+//     t.equal(str2, 'asd2')
+
+//     // cache should still have the same number of entries before
+//     // and after a cached entry was used as a response.
+//     t.equal(cacheLength3, cacheLength2)
+
+//     cache.close()
+//   })
+// })

--- a/test/cache.js
+++ b/test/cache.js
@@ -133,7 +133,7 @@ test('If no matching entry found, store the response in cache. Else return a mat
     // response not found in cache, response should be added to cache.
     const response = await undici.request(`http://0.0.0.0:${serverPort}`, {
       dispatcher: new undici.Agent().compose(interceptors.cache()),
-      cache: true,
+      cache,
     })
     let str = ''
     for await (const chunk of response.body) {
@@ -154,7 +154,7 @@ test('If no matching entry found, store the response in cache. Else return a mat
         'User-Agent': 'Chrome',
         origin2: 'www.google.com/images',
       },
-      cache: true,
+      cache,
     })
     let str2 = ''
     for await (const chunk of response2.body) {
@@ -200,7 +200,7 @@ test('Responses with header Vary: * should not be cached', async (t) => {
     // But the server returns Vary: *, and thus shouldn't be cached.
     const response = await undici.request(`http://0.0.0.0:${serverPort}`, {
       dispatcher: new undici.Agent().compose(interceptors.cache()),
-      cache: true,
+      cache,
       headers: {
         Accept: 'application/txt',
         'User-Agent': 'Chrome',
@@ -247,7 +247,7 @@ test('Store 307-status-responses that happen to be dependent on the Range header
 
     const request1 = undici.request(`http://0.0.0.0:${serverPort}`, {
       dispatcher: new undici.Agent().compose(interceptors.cache()),
-      cache: true,
+      cache,
       headers: {
         range: 'bytes=0-999',
       },
@@ -269,7 +269,7 @@ test('Store 307-status-responses that happen to be dependent on the Range header
 
     const request2 = undici.request(`http://0.0.0.0:${serverPort}`, {
       dispatcher: new undici.Agent().compose(interceptors.cache()),
-      cache: true,
+      cache,
       headers: {
         range: 'bytes=0-999',
       },


### PR DESCRIPTION
In this first commit, the cache handler handles multiple cached entries from the same cache key. It then tries to find which of the entries match the request, if any.

What I can't get my head around is how we are supposed to set the cache. We need both the response and the request at the same time. We need the vary headers and data from the response -  the vary headers so that we can compare, the data to cache the response, and the request headers to have something to compare against.

My interpretation of the current functionality is that after we fetch an existing entry from the cache, the `onComplete` method caches that object again. What is the purpose of caching the same entry again?

