### PR TITLE
refactor(request): types for request

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,18 @@
+import type { Dispatcher } from 'undici-types'
+import type { Logger } from 'pino'
+
+export type Headers =
+  | Record<string, string | string[] | null | undefined>
+  | (Buffer | string | (Buffer | string)[])[]
+
+export interface NxtUndiciRequestInit extends RequestInit {
+  headers?: Headers
+  throwOnError?: boolean
+  logger?: Logger
+}
+
+export function request(options: NxtUndiciRequestInit): Promise<Dispatcher.ResponseData>
+export function request(
+  url: string | URL,
+  options?: NxtUndiciRequestInit,
+): Promise<Dispatcher.ResponseData>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-n": "^17.16.2",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
+    "pino": "^9.6.0",
     "pinst": "^3.0.0",
     "prettier": "^3.5.3",
     "send": "^1.1.0",


### PR DESCRIPTION
Types for this repo would be nice, at least for `request`. Not 100% sure this is correct.