### PR TITLE
fix(log): redact credentials and stop embedding request bodies in log bindings

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -3,8 +3,81 @@ import { DecoratorHandler } from '../utils.js'
 const kGlobalIndex = Symbol.for('@nxtedition/nxt-undici#globalIndex')
 const kGlobalArray = Symbol.for('@nxtedition/nxt-undici#globalArray')
 
+const REDACTED = '[redacted]'
+
+// Header names (lowercase) whose values must never reach the logs.
+const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie', 'set-cookie'])
+
+// Build a plain, lowercase-keyed copy of `headers` with credential values
+// replaced by a redaction marker. Accepts both the object form used by the
+// request pipeline and the raw flat-array form ([name, value, name, value, ...]
+// with Buffer or string entries) that undici hands to onHeaders/onUpgrade.
+function sanitizeHeaders(headers) {
+  if (headers == null || typeof headers !== 'object') {
+    return undefined
+  }
+
+  const sanitized = {}
+
+  if (Array.isArray(headers)) {
+    for (let i = 0; i < headers.length - 1; i += 2) {
+      const name = String(headers[i]).toLowerCase()
+      if (SECRET_HEADERS.has(name)) {
+        sanitized[name] = REDACTED
+      } else {
+        const value = headers[i + 1]
+        sanitized[name] = Array.isArray(value) ? value.map(String) : String(value)
+      }
+    }
+  } else {
+    for (const key of Object.keys(headers)) {
+      const name = key.toLowerCase()
+      sanitized[name] = SECRET_HEADERS.has(name) ? REDACTED : headers[key]
+    }
+  }
+
+  return sanitized
+}
+
+// Summarize the request body (type + size) instead of embedding its content.
+// Bodies may contain credentials or be arbitrarily large, and pino serializes
+// child bindings eagerly — never put the payload itself into the log record.
+function describeBody(body) {
+  if (body == null) {
+    return undefined
+  }
+  if (typeof body === 'string') {
+    return `string(${Buffer.byteLength(body)} bytes)`
+  }
+  if (ArrayBuffer.isView(body)) {
+    return `${body.constructor?.name ?? 'Buffer'}(${body.byteLength} bytes)`
+  }
+  if (typeof body === 'object' && typeof body.byteLength === 'number') {
+    return `${body.constructor?.name ?? 'ArrayBuffer'}(${body.byteLength} bytes)`
+  }
+  if (typeof body === 'function') {
+    return 'function'
+  }
+  return body.constructor?.name ?? typeof body
+}
+
+// Small, sanitized summary of the request opts used for all `ureq` log
+// bindings. Built once per request instead of binding the live opts object,
+// which both leaked credentials/bodies into logs and paid eager pino
+// serialization of the full opts (including the entire body) per request.
+function sanitizeRequest(opts) {
+  return {
+    id: opts.id,
+    origin: opts.origin != null ? String(opts.origin) : undefined,
+    path: opts.path,
+    method: opts.method,
+    headers: sanitizeHeaders(opts.headers),
+    body: describeBody(opts.body),
+  }
+}
+
 class Handler extends DecoratorHandler {
-  #opts
+  #ureq
   #logger
 
   #abort
@@ -25,8 +98,8 @@ class Handler extends DecoratorHandler {
   constructor(logOpts, opts, { handler }) {
     super(handler)
 
-    this.#opts = opts
-    this.#logger = opts.logger.child({ ureq: opts })
+    this.#ureq = sanitizeRequest(opts)
+    this.#logger = opts.logger.child({ ureq: this.#ureq })
 
     if (logOpts?.bindings) {
       this.#logger = this.#logger.child(logOpts?.bindings)
@@ -59,7 +132,7 @@ class Handler extends DecoratorHandler {
 
     this.#logger.debug(
       {
-        ures: { statusCode, headers },
+        ures: { statusCode, headers: sanitizeHeaders(headers) },
         elapsedTime: this.#timing.headers,
       },
       'upstream request upgrade',
@@ -76,7 +149,9 @@ class Handler extends DecoratorHandler {
   onHeaders(statusCode, headers, resume) {
     this.#timing.headers = performance.now() - this.#created
     this.#statusCode = statusCode
-    this.#headers = headers
+    // Only used for log records; store the sanitized copy so set-cookie etc.
+    // never end up in retained (error-level) logs.
+    this.#headers = sanitizeHeaders(headers)
 
     return super.onHeaders(statusCode, headers, resume)
   }
@@ -95,7 +170,7 @@ class Handler extends DecoratorHandler {
     this.#timing.end = performance.now() - this.#created
 
     const data = {
-      ureq: this.#opts,
+      ureq: this.#ureq,
       ures: {
         statusCode: this.#statusCode,
         headers: this.#headers,

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -49,8 +49,11 @@ function describeBody(body) {
   if (typeof body === 'string') {
     return `string(${Buffer.byteLength(body)} bytes)`
   }
+  if (Buffer.isBuffer(body)) {
+    return `Buffer(${body.byteLength} bytes)`
+  }
   if (ArrayBuffer.isView(body)) {
-    return `${body.constructor?.name ?? 'Buffer'}(${body.byteLength} bytes)`
+    return `${body.constructor?.name ?? 'TypedArray'}(${body.byteLength} bytes)`
   }
   if (typeof body === 'object' && typeof body.byteLength === 'number') {
     return `${body.constructor?.name ?? 'ArrayBuffer'}(${body.byteLength} bytes)`

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -66,15 +66,18 @@ function sanitizeHeaders(headers) {
 // Normalize the request origin for logging without leaking userinfo
 // credentials embedded as `http://user:pass@host`. Copy-on-write: userinfo
 // requires an '@', so a string without one is returned as-is — no URL
-// allocation. URL-like objects already expose a credential-free `origin`.
-// Only strings that could carry userinfo are parsed and reduced to
-// URL#origin (which never contains userinfo); if such a string is not a
-// parseable URL, prefer losing the value over risking embedded credentials.
+// allocation. Real `URL` instances already expose a credential-free
+// `origin`; arbitrary URL-like objects do NOT get that fast path, since a
+// plain `{ origin: 'http://user:pass@host' }` would bypass the userinfo
+// check. Everything else is stringified, and only strings that could carry
+// userinfo are parsed and reduced to URL#origin (which never contains
+// userinfo); if such a string is not a parseable URL, prefer losing the
+// value over risking embedded credentials.
 function sanitizeOrigin(origin) {
   if (origin == null) {
     return undefined
   }
-  if (typeof origin === 'object' && typeof origin.origin === 'string') {
+  if (origin instanceof URL) {
     return origin.origin
   }
   const str = typeof origin === 'string' ? origin : String(origin)

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -8,16 +8,48 @@ const REDACTED = '[redacted]'
 // Header names (lowercase) whose values must never reach the logs.
 const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie', 'set-cookie'])
 
-// Build a plain, lowercase-keyed copy of `headers` with credential values
-// replaced by a redaction marker. Accepts both the object form used by the
-// request pipeline and the raw flat-array form ([name, value, name, value, ...]
-// with Buffer or string entries) that undici hands to onHeaders/onUpgrade.
-// parseHeaders lowercases names, stringifies values (Buffers included, so no
+// Allocation-free pre-scan: true when `headers` is a plain object that the
+// parse + redact path would reproduce verbatim — every key already lowercase,
+// every value a string (or array of strings), no secret header present. In
+// that case the original object can be logged as-is: log bindings only read
+// it (pino serializes child bindings eagerly), nothing in the pipeline
+// mutates a caller's headers object in place.
+function isCleanHeaderObject(headers) {
+  for (const key of Object.keys(headers)) {
+    if (SECRET_HEADERS.has(key) || key.toLowerCase() !== key) {
+      return false
+    }
+    const val = headers[key]
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        if (typeof item !== 'string') {
+          return false
+        }
+      }
+    } else if (typeof val !== 'string') {
+      return false
+    }
+  }
+  return true
+}
+
+// Return a loggable view of `headers` with credential values replaced by a
+// redaction marker. Copy-on-write: the common case (already-lowercased plain
+// object, string values, nothing to redact) returns the original object
+// without allocating. Only when something actually needs work — flat-array
+// form ([name, value, name, value, ...] with Buffer or string entries from
+// onHeaders/onUpgrade), a secret header, a non-lowercase name, or a
+// non-string value — do we build a sanitized copy via parseHeaders, which
+// lowercases names, stringifies values (Buffers included, so no
 // `{type:'Buffer',data:[...]}` blobs in bindings), skips null/undefined, and
 // merges duplicate names into arrays instead of overwriting earlier values.
 function sanitizeHeaders(headers) {
   if (headers == null || typeof headers !== 'object') {
     return undefined
+  }
+
+  if (!Array.isArray(headers) && isCleanHeaderObject(headers)) {
+    return headers
   }
 
   const sanitized = parseHeaders(headers)
@@ -31,16 +63,26 @@ function sanitizeHeaders(headers) {
   return sanitized
 }
 
-// Normalize the request origin for logging. URL#origin never contains
-// userinfo, so credentials embedded as `http://user:pass@host` cannot leak
-// into log records. If the origin is not a parseable URL, prefer losing the
-// value over risking embedded credentials.
+// Normalize the request origin for logging without leaking userinfo
+// credentials embedded as `http://user:pass@host`. Copy-on-write: userinfo
+// requires an '@', so a string without one is returned as-is — no URL
+// allocation. URL-like objects already expose a credential-free `origin`.
+// Only strings that could carry userinfo are parsed and reduced to
+// URL#origin (which never contains userinfo); if such a string is not a
+// parseable URL, prefer losing the value over risking embedded credentials.
 function sanitizeOrigin(origin) {
   if (origin == null) {
     return undefined
   }
+  if (typeof origin === 'object' && typeof origin.origin === 'string') {
+    return origin.origin
+  }
+  const str = typeof origin === 'string' ? origin : String(origin)
+  if (!str.includes('@')) {
+    return str
+  }
   try {
-    return new URL(String(origin)).origin
+    return new URL(str).origin
   } catch {
     return REDACTED
   }

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -1,4 +1,4 @@
-import { DecoratorHandler } from '../utils.js'
+import { DecoratorHandler, parseHeaders } from '../utils.js'
 
 const kGlobalIndex = Symbol.for('@nxtedition/nxt-undici#globalIndex')
 const kGlobalArray = Symbol.for('@nxtedition/nxt-undici#globalArray')
@@ -12,31 +12,38 @@ const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie'
 // replaced by a redaction marker. Accepts both the object form used by the
 // request pipeline and the raw flat-array form ([name, value, name, value, ...]
 // with Buffer or string entries) that undici hands to onHeaders/onUpgrade.
+// parseHeaders lowercases names, stringifies values (Buffers included, so no
+// `{type:'Buffer',data:[...]}` blobs in bindings), skips null/undefined, and
+// merges duplicate names into arrays instead of overwriting earlier values.
 function sanitizeHeaders(headers) {
   if (headers == null || typeof headers !== 'object') {
     return undefined
   }
 
-  const sanitized = {}
+  const sanitized = parseHeaders(headers)
 
-  if (Array.isArray(headers)) {
-    for (let i = 0; i < headers.length - 1; i += 2) {
-      const name = String(headers[i]).toLowerCase()
-      if (SECRET_HEADERS.has(name)) {
-        sanitized[name] = REDACTED
-      } else {
-        const value = headers[i + 1]
-        sanitized[name] = Array.isArray(value) ? value.map(String) : String(value)
-      }
-    }
-  } else {
-    for (const key of Object.keys(headers)) {
-      const name = key.toLowerCase()
-      sanitized[name] = SECRET_HEADERS.has(name) ? REDACTED : headers[key]
+  for (const name of SECRET_HEADERS) {
+    if (name in sanitized) {
+      sanitized[name] = REDACTED
     }
   }
 
   return sanitized
+}
+
+// Normalize the request origin for logging. URL#origin never contains
+// userinfo, so credentials embedded as `http://user:pass@host` cannot leak
+// into log records. If the origin is not a parseable URL, prefer losing the
+// value over risking embedded credentials.
+function sanitizeOrigin(origin) {
+  if (origin == null) {
+    return undefined
+  }
+  try {
+    return new URL(String(origin)).origin
+  } catch {
+    return REDACTED
+  }
 }
 
 // Summarize the request body (type + size) instead of embedding its content.
@@ -71,7 +78,7 @@ function describeBody(body) {
 function sanitizeRequest(opts) {
   return {
     id: opts.id,
-    origin: opts.origin != null ? String(opts.origin) : undefined,
+    origin: sanitizeOrigin(opts.origin),
     path: opts.path,
     method: opts.method,
     headers: sanitizeHeaders(opts.headers),

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -13,9 +13,14 @@ const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie'
 // every value a string (or array of strings), no secret header present. In
 // that case the original object can be logged as-is: log bindings only read
 // it (pino serializes child bindings eagerly), nothing in the pipeline
-// mutates a caller's headers object in place.
+// mutates a caller's headers object in place. Uses a `for..in` + `Object.hasOwn`
+// guard rather than `Object.keys` so the scan itself allocates nothing while
+// still ignoring inherited props exactly as `Object.keys` would.
 function isCleanHeaderObject(headers) {
-  for (const key of Object.keys(headers)) {
+  for (const key in headers) {
+    if (!Object.hasOwn(headers, key)) {
+      continue
+    }
     if (SECRET_HEADERS.has(key) || key.toLowerCase() !== key) {
       return false
     }
@@ -35,8 +40,9 @@ function isCleanHeaderObject(headers) {
 
 // Return a loggable view of `headers` with credential values replaced by a
 // redaction marker. Copy-on-write: the common case (already-lowercased plain
-// object, string values, nothing to redact) returns the original object
-// without allocating. Only when something actually needs work — flat-array
+// object, string values, nothing to redact) returns the original object as-is,
+// allocating no new headers object (the pre-scan itself is allocation-free
+// too). Only when something actually needs work — flat-array
 // form ([name, value, name, value, ...] with Buffer or string entries from
 // onHeaders/onUpgrade), a secret header, a non-lowercase name, or a
 // non-string value — do we build a sanitized copy via parseHeaders, which

--- a/test/review-bugfixes-4-log-redact.js
+++ b/test/review-bugfixes-4-log-redact.js
@@ -182,3 +182,103 @@ test('log: buffer body is summarized and flat-array headers are redacted', async
   t.notMatch(text, /dXNlcjpwYXNz/, 'proxy-authorization value absent from all captured logs')
   t.notMatch(text, /buffer-body-secret-payload/, 'buffer content absent from all captured logs')
 })
+
+// ---------------------------------------------------------------------------
+// Duplicate flat-array headers merge into an array instead of overwriting
+// ---------------------------------------------------------------------------
+
+test('log: duplicate flat-array header names merge into an array', async (t) => {
+  const server = await startServer()
+  t.teardown(server.close.bind(server))
+
+  const logger = makeCapturingLogger()
+  const dispatch = compose(new undici.Agent(), interceptors.log())
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: ['X-Multi', 'first-value', 'x-multi', 'second-value', 'x-plain', 'visible-value'],
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.strictSame(
+    ureq.headers['x-multi'],
+    ['first-value', 'second-value'],
+    'duplicate names merged into an array, first value not overwritten',
+  )
+  t.equal(ureq.headers['x-plain'], 'visible-value', 'unique headers stay plain strings')
+})
+
+// ---------------------------------------------------------------------------
+// Object-form header values are stringified, null/undefined skipped
+// ---------------------------------------------------------------------------
+
+test('log: object-form Buffer header values are stringified and nullish values skipped', async (t) => {
+  // undici's own Request validation rejects Buffer values in object-form
+  // headers before they reach the wire, but the log binding is built from the
+  // raw opts before dispatch validation runs — so drive the interceptor over a
+  // stub dispatch to assert the sanitizer stringifies rather than letting pino
+  // serialize `{type:'Buffer',data:[...]}` blobs into the bindings.
+  const logger = makeCapturingLogger()
+  const dispatch = interceptors.log()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, ['content-length', '0'], () => {})
+    handler.onComplete([])
+    return true
+  })
+  const status = await rawRequest(dispatch, {
+    origin: 'http://127.0.0.1:8080',
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-buf': Buffer.from('buffer-header-value'),
+      'x-null': null,
+      'x-undefined': undefined,
+      'x-plain': 'visible-value',
+    },
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.headers['x-buf'], 'buffer-header-value', 'Buffer value stringified')
+  t.notOk('x-null' in ureq.headers, 'null header value skipped')
+  t.notOk('x-undefined' in ureq.headers, 'undefined header value skipped')
+  t.equal(ureq.headers['x-plain'], 'visible-value', 'plain string values preserved')
+
+  const text = capturedText(logger)
+  t.notMatch(text, /type.{0,3}Buffer/, 'no serialized Buffer objects leaked into logs')
+  t.notMatch(text, /"data"|data:\s*\[/, 'no Buffer data arrays leaked into logs')
+})
+
+// ---------------------------------------------------------------------------
+// Origin userinfo credentials must not reach the logger
+// ---------------------------------------------------------------------------
+
+test('log: origin with userinfo credentials is logged without them', async (t) => {
+  const server = await startServer()
+  t.teardown(server.close.bind(server))
+
+  const logger = makeCapturingLogger()
+  const dispatch = compose(new undici.Agent(), interceptors.log())
+  const port = server.address().port
+  const status = await rawRequest(dispatch, {
+    origin: `http://secret-user:hunter2@127.0.0.1:${port}`,
+    path: '/',
+    method: 'GET',
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.origin, `http://127.0.0.1:${port}`, 'origin normalized without userinfo')
+
+  const text = capturedText(logger)
+  t.notMatch(text, /secret-user/, 'username absent from all captured logs')
+  t.notMatch(text, /hunter2/, 'password absent from all captured logs')
+})

--- a/test/review-bugfixes-4-log-redact.js
+++ b/test/review-bugfixes-4-log-redact.js
@@ -1,0 +1,184 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { inspect } from 'node:util'
+import { compose, interceptors } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+async function startServer(handler) {
+  const server = createServer(handler ?? ((req, res) => res.end('ok')))
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+// Stub logger that captures both child() bindings and every log record so we
+// can assert on exactly what would end up in pino output.
+function makeCapturingLogger() {
+  const bindings = []
+  const records = []
+  function makeChild() {
+    return {
+      bindings,
+      records,
+      debug(...args) {
+        records.push({ level: 'debug', args })
+      },
+      warn(...args) {
+        records.push({ level: 'warn', args })
+      },
+      error(...args) {
+        records.push({ level: 'error', args })
+      },
+      child(b) {
+        bindings.push(b)
+        return makeChild()
+      },
+    }
+  }
+  return makeChild()
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData() {},
+      onComplete() {
+        resolve(statusCode)
+      },
+      onError: reject,
+    })
+  })
+}
+
+// Everything the stub logger ever saw, flattened to a string, so we can assert
+// a secret value is not present anywhere (bindings or log records).
+function capturedText(logger) {
+  return inspect({ bindings: logger.bindings, records: logger.records }, { depth: 20 })
+}
+
+// ---------------------------------------------------------------------------
+// Request credentials and body content must not reach the logger
+// ---------------------------------------------------------------------------
+
+test('log: authorization/cookie header values and body content are not logged', async (t) => {
+  const server = await startServer((req, res) => {
+    req.resume()
+    req.on('end', () => {
+      res.writeHead(200)
+      res.end()
+    })
+  })
+  t.teardown(server.close.bind(server))
+
+  const logger = makeCapturingLogger()
+  const dispatch = compose(new undici.Agent(), interceptors.log())
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer top-secret-token',
+      Cookie: 'session=super-secret-cookie',
+      'x-plain': 'visible-value',
+    },
+    body: 'this-body-is-confidential',
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.headers.authorization, '[redacted]', 'authorization redacted (case-insensitive)')
+  t.equal(ureq.headers.cookie, '[redacted]', 'cookie redacted (case-insensitive)')
+  t.equal(ureq.headers['x-plain'], 'visible-value', 'non-secret headers preserved')
+  t.equal(ureq.method, 'POST')
+  t.equal(ureq.path, '/')
+  t.match(ureq.body, /^string\(\d+ bytes\)$/, 'body summarized as type + byte length')
+
+  const text = capturedText(logger)
+  t.notMatch(text, /top-secret-token/, 'authorization value absent from all captured logs')
+  t.notMatch(text, /super-secret-cookie/, 'cookie value absent from all captured logs')
+  t.notMatch(text, /this-body-is-confidential/, 'body content absent from all captured logs')
+})
+
+// ---------------------------------------------------------------------------
+// 5xx error-level record: ureq redacted, response set-cookie redacted
+// ---------------------------------------------------------------------------
+
+test('log: 5xx error record redacts request credentials and response set-cookie', async (t) => {
+  const server = await startServer((req, res) => {
+    res.writeHead(500, { 'Set-Cookie': 'session=server-secret', 'x-plain': 'visible-value' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const logger = makeCapturingLogger()
+  const dispatch = compose(new undici.Agent(), interceptors.log())
+  await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { authorization: 'Bearer top-secret-token' },
+    logger,
+  })
+
+  const errorRecord = logger.records.find(
+    (r) => r.level === 'error' && String(r.args[r.args.length - 1]).includes('completed'),
+  )
+  t.ok(errorRecord, 'error was logged for 5xx response')
+
+  const data = errorRecord.args[0]
+  t.equal(data.ureq.headers.authorization, '[redacted]', 'authorization redacted in error record')
+  t.equal(data.ures.headers['set-cookie'], '[redacted]', 'set-cookie redacted in error record')
+  t.equal(data.ures.headers['x-plain'], 'visible-value', 'non-secret response headers preserved')
+  t.equal(data.ures.statusCode, 500)
+
+  const text = capturedText(logger)
+  t.notMatch(text, /top-secret-token/, 'authorization value absent from all captured logs')
+  t.notMatch(text, /server-secret/, 'set-cookie value absent from all captured logs')
+})
+
+// ---------------------------------------------------------------------------
+// Buffer body summarized, flat-array request headers redacted too
+// ---------------------------------------------------------------------------
+
+test('log: buffer body is summarized and flat-array headers are redacted', async (t) => {
+  const server = await startServer((req, res) => {
+    req.resume()
+    req.on('end', () => {
+      res.writeHead(200)
+      res.end()
+    })
+  })
+  t.teardown(server.close.bind(server))
+
+  const logger = makeCapturingLogger()
+  const dispatch = compose(new undici.Agent(), interceptors.log())
+  const body = Buffer.from('buffer-body-secret-payload')
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: ['Proxy-Authorization', 'Basic dXNlcjpwYXNz', 'x-plain', 'visible-value'],
+    body,
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.headers['proxy-authorization'], '[redacted]', 'proxy-authorization redacted')
+  t.equal(ureq.headers['x-plain'], 'visible-value', 'non-secret headers preserved')
+  t.equal(ureq.body, `Buffer(${body.byteLength} bytes)`, 'buffer body summarized, not embedded')
+
+  const text = capturedText(logger)
+  t.notMatch(text, /dXNlcjpwYXNz/, 'proxy-authorization value absent from all captured logs')
+  t.notMatch(text, /buffer-body-secret-payload/, 'buffer content absent from all captured logs')
+})

--- a/test/review-bugfixes-4-log-redact.js
+++ b/test/review-bugfixes-4-log-redact.js
@@ -282,3 +282,59 @@ test('log: origin with userinfo credentials is logged without them', async (t) =
   t.notMatch(text, /secret-user/, 'username absent from all captured logs')
   t.notMatch(text, /hunter2/, 'password absent from all captured logs')
 })
+
+// ---------------------------------------------------------------------------
+// Copy-on-write fast path: nothing to redact → no new objects are allocated
+// ---------------------------------------------------------------------------
+
+test('log: clean headers and origin are passed through by reference (no copy)', async (t) => {
+  // Drive the interceptor over a stub dispatch so the exact opts objects reach
+  // the log handler and identity can be asserted on the captured binding.
+  const logger = makeCapturingLogger()
+  const dispatch = interceptors.log()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, ['content-length', '0'], () => {})
+    handler.onComplete([])
+    return true
+  })
+  const headers = {
+    accept: 'application/json',
+    'x-plain': 'visible-value',
+    'x-multi': ['first-value', 'second-value'],
+  }
+  const origin = 'http://127.0.0.1:8080'
+  const status = await rawRequest(dispatch, { origin, path: '/', method: 'GET', headers, logger })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.headers, headers, 'zero-mutation header object bound by reference, not copied')
+  t.equal(ureq.origin, origin, 'origin without userinfo logged as-is without URL parsing')
+  t.equal(ureq.headers['x-plain'], 'visible-value', 'values still readable through the binding')
+})
+
+test('log: headers needing work still produce a sanitized copy', async (t) => {
+  const logger = makeCapturingLogger()
+  const dispatch = interceptors.log()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, ['content-length', '0'], () => {})
+    handler.onComplete([])
+    return true
+  })
+  const headers = { 'X-Mixed-Case': 'visible-value', cookie: 'session=super-secret-cookie' }
+  const status = await rawRequest(dispatch, {
+    origin: 'http://127.0.0.1:8080',
+    path: '/',
+    method: 'GET',
+    headers,
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.not(ureq.headers, headers, 'headers with a secret are copied, original left untouched')
+  t.equal(ureq.headers['x-mixed-case'], 'visible-value', 'mixed-case names still lowercased')
+  t.equal(ureq.headers.cookie, '[redacted]', 'secret still redacted on the slow path')
+  t.equal(headers.cookie, 'session=super-secret-cookie', 'caller headers object not mutated')
+})

--- a/test/review-bugfixes-4-log-redact.js
+++ b/test/review-bugfixes-4-log-redact.js
@@ -283,6 +283,57 @@ test('log: origin with userinfo credentials is logged without them', async (t) =
   t.notMatch(text, /hunter2/, 'password absent from all captured logs')
 })
 
+test('log: URL-like object origin does not bypass the userinfo check', async (t) => {
+  // A plain object with a string `.origin` property must NOT get the URL fast
+  // path — `{ origin: 'http://user:pass@host' }` would leak credentials
+  // verbatim. Only real URL instances (whose `.origin` never contains
+  // userinfo) may skip the string normalization.
+  const logger = makeCapturingLogger()
+  const dispatch = interceptors.log()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, ['content-length', '0'], () => {})
+    handler.onComplete([])
+    return true
+  })
+  const status = await rawRequest(dispatch, {
+    origin: { origin: 'http://secret-user:hunter2@127.0.0.1:8080' },
+    path: '/',
+    method: 'GET',
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  const text = capturedText(logger)
+  t.notMatch(text, /secret-user/, 'username absent from all captured logs')
+  t.notMatch(text, /hunter2/, 'password absent from all captured logs')
+})
+
+test('log: real URL instance origin uses its credential-free origin', async (t) => {
+  const logger = makeCapturingLogger()
+  const dispatch = interceptors.log()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, ['content-length', '0'], () => {})
+    handler.onComplete([])
+    return true
+  })
+  const status = await rawRequest(dispatch, {
+    origin: new URL('http://secret-user:hunter2@127.0.0.1:8080'),
+    path: '/',
+    method: 'GET',
+    logger,
+  })
+  t.equal(status, 200)
+
+  const ureq = logger.bindings[0]?.ureq
+  t.ok(ureq, 'child() was called with a ureq binding')
+  t.equal(ureq.origin, 'http://127.0.0.1:8080', 'URL instance reduced to credential-free origin')
+  const text = capturedText(logger)
+  t.notMatch(text, /secret-user/, 'username absent from all captured logs')
+  t.notMatch(text, /hunter2/, 'password absent from all captured logs')
+})
+
 // ---------------------------------------------------------------------------
 // Copy-on-write fast path: nothing to redact → no new objects are allocated
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`lib/interceptor/log.js` bound the **live request opts** into the child logger (`opts.logger.child({ ureq: opts })`) and re-attached the same object as `ureq` on every completion record:

- **Secret leak:** `headers` (including `authorization`, `proxy-authorization`, `cookie`) and the full request `body` content ended up in log bindings, and were logged at **error** level for every 5xx — exactly the records most likely to be retained and shipped to a log aggregator. Response headers (which may contain `set-cookie`) were also logged unredacted on completion/error/upgrade.
- **Eager serialization cost:** pino serializes child bindings at `child()` time regardless of the active level, so every request paid JSON-stringification of the whole opts object — for a Buffer/string body, the entire payload was encoded into chindings even when nothing was ever logged.

## Fix

Build a small sanitized `ureq` summary **once per request** and use it for the `child()` binding and all subsequent log records:

- `id`, `origin`, `path`, `method` are kept.
- Header values for `authorization`, `proxy-authorization`, `cookie`, `set-cookie` are replaced with `'[redacted]'` (case-insensitive), on both request and response sides (`onHeaders`, `onUpgrade`, completion/error records). Both object-form and raw flat-array header shapes are handled.
- The body is summarized as type + byte length (e.g. `string(25 bytes)`, `Buffer(26 bytes)`, `Readable`) — content is never embedded, and bodies are never deep-cloned.

All existing log messages, levels, and the global in-flight registry logic are unchanged.

## Note: log record shape change (please veto if unwanted)

`ureq` is now a **sanitized summary object** instead of the raw opts object: fields like `logger`, `signal`, timeouts, etc. no longer appear, header keys are lowercased, and `body` is a summary string. Response `ures.headers` are now a lowercase-keyed plain object with secrets redacted (previously the raw shape passed to `onHeaders`). No existing test assertions had to change.

## Tests

New `test/review-bugfixes-4-log-redact.js` (tap, capturing stub logger):

1. Request with `Authorization` + `Cookie` headers and a string body → captured child bindings and records contain no secret values (redaction marker instead), body content absent, body summarized.
2. 5xx response → error-level record has redacted `ureq` credentials and redacted response `set-cookie`; non-secret headers preserved.
3. Buffer body + flat-array request headers → `proxy-authorization` redacted, buffer content absent, summarized as `Buffer(N bytes)`.

- `npx tap test/review-bugfixes-4-log-redact.js test/log-advanced.js`: **38/38 pass** (all pre-existing log tests untouched and passing).
- Verified the new tests **fail** (14 assertions) with the fix reverted.
- eslint + prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)