### PR TITLE
fix(retry): guard against non-string (array) ETag headers

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -129,10 +129,12 @@ class Handler extends DecoratorHandler {
         return super.onHeaders(statusCode, headers, resume)
       }
 
+      // A duplicated etag response header arrives as an array, which has no
+      // startsWith and cannot be used for resumption — treat it as absent.
       // Weak etags are not useful for comparison nor cache
       // for instance not safe to assume if the response is byte-per-byte
       // equal
-      if (this.#etag != null && this.#etag.startsWith('W/')) {
+      if (this.#etag != null && (typeof this.#etag !== 'string' || this.#etag.startsWith('W/'))) {
         this.#etag = null
       }
 

--- a/test/review-bugfixes-4-retry-etag.js
+++ b/test/review-bugfixes-4-retry-etag.js
@@ -1,0 +1,45 @@
+// Regression tests for the response-retry interceptor mishandling a
+// duplicated (array-valued) etag response header. A misconfigured proxy that
+// duplicates ETag made `this.#etag.startsWith('W/')` throw a TypeError out of
+// onHeaders, aborting a perfectly good response. A non-string etag simply
+// means "no resume-etag available" — the response must still succeed.
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('duplicated (array) etag header on 200 does not abort the response', (t) => {
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    res.setHeader('etag', ['"abc"', '"abc"'])
+    res.end('asd')
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body, statusCode } = await request(`http://0.0.0.0:${server.address().port}`)
+    t.equal(statusCode, 200)
+    t.equal(await body.text(), 'asd')
+  })
+})
+
+test('duplicated (array) etag header on 206 does not abort the response', (t) => {
+  t.plan(3)
+
+  const server = createServer((req, res) => {
+    t.equal(req.headers.range, 'bytes=0-2')
+    res.statusCode = 206
+    res.setHeader('content-range', 'bytes 0-2/6')
+    res.setHeader('etag', ['"abc"', '"abc"'])
+    res.end('asd')
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body, statusCode } = await request(`http://0.0.0.0:${server.address().port}`, {
+      headers: { range: 'bytes=0-2' },
+    })
+    t.equal(statusCode, 206)
+    t.equal(await body.text(), 'asd')
+  })
+})


### PR DESCRIPTION
## Problem

`lib/interceptor/response-retry.js` assigns `this.#etag = headers.etag` in both the 206 and 200 branches of `onHeaders` and then calls `this.#etag.startsWith('W/')` with no type guard. When a response carries a duplicated `ETag` header (e.g. a misconfigured proxy adding a second, even identical, copy), the header parser delivers it as an **array** — and arrays have no `.startsWith`.

## Failure scenario

The `TypeError` is thrown out of `onHeaders` (a parser callback), which undici converts into `abort(err)` — so a perfectly good 200/206 response fails. The retry interceptor is installed by default for GET/HEAD/PUT/PATCH/QUERY requests, so this kills default-path requests against any origin/proxy that emits a duplicated ETag.

## Fix

Extend the existing weak-etag guard (which already runs after both assignment sites) to also null out any non-string etag:

```js
if (this.#etag != null && (typeof this.#etag !== 'string' || this.#etag.startsWith('W/'))) {
  this.#etag = null
}
```

A non-string etag simply means "no resume-etag available" — the response succeeds normally, it just isn't range-resumable. This mirrors the `typeof` check the cache interceptor's `isEtagUsable()` already performs.

## Tests

New `test/review-bugfixes-4-retry-etag.js`:

- 200 with `res.setHeader('etag', ['"abc"', '"abc"'])` and a body — request succeeds with the full body (previously aborted with a TypeError).
- 206/range variant with a duplicated etag — succeeds likewise.

Verified the new tests fail with the fix reverted. Full run of the new file plus `test/retry.js` and `test/retry-deep.js`: 97/97 passing. eslint and prettier clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)