### PR TITLE
fix(retry): stream large (>256KiB) error bodies through instead of replaying zero bytes

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -2,6 +2,11 @@ import assert from 'node:assert'
 import tp from 'node:timers/promises'
 import { DecoratorHandler, isDisturbed, decorateError, parseContentRange } from '../utils.js'
 
+// Maximum number of >= 400 response body bytes buffered for replay in case
+// the response is not retried. Larger bodies are passed straight through and
+// the response is not status-code retried.
+const MAX_ERROR_BODY_SIZE = 256 * 1024
+
 function noop() {}
 
 class Handler extends DecoratorHandler {
@@ -121,8 +126,21 @@ class Handler extends DecoratorHandler {
         this.#end = contentLength
         this.#etag = headers.etag
       } else if (statusCode >= 400) {
+        if (
+          contentLength != null &&
+          contentLength > MAX_ERROR_BODY_SIZE &&
+          this.#opts.method !== 'HEAD'
+        ) {
+          // The error body is too large to buffer for a replay if the retry
+          // is declined. Pass it straight through instead of buffering —
+          // such a response is simply not status-code retried.
+          this.#headersSent = true
+          return super.onHeaders(statusCode, headers, resume)
+        }
+
         this.#body = []
         this.#bodySize = 0
+        this.#resume = resume
         return true
       } else {
         this.#headersSent = true
@@ -193,16 +211,32 @@ class Handler extends DecoratorHandler {
       this.#pos += chunk.byteLength
     }
 
-    if (this.#statusCode < 400) {
+    if (this.#statusCode < 400 || (this.#headersSent && !this.#errorSent)) {
       return super.onData(chunk)
     }
 
     if (this.#body) {
       this.#body.push(chunk)
       this.#bodySize += chunk.byteLength
-      if (this.#bodySize > 256 * 1024) {
+      if (this.#bodySize > MAX_ERROR_BODY_SIZE) {
+        // The error body has grown too large to buffer for a replay if the
+        // retry is declined. Flush the buffered chunks downstream and fall
+        // back to passing the response through — it is no longer
+        // status-code retried. Previously the buffer was discarded here,
+        // which made #maybeError replay headers followed by zero body bytes.
+        const body = this.#body
         this.#body = null
         this.#bodySize = 0
+
+        this.#headersSent = true
+        let ret = super.onHeaders(this.#statusCode, this.#headers, () => this.#resume?.())
+        for (const buffered of body) {
+          if (this.#aborted) {
+            return false
+          }
+          ret = super.onData(buffered)
+        }
+        return ret
       }
     }
   }
@@ -211,6 +245,12 @@ class Handler extends DecoratorHandler {
     this.#trailers = trailers
 
     if (this.#statusCode < 400) {
+      return super.onComplete(trailers)
+    }
+
+    if (this.#headersSent && !this.#errorSent) {
+      // The >= 400 response was passed through (too large to buffer for
+      // replay) — headers and data have already been forwarded downstream.
       return super.onComplete(trailers)
     }
 
@@ -264,7 +304,16 @@ class Handler extends DecoratorHandler {
   }
 
   #maybeRetry(err) {
-    if (this.#aborted || isDisturbed(this.#opts.body) || (this.#pos && !this.#etag)) {
+    if (
+      this.#aborted ||
+      isDisturbed(this.#opts.body) ||
+      // Headers were forwarded downstream without range tracking (e.g. a
+      // passed-through >= 400 body or a trailer response) — there is no way
+      // to resume, so propagate the error instead of asserting in the
+      // range-resume branch below.
+      (this.#headersSent && this.#pos == null) ||
+      (this.#pos && !this.#etag)
+    ) {
       this.#maybeError(err)
       return
     }

--- a/test/review-bugfixes-4-retry-large-body.js
+++ b/test/review-bugfixes-4-retry-large-body.js
@@ -1,0 +1,155 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { request } from '../lib/index.js'
+
+// Exceeds the 256 KiB cap on how much of a >= 400 body response-retry
+// buffers for replay.
+const BODY_SIZE = 300 * 1024
+const LARGE_BODY = 'x'.repeat(BODY_SIZE)
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+// ---------------------------------------------------------------------------
+// Bug fix: for retry-eligible methods, response-retry buffered >= 400 bodies
+// so it could replay them if no retry happened, but discarded the ENTIRE
+// buffer once it grew past 256 KiB. When the retry decision was "no", it then
+// replayed the headers (still advertising the full content-length) followed
+// by zero body bytes — silent data loss, or a bogus "Response body size
+// mismatch" error from response-verify that masked the real HTTP error.
+// ---------------------------------------------------------------------------
+
+test('retry: large 4xx body with content-length is delivered in full', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(400, {
+      'content-type': 'text/plain',
+      'content-length': String(BODY_SIZE),
+    })
+    res.end(LARGE_BODY)
+  })
+  t.teardown(server.close.bind(server))
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${server.address().port}`, {
+    error: false,
+    verify: false,
+  })
+  const text = await body.text()
+  t.equal(statusCode, 400)
+  t.equal(text.length, BODY_SIZE, 'body must not be truncated to zero bytes')
+})
+
+test('retry: large chunked 4xx body is flushed through once the cap is exceeded', async (t) => {
+  t.plan(2)
+  const chunkSize = 60 * 1024
+  const server = await startServer((req, res) => {
+    // No content-length — chunked transfer-encoding. The cap is only
+    // exceeded mid-stream, exercising the onData flush path.
+    res.statusCode = 400
+    res.setHeader('content-type', 'text/plain')
+    for (let pos = 0; pos < BODY_SIZE; pos += chunkSize) {
+      res.write(LARGE_BODY.slice(pos, pos + chunkSize))
+    }
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${server.address().port}`, {
+    error: false,
+    verify: false,
+  })
+  const text = await body.text()
+  t.equal(statusCode, 400)
+  t.equal(text.length, BODY_SIZE, 'all buffered and subsequent chunks must be delivered')
+})
+
+test('retry: large 4xx body with default options rejects with the HTTP error', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(400, {
+      'content-type': 'text/plain',
+      'content-length': String(BODY_SIZE),
+    })
+    res.end(LARGE_BODY)
+  })
+  t.teardown(server.close.bind(server))
+
+  try {
+    await request(`http://127.0.0.1:${server.address().port}`)
+    t.fail('should have thrown')
+  } catch (err) {
+    t.equal(err.statusCode, 400, 'the real HTTP error must surface')
+    t.not(err.message, 'Response body size mismatch', 'must not be masked by response-verify')
+  }
+})
+
+test('retry: large 5xx body is passed through instead of retried', async (t) => {
+  t.plan(3)
+  let attempts = 0
+  const server = await startServer((req, res) => {
+    attempts++
+    res.writeHead(503, {
+      'content-type': 'text/plain',
+      'content-length': String(BODY_SIZE),
+    })
+    res.end(LARGE_BODY)
+  })
+  t.teardown(server.close.bind(server))
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${server.address().port}`, {
+    error: false,
+    verify: false,
+  })
+  const text = await body.text()
+  t.equal(statusCode, 503)
+  t.equal(text.length, BODY_SIZE)
+  t.equal(attempts, 1, 'a body too large to replay is not status-code retried')
+})
+
+// ---------------------------------------------------------------------------
+// Guard against regressions in the small-body paths.
+// ---------------------------------------------------------------------------
+
+test('retry: small 4xx error body is still buffered and replayed', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(404, {
+      'content-type': 'text/plain',
+      'content-length': '9',
+    })
+    res.end('not found')
+  })
+  t.teardown(server.close.bind(server))
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${server.address().port}`, {
+    error: false,
+  })
+  t.equal(statusCode, 404)
+  t.equal(await body.text(), 'not found')
+})
+
+test('retry: 503 followed by 200 still retries', async (t) => {
+  t.plan(3)
+  let attempts = 0
+  const server = await startServer((req, res) => {
+    attempts++
+    if (attempts === 1) {
+      res.statusCode = 503
+      res.end('unavailable')
+    } else {
+      res.statusCode = 200
+      res.end('ok')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const { statusCode, body } = await request(`http://127.0.0.1:${server.address().port}`)
+  t.equal(statusCode, 200)
+  t.equal(await body.text(), 'ok')
+  t.equal(attempts, 2)
+})


### PR DESCRIPTION
## Problem

For retry-eligible methods (default `GET`/`HEAD`/`PUT`/`PATCH`/`QUERY`), the `response-retry` interceptor buffers `>= 400` response bodies in `onHeaders` so it can replay them downstream if the retry decision turns out to be "no". However, once the buffer grew past 256 KiB, `onData` discarded the entire buffer (`this.#body = null`) while keeping the response in the buffered-replay path.

## Failure scenario (reproduced)

When no retry happens (a plain 404/400/500, or a 429/503 after retries are exhausted), `#maybeError(null)` replayed `super.onHeaders(...)` — still advertising the full `content-length` — followed by **no data** and `super.onComplete(...)`. For any `>= 400` response with a body over 256 KiB:

- With default options, `response-verify` (size check on by default) masked the real HTTP error with `Error('Response body size mismatch') { expected: 307200, actual: 0 }`.
- With `error: false, verify: false`, the caller silently received a `>= 400` response with a zero-byte body — data loss.

The existing coverage (`test/response-error-advanced.js`, 512 KiB case) only tested `retry: false`, which bypasses this interceptor entirely.

## Fix

Two coordinated changes in `lib/interceptor/response-retry.js`:

1. **Known-length path (`onHeaders`)**: when `content-length` is already known to exceed the 256 KiB cap, don't buffer at all — mark headers as sent and pass the response straight through. Such a response is simply not status-code retried; this trades nothing away, since the replay after a declined retry was broken anyway (`HEAD` is exempt: it has no body to buffer, so its retry behavior is unchanged).
2. **Chunked/unknown-length path (`onData`)**: when the cap is exceeded mid-stream, *flush* instead of discard — forward `super.onHeaders(...)` with the real `resume` callback wired through, replay the buffered chunks (checking `#aborted` between chunks, same discipline as the existing `#maybeError` replay loop), null the buffer, and pass all subsequent data straight through. `onComplete` then completes downstream directly instead of entering `#maybeRetry`.

Additionally, `#maybeRetry` now routes to `#maybeError` when headers were forwarded without range tracking (`#headersSent && #pos == null`, e.g. a flushed `>= 400` body or a trailer response). Previously a connection error in that state crashed on `assert(Number.isFinite(this.#pos))` in the range-resume branch; range-resume remains reserved for 200/206 responses where `#pos`/`#end` are tracked.

## Tests

New `test/review-bugfixes-4-retry-large-body.js` (all four bug cases fail without the fix):

- 400 + 300 KiB body with `content-length`, `{ error: false, verify: false }` → full 307200-byte body delivered (was 0).
- Same but chunked (no `content-length`) → full body delivered via the mid-stream flush path.
- 400 + 300 KiB body with default options → rejects with the real HTTP 400 error, not `Response body size mismatch`.
- 503 + 300 KiB body → passed through once, not retried (documents the new large-body semantics; previously burned all 8 retries and then delivered zero bytes).
- Regression guards: small (< 256 KiB) `>= 400` bodies still buffer and replay; 503-then-200 still retries.

Full suite: 921 passing / 4 skipped / 0 failing. `eslint` and `prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)