### PR TITLE
fix(cache): tolerate duplicated (array) Cache-Control headers

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -229,7 +229,13 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  const rawCacheControl = opts?.headers?.['cache-control']
+  // Cache-Control is a list-typed field: duplicated field lines arrive as an
+  // array and combine into a single comma-separated value per RFC 9110 §5.2,
+  // keeping the raw-string directive checks below working.
+  let rawCacheControl = opts?.headers?.['cache-control']
+  if (Array.isArray(rawCacheControl)) {
+    rawCacheControl = rawCacheControl.join(', ')
+  }
   const cacheControlDirectives = parseCacheControl(rawCacheControl) ?? {}
   // cache-control-parser does not recognise 'only-if-cached', so check the raw string.
   const onlyIfCached =

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,13 @@ export function getFastNow() {
 }
 
 export function parseCacheControl(str) {
-  return str ? cacheControlParser.parse(str) : null
+  if (Array.isArray(str)) {
+    // Cache-Control is a list-typed field, so duplicated field lines are legal
+    // (e.g. CDN + origin each adding one) and combine into a single
+    // comma-separated value per RFC 9110 §5.2.
+    str = str.join(', ')
+  }
+  return str && typeof str === 'string' ? cacheControlParser.parse(str) : null
 }
 
 export function isDisturbed(body) {

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -1,0 +1,166 @@
+// Regression tests for duplicated (array-valued) Cache-Control field lines.
+// Cache-Control is a list-typed field, so duplicated field lines are RFC-legal
+// and common (e.g. CDN + origin each adding one). The undici header parser
+// collects repeated field lines into an array, which parseCacheControl used to
+// pass straight into cache-control-parser's parse() — whose first operation is
+// str.toLowerCase() — turning every such response/request into a TypeError.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import { parseCacheControl } from '../lib/utils.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+// ---------------------------------------------------------------------------
+// parseCacheControl unit tests
+// ---------------------------------------------------------------------------
+
+test('parseCacheControl - array value is combined and parsed', (t) => {
+  t.strictSame(parseCacheControl(['max-age=600', 'public']), { 'max-age': 600, public: true })
+  t.end()
+})
+
+test('parseCacheControl - single-element array', (t) => {
+  t.strictSame(parseCacheControl(['no-store']), { 'no-store': true })
+  t.end()
+})
+
+test('parseCacheControl - non-string values return null', (t) => {
+  t.equal(parseCacheControl([]), null)
+  t.equal(parseCacheControl(123), null)
+  t.equal(parseCacheControl(null), null)
+  t.equal(parseCacheControl(undefined), null)
+  t.equal(parseCacheControl(''), null)
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Response side: duplicated Cache-Control field lines must not abort the
+// request. Previously the TypeError escaped CacheHandler.onHeaders and
+// undici converted it into abort(err) — every otherwise-good cacheable 200
+// from such an origin failed.
+// ---------------------------------------------------------------------------
+
+test('cache: response with duplicated Cache-Control field lines succeeds and is cached', async (t) => {
+  t.plan(4)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    // Sends TWO Cache-Control field lines.
+    res.setHeader('cache-control', ['max-age=600', 'public'])
+    res.setHeader('content-type', 'text/plain')
+    res.end('dual cache-control body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.statusCode, 200, 'first request succeeds despite duplicated Cache-Control')
+  t.equal(first.body, 'dual cache-control body', 'first response body intact')
+
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.statusCode, 200, 'second request succeeds')
+  t.equal(hits, 1, 'combined directives honored — second request served from cache')
+})
+
+// ---------------------------------------------------------------------------
+// Request side: array-form request cache-control must not throw synchronously
+// out of dispatch().
+// ---------------------------------------------------------------------------
+
+test('cache: array-form request cache-control does not throw', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('ok')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+
+  const result = await rawRequest(dispatch, {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': ['no-transform', 'no-store'] },
+    cache: { store },
+  })
+
+  t.equal(result.statusCode, 200, 'request with array cache-control succeeds')
+  t.equal(hits, 1, 'request reached the server')
+})
+
+test('cache: only-if-cached honored when supplied in an array element', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('ok')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+
+  const { statusCode } = await rawRequest(dispatch, {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': ['no-transform', 'only-if-cached'] },
+    cache: { store },
+  })
+
+  t.equal(statusCode, 504, 'only-if-cached in array returns 504 on cache miss')
+  t.equal(hits, 0, 'server must not be contacted for only-if-cached miss')
+})


### PR DESCRIPTION
## Problem

`Cache-Control` is a list-typed HTTP field, so duplicated field lines are RFC-legal and common — e.g. a CDN and the origin each adding one. The undici header parser collects repeated field lines into an **array**, but `parseCacheControl` in `lib/utils.js` passed any truthy value straight into `cache-control-parser`'s `parse()`, whose first operation is `str.toLowerCase()` → `TypeError: str.toLowerCase is not a function`.

## Concrete failure scenario

- **Response side** (`lib/interceptor/cache.js`, `CacheHandler.onHeaders`): a 200 response carrying two `Cache-Control` field lines (e.g. `max-age=600` + `public`) makes the TypeError escape `onHeaders`; undici's `Request.onHeaders` catch converts it into `abort(err)` — **every otherwise-good cacheable 200 from that origin fails**, even with `cache: true` requests that would otherwise succeed.
- **Request side**: an array-valued `opts.headers['cache-control']` throws synchronously out of `dispatch()`.

## Fix

- `parseCacheControl` now joins array values with `', '` before parsing — combining list-typed field lines with a comma is semantically correct per RFC 9110 §5.2 — and returns `null` for any remaining non-string value. This hardens every current and future call site.
- The cache interceptor normalizes the raw request `cache-control` the same way, so the raw-string directive checks (`only-if-cached`, `max-stale`, `min-fresh`) keep working when the directive arrives in one element of an array.

## Tests

New `test/review-bugfixes-4-cache-control.js` (all fail without the fix, pass with it):

- unit tests: array values are combined and parsed; non-string values return `null`
- response with **two** `Cache-Control` field lines succeeds, and the combined directives are honored (second request served from cache, server hit once)
- array-form request `cache-control` does not throw and reaches the origin
- `only-if-cached` supplied as one element of an array returns 504 on cache miss without contacting the server

Verified: `npx tap test/review-bugfixes-4-cache-control.js test/cache-advanced.js test/utils.js` → 198/198 pass; `test/cache.js`, `test/review-bugfixes-cache*.js`, `test/sqlite-cache-store.js` → 185/185 pass; eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)