### PR TITLE
fix(cache): in-depth review round 2 — directive handling, key asymmetry, storage guards + store perf

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,8 +1,8 @@
 import undici from '@nxtedition/undici'
-import { DecoratorHandler, parseCacheControl, parseContentRange } from '../utils.js'
+import { DecoratorHandler, getFastNow, parseCacheControl, parseContentRange } from '../utils.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
 
-const DEFAULT_STORE = new SqliteCacheStore({ location: ':memory:' })
+let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
 const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600
 const NOOP = () => {}
@@ -40,16 +40,34 @@ class CacheHandler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    if (headers.vary === '*' || headers.trailers) {
+    // 'trailer' is the RFC 9110 field name; 'trailers' is kept for backwards
+    // compatibility with servers that misspell it.
+    if (headers.vary === '*' || headers.trailer || headers.trailers) {
       // Not cacheble...
+      return super.onHeaders(statusCode, headers, resume)
+    }
+
+    if (headers['set-cookie']) {
+      // Shared cache: replaying Set-Cookie to other clients leaks sessions.
       return super.onHeaders(statusCode, headers, resume)
     }
 
     let contentRange
     if (headers['content-range']) {
       contentRange = parseContentRange(headers['content-range'])
-      if (contentRange === null) {
+      if (
+        contentRange == null ||
+        (contentRange.end != null &&
+          (contentRange.end <= contentRange.start ||
+            (contentRange.size != null && contentRange.end > contentRange.size)))
+      ) {
         // We don't support caching responses with invalid content-range...
+        return super.onHeaders(statusCode, headers, resume)
+      }
+      if (this.#key.method === 'HEAD') {
+        // A HEAD response delivers no body, so we never receive the byte
+        // window Content-Range describes — storing it would fail the store's
+        // body-length validation.
         return super.onHeaders(statusCode, headers, resume)
       }
     }
@@ -104,6 +122,10 @@ class CacheHandler extends DecoratorHandler {
       }
 
       for (const key of headers.vary.split(',').map((key) => key.trim().toLowerCase())) {
+        if (key === '*') {
+          // RFC 9111 §4.1: a Vary field containing '*' never matches.
+          return super.onHeaders(statusCode, headers, resume)
+        }
         // Record every selecting header, using a null sentinel when it was
         // absent from the request. RFC 9111 §4.1: absent-vs-present is a
         // mismatch, so an empty vary object must NOT act as a wildcard that
@@ -218,23 +240,32 @@ export default () => (dispatch) => (opts, handler) => {
   }
 
   if (
-    cacheControlDirectives['max-age'] ||
-    cacheControlDirectives['max-stale'] ||
-    cacheControlDirectives['min-fresh'] ||
+    // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
+    cacheControlDirectives['max-age'] != null ||
     cacheControlDirectives['no-cache'] ||
-    cacheControlDirectives['stale-if-error']
+    cacheControlDirectives['stale-if-error'] != null ||
+    // cache-control-parser does not recognise 'max-stale'/'min-fresh', so
+    // check the raw string like we do for 'only-if-cached'.
+    (typeof rawCacheControl === 'string' &&
+      (rawCacheControl.includes('max-stale') || rawCacheControl.includes('min-fresh')))
   ) {
     // TODO (fix): Support all cache control directives...
     return dispatch(opts, handler)
   }
 
-  const store = opts.cache.store ?? DEFAULT_STORE
+  const store =
+    opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
 
   // TODO (fix): enable range requests
 
+  // Build the key the same way for lookups and stores: makeCacheKey
+  // stringifies the origin (e.g. URL objects), so using raw opts on the get
+  // path while the set path normalizes would make the cache permanently miss.
+  const key = undici.util.cache.makeCacheKey(opts)
+
   let entry
   try {
-    entry = store.get(opts)
+    entry = store.get(key)
   } catch (err) {
     if (err.message === 'database is locked') {
       // Database is busy. We don't bother trying again...
@@ -251,16 +282,34 @@ export default () => (dispatch) => (opts, handler) => {
   }
 
   // RFC 9110 Section 13: Evaluate conditional request headers against cached entry.
+  // typeof guards: duplicated conditional headers arrive as arrays — treat
+  // them as non-matching and bypass to origin rather than crashing.
   if (entry && opts.headers?.['if-none-match']) {
-    if (entry.etag && weakMatch(opts.headers['if-none-match'], entry.etag)) {
-      return serveFromCache({ statusCode: 304, headers: entry.headers }, opts, handler)
+    if (
+      typeof opts.headers['if-none-match'] === 'string' &&
+      entry.etag &&
+      weakMatch(opts.headers['if-none-match'], entry.etag)
+    ) {
+      return serveFromCache(
+        { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
+        opts,
+        handler,
+      )
     }
     // Etag didn't match — bypass to origin.
     entry = undefined
   } else if (entry && opts.headers?.['if-modified-since']) {
     const lastModified = entry.headers?.['last-modified']
-    if (lastModified && new Date(lastModified) <= new Date(opts.headers['if-modified-since'])) {
-      return serveFromCache({ statusCode: 304, headers: entry.headers }, opts, handler)
+    if (
+      typeof opts.headers['if-modified-since'] === 'string' &&
+      lastModified &&
+      new Date(lastModified) <= new Date(opts.headers['if-modified-since'])
+    ) {
+      return serveFromCache(
+        { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
+        opts,
+        handler,
+      )
     }
     // No last-modified or modified since — bypass to origin.
     entry = undefined
@@ -280,7 +329,7 @@ export default () => (dispatch) => (opts, handler) => {
       opts,
       cacheControlDirectives['no-store']
         ? handler
-        : new CacheHandler(undici.util.cache.makeCacheKey(opts), {
+        : new CacheHandler(key, {
             maxEntrySize: opts.cache.maxEntrySize,
             maxEntryTTL: opts.cache.maxEntryTTL,
             store,
@@ -294,7 +343,19 @@ export default () => (dispatch) => (opts, handler) => {
 }
 
 function serveFromCache(entry, opts, handler) {
-  const { statusCode, headers, trailers, body } = entry
+  const { statusCode, trailers, body } = entry
+
+  let headers = entry.headers
+  if (entry.cachedAt != null) {
+    // RFC 9111 §5.1: every response served from cache must carry an Age header
+    // reflecting time spent in this cache plus any age it arrived with —
+    // otherwise downstream caches treat it as fresh-from-origin.
+    // getFastNow has 1s resolution — Age is whole seconds, so that's enough.
+    const residentAge = Math.max(0, Math.floor((getFastNow() - entry.cachedAt) / 1000))
+    const originAge = Number(headers?.age)
+    const age = Number.isFinite(originAge) && originAge > 0 ? originAge + residentAge : residentAge
+    headers = { ...headers, age: `${age}` }
+  }
 
   let aborted = false
   const abort = (reason) => {

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -420,6 +420,23 @@ export class SqliteCacheStore {
     const now = getFastNow()
     const requestedStart = range?.start ?? 0
 
+    if (this.#insertBatch.length === 0) {
+      // Fast path: rows arrive sorted (cachedAt DESC, id DESC) and there are
+      // no pending batch entries to merge, so fetch only the newest candidate.
+      // This covers misses and first-row hits (the overwhelmingly common
+      // cases) with a single row materialized — re-cached duplicates of a hot
+      // key would otherwise all be read including their blobs. Only when the
+      // newest row doesn't match (vary variant, range/206 mismatch) do we
+      // fall through to scan the full candidate set.
+      const value = this.#getValuesQuery.get(url, method, requestedStart, now)
+      if (value === undefined) {
+        return undefined
+      }
+      if (matchesValue(value, range, headers)) {
+        return value
+      }
+    }
+
     /**
      * @type {SqliteStoreValue[]}
      */
@@ -445,55 +462,63 @@ export class SqliteCacheStore {
     // deterministically toward the freshest write: pending batch entries
     // (tagged with a monotonic seq) are always newer than any flushed DB row,
     // and within each source a higher seq/id wins.
-    values.sort((a, b) => {
-      if (a.cachedAt !== b.cachedAt) {
-        return b.cachedAt - a.cachedAt
-      }
-      const aBatch = a.seq != null
-      const bBatch = b.seq != null
-      if (aBatch !== bBatch) {
-        return aBatch ? -1 : 1
-      }
-      if (aBatch) {
-        return b.seq - a.seq
-      }
-      return (b.id ?? 0) - (a.id ?? 0)
-    })
+    if (values.length > 1) {
+      values.sort((a, b) => {
+        if (a.cachedAt !== b.cachedAt) {
+          return b.cachedAt - a.cachedAt
+        }
+        const aBatch = a.seq != null
+        const bBatch = b.seq != null
+        if (aBatch !== bBatch) {
+          return aBatch ? -1 : 1
+        }
+        if (aBatch) {
+          return b.seq - a.seq
+        }
+        return (b.id ?? 0) - (a.id ?? 0)
+      })
+    }
 
     for (const value of values) {
-      // TODO (fix): Allow full and partial match?
-      if (range && (range.start !== value.start || range.end !== value.end)) {
-        continue
+      if (matchesValue(value, range, headers)) {
+        return value
       }
-
-      // A request without a Range header asks for the full representation, so
-      // a stored 206 partial (e.g. content-range bytes 0-4/100, which the SQL
-      // `start <= 0` filter does not exclude) must not be served verbatim.
-      if (!range && value.statusCode === 206) {
-        continue
-      }
-
-      if (value.vary) {
-        const vary = JSON.parse(value.vary)
-        let matches = true
-
-        for (const header in vary) {
-          if (!headerValueEquals(headers?.[header], vary[header])) {
-            matches = false
-            break
-          }
-        }
-
-        if (!matches) {
-          continue
-        }
-      }
-
-      return value
     }
 
     return undefined
   }
+}
+
+/**
+ * @param {SqliteStoreValue} value
+ * @param {import('./utils.js').RangeHeader | undefined} range
+ * @param {Record<string, string | string[]> | undefined} headers
+ * @returns {boolean}
+ */
+function matchesValue(value, range, headers) {
+  // TODO (fix): Allow full and partial match?
+  if (range && (range.start !== value.start || range.end !== value.end)) {
+    return false
+  }
+
+  // A request without a Range header asks for the full representation, so
+  // a stored 206 partial (e.g. content-range bytes 0-4/100, which the SQL
+  // `start <= 0` filter does not exclude) must not be served verbatim.
+  if (!range && value.statusCode === 206) {
+    return false
+  }
+
+  if (value.vary) {
+    const vary = JSON.parse(value.vary)
+
+    for (const header in vary) {
+      if (!headerValueEquals(headers?.[header], vary[header])) {
+        return false
+      }
+    }
+  }
+
+  return true
 }
 
 /**
@@ -531,11 +556,15 @@ function makeValueUrl(key) {
 
 function makeResult(value) {
   return {
-    // Copy rather than alias: on the in-flight batch read-through path
-    // value.body is the exact Buffer still queued for flushing, and the
-    // three-arg Buffer.from(arrayBuffer, ...) form would share its memory,
-    // so a consumer mutating the served body could corrupt the cached bytes.
-    body: value.body ? Buffer.from(value.body) : undefined,
+    // Batch entries (tagged with seq) must be copied: value.body is the exact
+    // Buffer still queued for flushing, so a consumer mutating the served body
+    // could corrupt the bytes about to be written. DB rows are safe to alias —
+    // node:sqlite allocates a fresh Uint8Array per read, so wrap it zero-copy.
+    body: value.body
+      ? value.seq != null
+        ? Buffer.from(value.body)
+        : Buffer.from(value.body.buffer, value.body.byteOffset, value.body.byteLength)
+      : undefined,
     statusCode: value.statusCode,
     statusMessage: value.statusMessage,
     headers: value.headers ? JSON.parse(value.headers) : undefined,

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -1,0 +1,455 @@
+/* eslint-disable */
+// End-to-end regression tests for cache interceptor bugs found during the
+// second in-depth review (request directive handling, Vary '*' member,
+// Set-Cookie, Trailer, invalid Content-Range, conditional header arrays,
+// get/set key asymmetry, Age on cache hits).
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc, h) {
+        statusCode = sc
+        headers = h
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, headers, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+function makeLogger(errors) {
+  const logger = {
+    error: (...a) => errors.push(a),
+    warn() {},
+    debug() {},
+    child() {
+      return logger
+    },
+  }
+  return logger
+}
+
+// ---------------------------------------------------------------------------
+// Request 'Cache-Control: max-age=0' must bypass the cache (the directive
+// parses to the falsy number 0, which the old truthy check missed).
+// ---------------------------------------------------------------------------
+
+test('cache: request max-age=0 bypasses cache lookup', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-age=0' } })
+  t.equal(hits, 2, 'max-age=0 must revalidate against the origin')
+
+  // The entry from the first request is still there for unconditional requests.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'plain request is still served from cache')
+})
+
+// ---------------------------------------------------------------------------
+// 'min-fresh' / 'max-stale' are not recognised by cache-control-parser, so the
+// old directive checks were dead code and the cache served entries anyway.
+// ---------------------------------------------------------------------------
+
+test('cache: request min-fresh bypasses cache lookup', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'min-fresh=30' } })
+  t.equal(hits, 2, 'min-fresh must go to the origin until the directive is supported')
+})
+
+test('cache: request max-stale bypasses cache lookup', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-stale=30' } })
+  t.equal(hits, 2, 'max-stale must go to the origin until the directive is supported')
+})
+
+// ---------------------------------------------------------------------------
+// A Vary list containing '*' among other members never matches (RFC 9111 §4.1)
+// and must not be cached. The old code only caught the exact value '*'.
+// ---------------------------------------------------------------------------
+
+test('cache: Vary list containing * is not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', vary: 'accept, *' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { accept: 'text/plain' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'vary: "accept, *" must never be served from cache')
+})
+
+// ---------------------------------------------------------------------------
+// Responses carrying Set-Cookie must not be stored in a shared cache.
+// ---------------------------------------------------------------------------
+
+test('cache: response with Set-Cookie is not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', 'set-cookie': 'session=abc' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'set-cookie response must not be replayed to other clients')
+})
+
+// ---------------------------------------------------------------------------
+// 'Trailer' is the RFC 9110 field name announcing trailers; the old check only
+// looked at the non-standard 'trailers'.
+// ---------------------------------------------------------------------------
+
+test('cache: response with Trailer header (RFC name) is not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', trailer: 'x-checksum' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'responses announcing trailers via Trailer are not cached')
+})
+
+// ---------------------------------------------------------------------------
+// Invalid Content-Range (end < start, or end > size) must not be cached and
+// must not reach store.set (which would throw and emit error-level logs).
+// ---------------------------------------------------------------------------
+
+test('cache: content-range with end < start is not cached and emits no error logs', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(206, { 'cache-control': 's-maxage=60', 'content-range': 'bytes 5-2/10' })
+    res.end('ab')
+  })
+  t.teardown(server.close.bind(server))
+
+  const errors = []
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+    logger: makeLogger(errors),
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'nonsensical content-range is never cached')
+  t.equal(errors.length, 0, 'no error-level log from store.set validation')
+})
+
+test('cache: content-range exceeding the complete length is not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const body = 'a'.repeat(100)
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(206, { 'cache-control': 's-maxage=60', 'content-range': 'bytes 0-99/50' })
+    res.end(body)
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { range: 'bytes=0-99' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'content-range with end > complete-length is never cached')
+})
+
+// ---------------------------------------------------------------------------
+// HEAD responses with Content-Range describe a body we never receive; storing
+// them would fail the store's body-length validation and log at error level.
+// ---------------------------------------------------------------------------
+
+test('cache: HEAD response with Content-Range is not cached and emits no error logs', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(206, {
+      'cache-control': 's-maxage=60',
+      'content-range': 'bytes 0-4/100',
+      'content-length': '5',
+    })
+    res.end() // HEAD: no body delivered
+  })
+  t.teardown(server.close.bind(server))
+
+  const errors = []
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'HEAD',
+    headers: {},
+    cache: { store },
+    logger: makeLogger(errors),
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'HEAD + content-range is not cached')
+  t.equal(errors.length, 0, 'no error-level log from store.set validation')
+})
+
+// ---------------------------------------------------------------------------
+// Duplicated conditional headers arrive as arrays; the old code called
+// String.prototype.split on them and threw synchronously inside dispatch.
+// ---------------------------------------------------------------------------
+
+test('cache: If-None-Match as array does not crash and bypasses to origin', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', etag: '"abc"' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 1)
+
+  const res = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'if-none-match': ['"abc"', '"def"'] },
+  })
+  t.equal(res.statusCode, 200, 'array conditional bypasses to origin instead of throwing')
+  t.equal(hits, 2)
+})
+
+// ---------------------------------------------------------------------------
+// get/set key asymmetry: the set path normalized the key via makeCacheKey
+// (origin.toString()) while the get path used raw opts, so a URL-object origin
+// could never produce a cache hit.
+// ---------------------------------------------------------------------------
+
+test('cache: URL object origin hits the cache on the second request', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const errors = []
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: new URL(`http://0.0.0.0:${server.address().port}`),
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+    logger: makeLogger(errors),
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'second request with a URL origin is served from cache')
+  t.equal(errors.length, 0, 'no error-level log from key validation on the get path')
+})
+
+// ---------------------------------------------------------------------------
+// RFC 9111 §5.1: responses served from cache must carry an Age header.
+// ---------------------------------------------------------------------------
+
+test('cache: cache hit carries an Age header', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1)
+  t.ok(second.headers.age != null, 'age header is present on the cache hit')
+  t.ok(Number(second.headers.age) >= 0, 'age is a non-negative number of seconds')
+})
+
+test('cache: Age accumulates on top of the age the response arrived with', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', age: '5' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1)
+  t.ok(Number(second.headers.age) >= 5, 'served age includes the age it arrived with')
+})


### PR DESCRIPTION
## Summary

Second in-depth review of the cache interceptor and SQLite store: 10 bug fixes, 13 new regression tests, and read-path optimizations (up to 2.2x on hot keys).

### Bug fixes (`lib/interceptor/cache.js`)

**Request directive handling** — `cache-control-parser` only recognises 12 directives, and numeric ones parse to `0` which the truthy checks missed:
- `Cache-Control: max-age=0` was served from cache instead of revalidating (now checked with `!= null`).
- `max-stale` / `min-fresh` were dead checks (the parser drops them); now detected on the raw header string like the existing `only-if-cached` workaround.

**Storage decisions:**
- get/set key asymmetry: the read path used raw `opts` while the write path used `makeCacheKey(opts)`, so a URL-object origin could never produce a hit and logged error-level key-validation failures on every lookup. Both paths now share one normalized key.
- Responses with `Set-Cookie` are no longer stored (session leak in a shared cache).
- A Vary list *containing* `*` (e.g. `vary: accept, *`) is uncacheable per RFC 9111 §4.1; only the exact value `*` was caught before.
- The trailer check looked at the nonexistent `trailers` header; the RFC 9110 name is `trailer` (both accepted now).
- Invalid `Content-Range` (end < start, end > complete-length) and HEAD+`Content-Range` responses no longer reach `store.set`, which threw and logged at error level.

**Conditional requests:** duplicated `If-None-Match`/`If-Modified-Since` headers arrive as arrays and crashed `weakMatch` synchronously inside dispatch; arrays now bypass to origin.

**Spec compliance:** cache hits and 304s now carry an `Age` header (RFC 9111 §5.1), accumulating on top of the age the response arrived with, so downstream caches no longer treat cached responses as fresh-from-origin.

### Performance (`lib/sqlite-cache-store.js`)

A/B micro-benchmarks vs main (interleaved same-process runs, medians):

| Path | Before | After |
|---|---|---|
| `get` hit, 128 KB body | 28 µs | 19 µs (**1.5x**) |
| `get` hit, hot key with 20 re-cached rows | 122 µs | 56 µs (**2.2x**) |
| `get` hit 1 KB / miss / vary hit | 3.7 / 0.65 / 4.0 µs | equal or slightly better |
| `set`+flush | 2.4 µs | unchanged |

- `makeResult` wraps DB-row bodies zero-copy (node:sqlite allocates a fresh `Uint8Array` per read); only in-flight batch entries are copied.
- `#findValue` fetches just the newest candidate via `.get()` when no batch entries are pending, falling back to the full `.all()` scan only when the newest row doesn't match.
- Tie-break sort skipped for single candidates; default in-memory store created lazily.

### Tests

`test/review-bugfixes-cache-2.js`: 13 end-to-end regression tests, one per fix, following the existing review-bugfixes pattern. Full cache set (284 assertions across 6 files) plus `request`/`compose`/`retry`/`redirect` sanity (89 assertions) all pass locally with `--disable-coverage`, files run in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)