### PR TITLE
feat(pressure): add error-pressure tier (5xx/429) → degraded

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -150,6 +150,9 @@ export interface PressureInterceptorOptions {
   /** Schmitt-trigger dead-band for `full` (pause the producer). */
   fullHi?: number
   fullLo?: number
+  /** Schmitt-trigger dead-band for `errorRate` (mark the origin degraded). */
+  errHi?: number
+  errLo?: number
 }
 
 export interface PressureStats {
@@ -159,21 +162,29 @@ export interface PressureStats {
   running: number
   /** Counter: cumulative settled requests (onComplete + onError). */
   completed: number
+  /** Counter: cumulative settled requests that were overload errors (429/420/5xx, transport failures). */
+  errored: number
   /** EWMA in [0,1]: fraction of recent time the origin had a connection backlog. */
   some: number
   /** EWMA in [0,1]: fraction of recent time the origin made zero progress under backlog. */
   full: number
+  /** EWMA in [0,1]: smoothed fraction of completions that were overload errors. */
+  errorRate: number
   /** Latched: shed discretionary work (engaged when `some` crosses `someHi`). */
   shed: boolean
   /** Latched: pause the producer (engaged when `full` crosses `fullHi`). */
   paused: boolean
+  /** Latched: error rate too high (engaged when `errorRate` crosses `errHi`). */
+  degraded: boolean
 }
 
 export interface PressureReading {
   some: number
   full: number
+  errorRate: number
   shed: boolean
   paused: boolean
+  degraded: boolean
 }
 
 export interface PressureInterceptor {

--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -26,8 +26,28 @@ import { DecoratorHandler } from '../utils.js'
 // flaps": the predicate filters healthy saturation before it enters the signal,
 // and the EWMA window + Schmitt-trigger dead-band (engage high, release low) is
 // the oomd-style sustained-duration requirement.
+//
+// PSI measures *stall* (latency) pressure; an HTTP origin has a second failure
+// mode the latency signal is blind to: responding *fast* but *failing*. A flood
+// of 503/429 drains `pending` and ticks `completed`, so neither `some` nor
+// `full` fires — yet it is exactly when you should back off. So we add a third,
+// HTTP-specific tier alongside the two PSI levels:
+//
+//  - errorRate (EWMA of the fraction of completions that were overload errors:
+//    429/420 or 5xx, plus transport failures) -> `degraded` -> shed
+//    discretionary work, same tier as `some`. (A *rate*, not a per-tick bool, so
+//    a trickle of errors under heavy traffic doesn't latch.) The `peer.dns`
+//    interceptor already tracks 5xx per resolved IP for load balancing; this is
+//    the same insight applied at the logical-origin level for backoff.
 
 const EPS = 1e-3
+
+// Overload-shaped response statuses: explicit rate limits (429/420) and server
+// errors (5xx). 4xx client errors (404, 400, 401, …) are NOT origin pressure —
+// they don't mean the origin is struggling — so they don't count.
+function isErrorStatus(statusCode) {
+  return statusCode === 429 || statusCode === 420 || statusCode >= 500
+}
 
 // Smallest priority that is still "discretionary" — sheddable under `some`
 // pressure. low/lower/lowest (<= -1); normal and above are never shed.
@@ -53,6 +73,8 @@ class PressureMonitor {
   #someLo
   #fullHi
   #fullLo
+  #errHi
+  #errLo
 
   constructor({
     sampleInterval = 200,
@@ -61,6 +83,8 @@ class PressureMonitor {
     someLo = 0.2,
     fullHi = 0.3,
     fullLo = 0.1,
+    errHi = 0.5,
+    errLo = 0.2,
   } = {}) {
     this.#sampleInterval = sampleInterval
     this.#tau = tau
@@ -68,6 +92,8 @@ class PressureMonitor {
     this.#someLo = someLo
     this.#fullHi = fullHi
     this.#fullLo = fullLo
+    this.#errHi = errHi
+    this.#errLo = errLo
   }
 
   // Called from the interceptor on each dispatch to get (or lazily create) the
@@ -85,11 +111,15 @@ class PressureMonitor {
         pending: 0, // gauge: dispatched, awaiting onConnect (waiting for a slot)
         running: 0, // gauge: connected and in-flight
         completed: 0, // counter: cumulative settled (onComplete + onError)
+        errored: 0, // counter: cumulative settled with an overload error
         prevCompleted: 0, // snapshot of `completed` at the previous sample
+        prevErrored: 0, // snapshot of `errored` at the previous sample
         some: 0, // EWMA: fraction of recent time `someNow` held
         full: 0, // EWMA: fraction of recent time `fullNow` held
+        errorRate: 0, // EWMA: smoothed fraction of completions that errored
         shed: false, // latched: shed discretionary work
         paused: false, // latched: pause the producer
+        degraded: false, // latched: error rate too high
         lastSample: performance.now(),
       }
       this.#origins.set(key, rec)
@@ -109,14 +139,21 @@ class PressureMonitor {
     }
     rec.lastSample = now
 
+    const dCompleted = rec.completed - rec.prevCompleted
+    const dErrored = rec.errored - rec.prevErrored
     const someNow = rec.pending > 0
-    const progressed = rec.completed - rec.prevCompleted > 0
-    const fullNow = someNow && !progressed
+    const fullNow = someNow && dCompleted === 0
+    // Error *fraction* this window — a rate, so volume doesn't matter. No
+    // completions this window (idle, or hung — `full` covers that) means no new
+    // error evidence, so the signal relaxes toward 0.
+    const errNow = dCompleted > 0 ? dErrored / dCompleted : 0
     rec.prevCompleted = rec.completed
+    rec.prevErrored = rec.errored
 
     const a = 1 - Math.exp(-dt / this.#tau)
     rec.some += a * ((someNow ? 1 : 0) - rec.some)
     rec.full += a * ((fullNow ? 1 : 0) - rec.full)
+    rec.errorRate += a * (errNow - rec.errorRate)
 
     // Hysteresis: engage high, release low.
     if (!rec.shed && rec.some > this.#someHi) {
@@ -129,6 +166,11 @@ class PressureMonitor {
     } else if (rec.paused && rec.full < this.#fullLo) {
       rec.paused = false
     }
+    if (!rec.degraded && rec.errorRate > this.#errHi) {
+      rec.degraded = true
+    } else if (rec.degraded && rec.errorRate < this.#errLo) {
+      rec.degraded = false
+    }
   }
 
   // Tick every tracked origin, then evict any that is fully idle and has decayed
@@ -138,7 +180,13 @@ class PressureMonitor {
     const now = performance.now()
     for (const [key, rec] of this.#origins) {
       this.#sample(rec, now)
-      if (rec.pending === 0 && rec.running === 0 && rec.some < EPS && rec.full < EPS) {
+      if (
+        rec.pending === 0 &&
+        rec.running === 0 &&
+        rec.some < EPS &&
+        rec.full < EPS &&
+        rec.errorRate < EPS
+      ) {
         this.#origins.delete(key)
       }
     }
@@ -169,10 +217,13 @@ class PressureMonitor {
       pending: rec.pending,
       running: rec.running,
       completed: rec.completed,
+      errored: rec.errored,
       some: rec.some,
       full: rec.full,
+      errorRate: rec.errorRate,
       shed: rec.shed,
       paused: rec.paused,
+      degraded: rec.degraded,
     }
   }
 
@@ -196,12 +247,20 @@ class PressureMonitor {
   pressure(origin) {
     const rec = this.#origins.get(origin)
     return rec
-      ? { some: rec.some, full: rec.full, shed: rec.shed, paused: rec.paused }
-      : { some: 0, full: 0, shed: false, paused: false }
+      ? {
+          some: rec.some,
+          full: rec.full,
+          errorRate: rec.errorRate,
+          shed: rec.shed,
+          paused: rec.paused,
+          degraded: rec.degraded,
+        }
+      : { some: 0, full: 0, errorRate: 0, shed: false, paused: false, degraded: false }
   }
 
   // Producer-side gate mirroring the README's `submit` recipe: `full` pauses
-  // everything; `some` sheds only discretionary (low-priority) work.
+  // everything; `some` (backlog) or `degraded` (error rate) sheds only
+  // discretionary (low-priority) work.
   shouldBackoff(origin, priority) {
     const rec = this.#origins.get(origin)
     if (rec == null) {
@@ -210,7 +269,7 @@ class PressureMonitor {
     if (rec.paused) {
       return true
     }
-    if (rec.shed) {
+    if (rec.shed || rec.degraded) {
       return isDiscretionary(priority)
     }
     return false
@@ -236,6 +295,7 @@ class Handler extends DecoratorHandler {
   // times onConnect is invoked (e.g. a retry handler upstream) or which
   // terminal callback fires.
   #state = 'pending'
+  #statusCode = 0
 
   constructor(handler, rec) {
     // super() validates the handler and throws on a non-object before we touch
@@ -254,17 +314,31 @@ class Handler extends DecoratorHandler {
     super.onConnect(abort)
   }
 
+  onHeaders(statusCode, headers, resume) {
+    // Latest status wins, so an informational 1xx is superseded by the final
+    // response. Read at onComplete to classify the outcome.
+    this.#statusCode = statusCode
+    return super.onHeaders(statusCode, headers, resume)
+  }
+
   onComplete(trailers) {
-    this.#settle()
+    this.#settle(isErrorStatus(this.#statusCode))
     super.onComplete(trailers)
   }
 
   onError(err) {
-    this.#settle()
+    // A status-bearing error is `responseError`'s decorated 4xx/5xx (when this
+    // interceptor sits outside it); classify by that status. A status-less
+    // error is a transport/connection failure (ECONNREFUSED, timeout, a sync
+    // dispatch throw) — count it, unless it's a client-initiated abort.
+    const statusCode = err?.statusCode ?? this.#statusCode
+    const isError =
+      err?.name === 'AbortError' ? false : statusCode >= 200 ? isErrorStatus(statusCode) : true
+    this.#settle(isError)
     super.onError(err)
   }
 
-  #settle() {
+  #settle(isError) {
     if (this.#state === 'done') {
       return
     }
@@ -274,6 +348,9 @@ class Handler extends DecoratorHandler {
       this.#rec.running -= 1
     }
     this.#rec.completed += 1
+    if (isError) {
+      this.#rec.errored += 1
+    }
     this.#state = 'done'
   }
 }

--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -306,6 +306,11 @@ class Handler extends DecoratorHandler {
   }
 
   onConnect(abort) {
+    // A (re)connect begins a fresh attempt: clear the captured status so a prior
+    // attempt's status can't leak into a later transport failure's
+    // classification. A handler upstream (e.g. response-retry) may reconnect
+    // this same handler across retries, and response-retry itself resets here.
+    this.#statusCode = 0
     if (this.#state === 'pending') {
       this.#state = 'running'
       this.#rec.pending -= 1

--- a/test/pressure-advanced.js
+++ b/test/pressure-advanced.js
@@ -34,6 +34,13 @@ async function tick(interceptor) {
   interceptor.sample()
 }
 
+// Drive a captured handler through a full successful lifecycle with a status.
+function complete(handler, statusCode) {
+  handler.onConnect(() => {})
+  handler.onHeaders(statusCode, {}, () => {})
+  handler.onComplete()
+}
+
 // ---------------------------------------------------------------------------
 // accounting: pending -> running -> completed reconstructed from the lifecycle
 // ---------------------------------------------------------------------------
@@ -48,10 +55,13 @@ test('pressure: reconstructs pending/running/completed gauges from the lifecycle
     pending: 1,
     running: 0,
     completed: 0,
+    errored: 0,
     some: 0,
     full: 0,
+    errorRate: 0,
     shed: false,
     paused: false,
+    degraded: false,
   })
 
   captured[0].onConnect(() => {})
@@ -217,7 +227,14 @@ test('pressure: a fully idle, decayed origin is evicted', async (t) => {
 
 test('pressure: untracked origin reports no pressure', async (t) => {
   const p = makeInterceptor()
-  t.same(p.pressure('http://never.test'), { some: 0, full: 0, shed: false, paused: false })
+  t.same(p.pressure('http://never.test'), {
+    some: 0,
+    full: 0,
+    errorRate: 0,
+    shed: false,
+    paused: false,
+    degraded: false,
+  })
   t.equal(p.stats('http://never.test'), undefined)
   t.notOk(p.shouldBackoff('http://never.test', 'low'))
   p.close()
@@ -275,6 +292,106 @@ test('pressure: an invalid handler throws without leaking the pending gauge', as
   t.ok(s == null || s.pending === 0, 'pending gauge not leaked')
   await tick(p)
   t.equal(p.stats(ORIGIN), undefined, 'empty record evicted on the next idle tick')
+
+  p.close()
+})
+
+// ---------------------------------------------------------------------------
+// error pressure: a fast-but-failing origin (5xx/429) engages `degraded`
+// ---------------------------------------------------------------------------
+
+test('pressure: a burst of overload errors (5xx) engages degraded without backlog or pause', async (t) => {
+  const p = makeInterceptor()
+  const { dispatch, captured } = capturingDispatch()
+  const wrapped = p(dispatch)
+
+  // Three requests that connect and complete *quickly* — no backlog, full
+  // progress — but every one is a 503. Pure latency/backlog pressure stays 0.
+  for (let i = 0; i < 3; i++) wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  for (const h of captured) complete(h, 503)
+
+  await tick(p)
+  const r = p.pressure(ORIGIN)
+  t.equal(r.some, 0, 'no connection backlog')
+  t.equal(r.full, 0, 'work completed — not stalled')
+  t.ok(r.errorRate > 0.5, 'error-rate EWMA is high')
+  t.ok(r.degraded, 'degraded latched')
+  t.notOk(r.paused, 'not paused — the origin is responding, just failing')
+
+  // degraded sheds discretionary work, like `some`.
+  t.ok(p.shouldBackoff(ORIGIN, 'low'), 'low priority is shed')
+  t.notOk(p.shouldBackoff(ORIGIN, 'normal'), 'normal priority is not shed')
+  t.notOk(p.shouldBackoff(ORIGIN), 'undirected work is not shed by errors alone')
+
+  p.close()
+})
+
+test('pressure: 429 counts as an overload error; 4xx client errors do not', async (t) => {
+  const p = makeInterceptor()
+  const { dispatch, captured } = capturingDispatch()
+  const wrapped = p(dispatch)
+
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler) // 429 -> error
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler) // 404 -> not an error
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler) // 200 -> not an error
+  complete(captured[0], 429)
+  complete(captured[1], 404)
+  complete(captured[2], 200)
+
+  const s = p.stats(ORIGIN)
+  t.equal(s?.completed, 3, 'all three completed')
+  t.equal(s?.errored, 1, 'only the 429 is counted as an overload error')
+
+  p.close()
+})
+
+test('pressure: a transport error counts; a client abort does not', async (t) => {
+  const p = makeInterceptor()
+  const { dispatch, captured } = capturingDispatch()
+  const wrapped = p(dispatch)
+
+  // Transport failure (no status) -> counted.
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  captured[0].onConnect(() => {})
+  captured[0].onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+
+  // Client-initiated abort -> not the origin's fault, not counted.
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  captured[1].onConnect(() => {})
+  captured[1].onError(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+
+  const s = p.stats(ORIGIN)
+  t.equal(s?.completed, 2, 'both settled')
+  t.equal(s?.errored, 1, 'transport error counted, abort not')
+
+  p.close()
+})
+
+test('pressure: degraded releases once responses recover', async (t) => {
+  const p = makeInterceptor()
+  const { dispatch, captured } = capturingDispatch()
+  const wrapped = p(dispatch)
+
+  // Engage on a 503 burst.
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  complete(captured[0], 503)
+  complete(captured[1], 503)
+  await tick(p)
+  t.ok(p.pressure(ORIGIN).degraded, 'degraded engaged on 5xx burst')
+
+  // Keep one request in-flight so the record is retained, then complete two
+  // healthy 200s — the error fraction this window is 0.
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  captured[2].onConnect(() => {})
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  complete(captured[3], 200)
+  complete(captured[4], 200)
+  await tick(p)
+
+  t.notOk(p.pressure(ORIGIN).degraded, 'degraded released after healthy responses')
+  t.match(p.stats(ORIGIN), { running: 1 }, 'record retained while in-flight')
 
   p.close()
 })

--- a/test/pressure-advanced.js
+++ b/test/pressure-advanced.js
@@ -396,6 +396,30 @@ test('pressure: degraded releases once responses recover', async (t) => {
   p.close()
 })
 
+test('pressure: a reconnect clears stale status so a later transport failure still counts', async (t) => {
+  const p = makeInterceptor()
+  const { dispatch, captured } = capturingDispatch()
+  const wrapped = p(dispatch)
+
+  // One handler reconnected across attempts, as an upstream retry handler does.
+  wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
+  const h = captured[0]
+  h.onConnect(() => {})
+  h.onHeaders(200, {}, () => {}) // attempt 1 captured a (non-error) success status
+  h.onConnect(() => {}) // retry -> fresh attempt; captured status must reset
+  h.onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+
+  // Without the per-connect reset, the stale 200 would mask the transport
+  // failure (200 -> not an error) and errored would be 0.
+  t.match(
+    p.stats(ORIGIN),
+    { completed: 1, errored: 1 },
+    'transport failure counted, not masked by the prior attempt status',
+  )
+
+  p.close()
+})
+
 // ---------------------------------------------------------------------------
 // integration: composed in front of a real dispatcher
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an **error-pressure tier** to the `pressure` interceptor (shipped in 7.4.0). PSI measures *stall* (latency) pressure; an HTTP origin has a second failure mode the latency signal is blind to: responding **fast but failing**. A flood of `503`/`429` drains `pending` and ticks `completed`, so neither `some` nor `full` fires — yet that is exactly when to back off.

This is the `dns` interceptor's per-IP 5xx insight (`record.errored`, connection-error ejection) applied at the **logical-origin** level for backoff — kept self-contained (no cross-interceptor coupling).

## What's added

- The `Handler` now captures the response status (`onHeaders`) and classifies the outcome on settle:
  - **Counts as overload error:** `429`/`420`, any `5xx`, and status-less transport failures (ECONNREFUSED, timeouts, a sync dispatch throw).
  - **Does not count:** `4xx` client errors (404/400/401…) and client-initiated aborts (`AbortError`).
- A new `errored` counter feeds an `errorRate` EWMA — a **fraction** of completions (`Δerrored / Δcompleted`), so a trickle of errors under heavy traffic doesn't latch — with its own Schmitt-trigger `degraded` latch (`errHi`/`errLo`, default `0.5`/`0.2`).
- `degraded` sheds discretionary (low-priority) work, same tier as `some`. `errorRate` decays on idle/no-completion windows so a degraded-then-idle origin still gets evicted.
- `shouldBackoff()`, `pressure()`, and `stats()` surface the new signal; typings updated.

## Tiers, recap

| Tier | Trigger | Action |
| --- | --- | --- |
| `some` | connection backlog | shed discretionary |
| `full` | backlog + zero progress | pause everything |
| **`degraded`** (new) | **high error rate (429/5xx)** | **shed discretionary** |

## Test plan

- `test/pressure-advanced.js` — error-tier tests added: 5xx burst → `degraded` (no backlog/pause), 429 counts / 404 doesn't, transport error counts / abort doesn't, hysteresis release on recovery. Full file **55/55 assertions pass**.
- Lint clean, prettier clean, `pressure.js` typechecks clean.

## Note

Branched from the accidental direct-to-`main` push of this commit; `main` has since been reset to 7.4.0, so this is the proper reviewable PR for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
