### PR TITLE
fix: allow 303 redirects even if body is disturbed

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -52,7 +52,7 @@ class Handler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    if (isDisturbed(this.#opts.body)) {
+    if (statusCode !== 303 && isDisturbed(this.#opts.body)) {
       throw new Error(`Disturbed request cannot be redirected.`)
     }
 
@@ -102,8 +102,12 @@ class Handler extends DecoratorHandler {
 
     // https://tools.ietf.org/html/rfc7231#section-6.4.4
     // In case of HTTP 303, always replace method to be either HEAD or GET
-    if (statusCode === 303 && this.#opts.method !== 'HEAD') {
-      this.#opts = { ...this.#opts, method: 'GET', body: null }
+    if (statusCode === 303) {
+      this.#opts = {
+        ...this.#opts,
+        method: this.#opts.method !== 'HEAD' ? 'GET' : 'HEAD',
+        body: null,
+      }
     }
   }
 

--- a/test/redirect.js
+++ b/test/redirect.js
@@ -301,6 +301,26 @@ t.test('should not follow redirects when using Readable request bodies', async (
   }
 })
 
+t.test('should follow HTTP 303 when using Readable request bodies', async (t) => {
+  const server = await startRedirectingServer(t)
+
+  const {
+    statusCode,
+    headers,
+    body: bodyStream,
+  } = await request(`http://${server}/303`, {
+    method: 'POST',
+    body: createReadable('REQUEST'),
+    follow: 10,
+  })
+
+  const body = await bodyStream.text()
+
+  t.equal(statusCode, 200)
+  t.notOk(headers.location)
+  t.equal(body, `GET /5 :: host@${server} connection@keep-alive`)
+})
+
 t.test('should follow redirections when going cross origin', async (t) => {
   const [server1] = await startRedirectingChainServers(t)
 


### PR DESCRIPTION
Since 303 always redirects as a GET, this is safe and should be allowed.