### PR TITLE
fix(redirect): strip proxy-authorization on cross-origin redirects

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -199,6 +199,9 @@ function shouldRemoveHeader(header, removeContent, unknownOrigin) {
     (unknownOrigin &&
       header.length === 13 &&
       header.toString().toLowerCase() === 'authorization') ||
+    (unknownOrigin &&
+      header.length === 19 &&
+      header.toString().toLowerCase() === 'proxy-authorization') ||
     (unknownOrigin && header.length === 6 && header.toString().toLowerCase() === 'cookie')
   )
 }

--- a/test/redirect-advanced.js
+++ b/test/redirect-advanced.js
@@ -317,6 +317,72 @@ test('redirect: same-origin redirect preserves authorization header', async (t) 
 })
 
 // ---------------------------------------------------------------------------
+// Cross-origin redirect strips proxy-authorization header
+// ---------------------------------------------------------------------------
+
+test('redirect: cross-origin redirect strips proxy-authorization', async (t) => {
+  t.plan(2)
+  const serverB = await startServer((req, res) => {
+    t.notOk(
+      req.headers['proxy-authorization'],
+      'proxy-authorization header must be stripped on cross-origin',
+    )
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(serverB.close.bind(serverB))
+
+  const serverA = await startServer((req, res) => {
+    res.writeHead(302, { location: `http://127.0.0.1:${serverB.address().port}/dest` })
+    res.end()
+  })
+  t.teardown(serverA.close.bind(serverA))
+
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${serverA.address().port}`,
+    path: '/start',
+    method: 'GET',
+    headers: { 'proxy-authorization': 'Basic c2VjcmV0OnNlY3JldA==' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+})
+
+// ---------------------------------------------------------------------------
+// Same-origin redirect preserves proxy-authorization header
+// ---------------------------------------------------------------------------
+
+test('redirect: same-origin redirect preserves proxy-authorization header', async (t) => {
+  t.plan(2)
+  let proxyAuthOnRedirect = null
+  let hop = 0
+  const server = await startServer((req, res) => {
+    hop++
+    if (hop === 1) {
+      res.writeHead(301, { location: '/dest' })
+      res.end()
+    } else {
+      proxyAuthOnRedirect = req.headers['proxy-authorization']
+      res.writeHead(200)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/start',
+    method: 'GET',
+    headers: { 'proxy-authorization': 'Basic c2VjcmV0OnNlY3JldA==' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+  t.ok(proxyAuthOnRedirect, 'proxy-authorization preserved for same-origin redirect')
+})
+
+// ---------------------------------------------------------------------------
 // 307 redirect preserves method (PUT stays PUT)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`shouldRemoveHeader` in `lib/interceptor/redirect.js` strips `host`, `content-*` (on 303), `authorization`, and `cookie` when following a redirect to a different origin — but not `proxy-authorization`. Upstream undici's redirect handler drops `proxy-authorization` on cross-origin redirects; ours leaked it.

## Failure scenario

1. Client sends `GET http://internal.example/` with `proxy-authorization: Basic <creds>` (redirect following is on by default, `follow: 8`).
2. Server replies `302 Location: http://attacker.example/`.
3. The follow-up request to `attacker.example` still carries the `proxy-authorization` header, leaking the credential to an arbitrary third-party host.

## Fix

Add `proxy-authorization` (length 19) to the `unknownOrigin` strip set in `shouldRemoveHeader`, following the exact pattern used for `authorization` and `cookie`.

## Tests

Added to `test/redirect-advanced.js`, mirroring the existing authorization/cookie tests:

- cross-origin redirect strips `proxy-authorization` (fails without the fix, verified by reverting)
- same-origin redirect preserves `proxy-authorization` (matches existing `authorization` semantics)

Full run: `npx tap test/redirect.js test/redirect-advanced.js` — 75/75 passing. eslint and prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)