### PR TITLE
fix(cache): cache private redirects via a private column

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -121,6 +121,9 @@ export interface ProxyOptions {
 export interface CacheOptions {
   store?: CacheStore
   maxEntrySize?: number
+  // Opt in to reading entries cached from Cache-Control: private responses
+  // (private redirects). Without it such entries are bypassed on read.
+  private?: boolean
 }
 
 export interface VerifyOptions {
@@ -156,6 +159,7 @@ export interface CacheValue {
   vary?: Record<string, string | string[]>
   cachedAt: number
   deleteAt?: number
+  private?: boolean
 }
 
 export interface CacheGetResult {
@@ -168,6 +172,7 @@ export interface CacheGetResult {
   vary?: Record<string, string | string[]>
   cachedAt: number
   deleteAt: number
+  private?: boolean
 }
 
 export interface CacheStore {

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -96,7 +96,10 @@ class CacheHandler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    // Cache redirections even if private.
+    // Cache redirections even if private. Of these, only 307 can reach this
+    // point today (the admit guard at the top of onHeaders allows 307/200/206)
+    // — the full redirect set is listed so broadening the admit list later
+    // doesn't silently drop private redirects.
     if (
       cacheControlDirectives['private'] &&
       statusCode !== 307 &&

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -92,7 +92,20 @@ class CacheHandler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    if (cacheControlDirectives.private || cacheControlDirectives['no-store']) {
+    if (cacheControlDirectives['no-store']) {
+      return super.onHeaders(statusCode, headers, resume)
+    }
+
+    // Cache redirections even if private.
+    if (
+      cacheControlDirectives['private'] &&
+      statusCode !== 307 &&
+      statusCode !== 308 &&
+      statusCode !== 300 &&
+      statusCode !== 301 &&
+      statusCode !== 302 &&
+      statusCode !== 303
+    ) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -173,6 +186,7 @@ class CacheHandler extends DecoratorHandler {
         etag: isEtagUsable(headers.etag) ? headers.etag : '',
         vary,
         cachedAt,
+        private: Boolean(cacheControlDirectives['private']),
         // Handler state.
         size: 0,
       }
@@ -287,6 +301,10 @@ export default () => (dispatch) => (opts, handler) => {
     } else {
       opts.logger?.error({ err }, 'failed to get cache entry')
     }
+  }
+
+  if (entry?.private && !opts.cache.private) {
+    entry = null
   }
 
   // RFC 9111 Section 3.5: A shared cache must not use a cached response to a

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -44,7 +44,7 @@ const stores = new Set()
  *  cacheControlDirectives?: string
  *  cachedAt: number
  *  deleteAt: number
- *  private: boolean
+ *  private: 0 | 1
  * }} SqliteStoreValue
  */
 export class SqliteCacheStore {

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
-const VERSION = 10
+const VERSION = 11
 
 /** @typedef {{ gc: () => void, clear: () => void } } */
 const stores = new Set()
@@ -44,6 +44,7 @@ const stores = new Set()
  *  cacheControlDirectives?: string
  *  cachedAt: number
  *  deleteAt: number
+ *  private: boolean
  * }} SqliteStoreValue
  */
 export class SqliteCacheStore {
@@ -115,7 +116,8 @@ export class SqliteCacheStore {
         cacheControlDirectives TEXT NULL,
         etag TEXT NULL,
         vary TEXT NULL,
-        cachedAt INTEGER NOT NULL
+        cachedAt INTEGER NOT NULL,
+        private BOOLEAN NOT NULL DEFAULT 0
       );
 
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method, start, deleteAt);
@@ -135,7 +137,8 @@ export class SqliteCacheStore {
         etag,
         cacheControlDirectives,
         vary,
-        cachedAt
+        cachedAt,
+        private
       FROM cacheInterceptorV${VERSION}
       WHERE
         url = ?
@@ -160,8 +163,9 @@ export class SqliteCacheStore {
         etag,
         cacheControlDirectives,
         vary,
-        cachedAt
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        cachedAt,
+        private
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     this.#deleteExpiredValuesQuery = this.#db.prepare(
@@ -252,7 +256,7 @@ export class SqliteCacheStore {
 
   /**
    * @param {import('undici-types/cache-interceptor.d.ts').default.CacheKey} key
-   * @param {import('undici-types/cache-interceptor.d.ts').default.CacheValue & { body: null | Buffer | Array<Buffer>, start: number, end: number }} value
+   * @param {import('undici-types/cache-interceptor.d.ts').default.CacheValue & { body: null | Buffer | Array<Buffer>, start: number, end: number, private?: boolean }} value
    */
   set(key, value) {
     assertCacheKey(key)
@@ -313,6 +317,8 @@ export class SqliteCacheStore {
         : null,
       vary: value.vary ? JSON.stringify(value.vary) : null,
       cachedAt: value.cachedAt,
+      // node:sqlite cannot bind a JS boolean; store as 0/1.
+      private: value.private ? 1 : 0,
     })
   }
 
@@ -343,6 +349,8 @@ export class SqliteCacheStore {
               cacheControlDirectives,
               vary,
               cachedAt,
+              // 'private' is a reserved word — bind under a safe name.
+              private: isPrivate,
             } = this.#insertBatch[n++]
             this.#insertValueQuery.run(
               url,
@@ -358,6 +366,7 @@ export class SqliteCacheStore {
               cacheControlDirectives,
               vary,
               cachedAt,
+              isPrivate,
             )
             if (!final && (n & 0xf) === 0 && performance.now() - startTime > 10) {
               break
@@ -580,6 +589,7 @@ function makeResult(value) {
       ? JSON.parse(value.cacheControlDirectives)
       : undefined,
     cachedAt: value.cachedAt,
+    private: Boolean(value.private),
     deleteAt: value.deleteAt,
   }
 }


### PR DESCRIPTION
## Summary

Caches responses marked `Cache-Control: private` (redirects) instead of dropping them, tracking the flag in a new `private` column on the SQLite store so they are **bypassed on read** rather than shared across clients (the cross-client propagation for redirect-following is left as a TODO).

While reviewing, the in-progress change was non-functional — it would not parse, construct, or survive a cache miss. This PR fixes those bugs so the feature actually works:

| # | Bug | Fix |
|---|-----|-----|
| 1 | `private` is a strict-mode reserved word — used as a destructuring binding + variable in `#flush`, so the module failed to parse (`SyntaxError`) | bind under a safe name (`private: isPrivate`) |
| 2 | Missing commas in `CREATE TABLE`, `SELECT`, and `INSERT` column lists | added |
| 3 | `node:sqlite` rejects JS booleans as bind params (`TypeError`) | persist the flag as `0`/`1`, convert back with `Boolean()` |
| 4 | Schema changed but `VERSION` not bumped — an existing `cacheInterceptorV10` table would lack the column | bumped to `11` |
| 5 | `entry.private` threw `Cannot read properties of undefined` on **every cache miss** | guard with `entry?.private` |
| 6 | `statusCode !== 30` typo; redirect set also missing `303` | fixed to `302`, added `303` |

## Known limitation (not changed here)

`onHeaders` only admits `307`/`200`/`206` (existing behavior), so the private-redirect allow-list is currently only reachable for `307`. Broadening which redirect codes are cacheable is a larger, separate behavioral change and out of scope for this fix.

## Test plan

- [x] `tap test/sqlite-cache-store.js` — 154 assertions pass
- [x] `tap test/cache.js test/cache-advanced.js` — 88 assertions pass
- [x] `tap test/review-bugfixes-cache.js test/review-bugfixes-cache-2.js test/review-bugfixes-store.js` — 42 assertions pass
- [x] private-flag round-trip smoke test through the store
- [x] prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)