### PR TITLE
fix(redirect): resolve Location against a safely-built base URL (protocol-relative path SSRF)

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { DecoratorHandler, isDisturbed, parseURL, parseHeaders } from '../utils.js'
+import { DecoratorHandler, isDisturbed, parseURL, parseHeaders, buildURL } from '../utils.js'
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -105,9 +105,15 @@ class Handler extends DecoratorHandler {
       }
     }
 
-    const { origin, pathname, search } = parseURL(
-      new URL(this.#location, this.#opts.origin && new URL(this.#opts.path, this.#opts.origin)),
-    )
+    // Build the base URL by concatenating origin + path via buildURL rather
+    // than `new URL(path, origin)`: the latter is unsafe when `path` is
+    // protocol-relative (e.g. `//evil-host/x`, reachable via a request URL like
+    // `https://good.com//evil-host/x`). WHATWG URL would then treat the path's
+    // leading host as the authority and discard the good origin, so a *relative*
+    // Location would resolve against the attacker-controlled host — an SSRF /
+    // request-misrouting pivot. See buildURL in ../utils.js.
+    const base = this.#opts.origin && buildURL(this.#opts.origin, this.#opts.path)
+    const { origin, pathname, search } = parseURL(new URL(this.#location, base))
     const path = search ? `${pathname}${search}` : pathname
 
     // Remove headers referring to the original URL.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -133,24 +133,41 @@ export function parseURL(url) {
 
   if (!(url instanceof URL)) {
     const port = url.port != null ? url.port : url.protocol === 'https:' ? 443 : 80
-    let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`
-    let path = url.path != null ? url.path : `${url.pathname || ''}${url.search || ''}`
+    const origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`
+    const path = url.path != null ? url.path : `${url.pathname || ''}${url.search || ''}`
 
-    if (origin.endsWith('/')) {
-      origin = origin.substring(0, origin.length - 1)
-    }
-
-    if (path && !path.startsWith('/')) {
-      path = `/${path}`
-    }
-    // new URL(path, origin) is unsafe when `path` contains an absolute URL
-    // From https://developer.mozilla.org/en-US/docs/Web/API/URL/URL:
-    // If first parameter is a relative URL, second param is required, and will be used as the base URL.
-    // If first parameter is an absolute URL, a given second param will be ignored.
-    url = new URL(origin + path)
+    url = buildURL(origin, path)
   }
 
   return url
+}
+
+// Build an absolute URL from an origin and a path by concatenation.
+//
+// `new URL(path, origin)` is unsafe when `path` is itself absolute or
+// protocol-relative (e.g. starts with `//host`): per the WHATWG URL spec, a
+// protocol-relative first argument inherits only the scheme from the base and
+// resolves its authority from `path`, so the origin's host is silently
+// discarded. Concatenating `origin + path` and parsing the whole thing as a
+// single absolute URL keeps the origin authoritative — which matters for
+// redirect resolution, where a leaked host is an SSRF/misrouting vector.
+//
+// From https://developer.mozilla.org/en-US/docs/Web/API/URL/URL:
+// If first parameter is a relative URL, second param is required, and will be used as the base URL.
+// If first parameter is an absolute URL, a given second param will be ignored.
+export function buildURL(origin, path) {
+  origin = String(origin)
+  path = path == null ? '' : String(path)
+
+  if (origin.endsWith('/')) {
+    origin = origin.substring(0, origin.length - 1)
+  }
+
+  if (path && !path.startsWith('/')) {
+    path = `/${path}`
+  }
+
+  return new URL(origin + path)
 }
 
 export function parseOrigin(url) {

--- a/test/review-bugfixes-4-redirect-base.js
+++ b/test/review-bugfixes-4-redirect-base.js
@@ -1,0 +1,66 @@
+import t from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { request } from '../lib/index.js'
+
+// Regression: redirect.js resolved a relative Location against
+// `new URL(opts.path, opts.origin)`. When the request path is
+// protocol-relative (starts with `//`, reachable via a public request URL such
+// as `http://good//evil/x`), WHATWG URL treats the leading `//evil` as the
+// authority and discards the good origin's host. A relative redirect from the
+// good origin would then be re-dispatched to the attacker-controlled host —
+// an SSRF / request-misrouting pivot. The fix builds the base by concatenating
+// origin + path (utils.buildURL), keeping the origin authoritative.
+t.test('protocol-relative request path: relative Location stays on the good origin', async (t) => {
+  // "evil" host — the buggy code would re-dispatch the redirect here.
+  let evilHits = 0
+  const evil = createServer((req, res) => {
+    evilHits += 1
+    res.setHeader('Connection', 'close')
+    res.statusCode = 200
+    res.end('EVIL')
+  })
+  evil.listen(0, '127.0.0.1')
+  await once(evil, 'listening')
+  t.teardown(() => evil.close())
+  const evilPort = evil.address().port
+
+  // "good" origin — the only host we ever want to talk to.
+  let goodRequests = 0
+  let secondPath = null
+  const good = createServer((req, res) => {
+    goodRequests += 1
+    res.setHeader('Connection', 'close')
+    if (goodRequests === 1) {
+      // First hop: reply with a *relative* Location.
+      res.statusCode = 301
+      res.setHeader('Location', 'b')
+      res.end('')
+    } else {
+      secondPath = req.url
+      res.statusCode = 200
+      res.end(`GOOD ${req.url}`)
+    }
+  })
+  good.listen(0, '127.0.0.1')
+  await once(good, 'listening')
+  t.teardown(() => good.close())
+  const goodPort = good.address().port
+
+  // Public request URL whose path is protocol-relative and embeds the evil
+  // host: parseURL yields origin=http://127.0.0.1:<goodPort>,
+  // path=//127.0.0.1:<evilPort>/x.
+  const { statusCode, body } = await request(
+    `http://127.0.0.1:${goodPort}//127.0.0.1:${evilPort}/x`,
+    { follow: 5 },
+  )
+  const text = await body.text()
+
+  t.equal(statusCode, 200, 'final response comes back OK')
+  t.equal(evilHits, 0, 'must never hit the protocol-relative (evil) host')
+  t.equal(goodRequests, 2, 'both hops stay on the good origin')
+  // Relative `b` resolves against the good host, in the directory of the
+  // original protocol-relative path — NOT against the evil host.
+  t.equal(secondPath, `//127.0.0.1:${evilPort}/b`)
+  t.equal(text, `GOOD //127.0.0.1:${evilPort}/b`)
+})


### PR DESCRIPTION
## Problem

The redirect interceptor (`lib/interceptor/redirect.js`) resolved a relative `Location` against a base built with `new URL(opts.path, opts.origin)`:

```js
new URL(this.#location, this.#opts.origin && new URL(this.#opts.path, this.#opts.origin))
```

Per the WHATWG URL spec, when the first argument to `new URL()` is **protocol-relative** (starts with `//host`), the parser adopts the leading segment as the authority and **silently discards the base's host**. `opts.path` can be protocol-relative straight from the public API — `new URL('https://good.com//evil.com/x')` yields `pathname === '//evil.com/x'` while `origin` stays `https://good.com`.

Notably, `lib/utils.js` (`parseURL`, ~L146) already documents this exact pitfall (*"new URL(path, origin) is unsafe when path contains an absolute URL"*) and works around it with `new URL(origin + path)` — but `redirect.js` used the unsafe form.

## Failure scenario

1. Caller issues `request('https://good.com//evil.com/x', { follow: n })`.
   → `origin = https://good.com`, `path = //evil.com/x`.
2. `good.com` returns a **relative** redirect, e.g. `301 Location: b`.
3. The base is computed as `new URL('//evil.com/x', 'https://good.com')` = `https://evil.com/x`.
4. `Location: b` resolves to `https://evil.com/b` and is re-dispatched to the attacker-controlled host.

Result: request misrouting / an SSRF pivot. `Host`/`authorization`/`cookie` stripping does not help — the socket already connects to the wrong origin. Upstream undici's redirect handler shares the same `new URL(path, origin)` construction and is affected by the same class of issue.

## Fix

Build the base the safe way — concatenate `origin + path` and parse it as one absolute URL, so the origin stays authoritative. The `parseURL` workaround is extracted into a small exported helper and reused in both places:

```js
// lib/utils.js
export function buildURL(origin, path) {
  origin = String(origin)
  path = path == null ? '' : String(path)
  if (origin.endsWith('/')) origin = origin.substring(0, origin.length - 1)
  if (path && !path.startsWith('/')) path = `/${path}`
  return new URL(origin + path)
}
```

```js
// lib/interceptor/redirect.js
const base = this.#opts.origin && buildURL(this.#opts.origin, this.#opts.path)
const { origin, pathname, search } = parseURL(new URL(this.#location, base))
```

The falsy-origin branch (`this.#opts.origin && …`) is preserved unchanged, and `parseURL` is refactored to delegate to `buildURL` with no behavior change.

## Tests

New `test/review-bugfixes-4-redirect-base.js`: runs a "good" and an "evil" local server where the evil host is a real `127.0.0.1:<port>` embedded in a protocol-relative request path (`http://good//127.0.0.1:<evilPort>/x`). The good server replies with a relative `Location: b`. The test asserts the follow-up stays on the good origin (resolved path `//127.0.0.1:<evilPort>/b`) and the evil server receives **zero** requests. Verified this test fails on the pre-fix code (the request lands on the evil server) and passes after.

Existing `test/redirect.js` and `test/redirect-advanced.js` (normal relative + absolute + cross-origin resolution) continue to pass, as do `test/utils.js` / `test/request.js` (parseURL refactor). 76 + 117 assertions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)