### PR TITLE
fix(cache): immutable no longer overrides explicit max-age/s-maxage (RFC 8246)

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -141,9 +141,15 @@ class CacheHandler extends DecoratorHandler {
       }
     }
 
-    const ttl = cacheControlDirectives.immutable
-      ? 31556952
-      : Number(cacheControlDirectives['s-maxage'] ?? cacheControlDirectives['max-age'])
+    // RFC 8246: 'immutable' means the body won't change during the freshness
+    // lifetime — it does not define or extend that lifetime. An explicit
+    // s-maxage/max-age always wins; immutable only supplies a (long) default
+    // when no explicit lifetime is present. Capped by maxEntryTTL below.
+    const ttl = Number(
+      cacheControlDirectives['s-maxage'] ??
+        cacheControlDirectives['max-age'] ??
+        (cacheControlDirectives.immutable ? 31556952 : NaN),
+    )
     if (!ttl || !Number.isFinite(ttl) || ttl <= 0) {
       return super.onHeaders(statusCode, headers, resume)
     }

--- a/test/review-bugfixes-4-cache-immutable.js
+++ b/test/review-bugfixes-4-cache-immutable.js
@@ -1,0 +1,131 @@
+// Regression tests for the RFC 8246 'immutable' TTL bug: immutable marks the
+// body as unchanging during the freshness lifetime — it does not define or
+// extend that lifetime. An explicit s-maxage/max-age must win; immutable only
+// supplies a long default TTL when no explicit lifetime is present.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData() {},
+      onComplete() {
+        resolve(statusCode)
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('cache: immutable does not override explicit max-age (expires on schedule)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=1, immutable', 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'served from cache within the max-age window')
+
+  // getFastNow (used by the store's expiry check) refreshes on a 1s interval,
+  // so wait comfortably past max-age=1 for at least two ticks to elapse.
+  await sleep(2600)
+
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'goes back to origin after max-age expires despite immutable')
+})
+
+test('cache: immutable alone still caches with a long default TTL', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'immutable', 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'immutable without explicit lifetime is still cached')
+
+  // The ~1 year immutable default is capped by maxEntryTTL (default 30 days).
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.deleteAt - entry.cachedAt, 30 * 24 * 3600 * 1000, 'TTL capped at maxEntryTTL')
+})
+
+test('cache: explicit s-maxage wins over immutable', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60, immutable', 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'served from cache within the s-maxage window')
+
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.deleteAt - entry.cachedAt, 60 * 1000, 's-maxage=60 sets the TTL, not immutable')
+})


### PR DESCRIPTION
## Problem

In `lib/interceptor/cache.js`, the TTL computation let the `immutable` directive unconditionally win:

```js
const ttl = cacheControlDirectives.immutable
  ? 31556952
  : Number(cacheControlDirectives['s-maxage'] ?? cacheControlDirectives['max-age'])
```

RFC 8246 defines `immutable` as a promise that the body will not change **during the response's freshness lifetime** — it does not define or extend that lifetime, which still comes from `max-age`/`s-maxage`.

## Failure scenario (reproduced at runtime)

Origin sends `Cache-Control: max-age=1, immutable`. The entry is stored with a ~1 year TTL (capped by `maxEntryTTL`, default 30 days) instead of 1 second. After the declared lifetime expires, the response keeps being served fresh from cache without ever contacting the origin.

## Fix

`immutable` now only supplies the long default lifetime when no explicit lifetime is present:

```js
const ttl = Number(
  cacheControlDirectives['s-maxage'] ??
    cacheControlDirectives['max-age'] ??
    (cacheControlDirectives.immutable ? 31556952 : NaN),
)
```

Behavior is unchanged for `immutable` without an explicit lifetime (still cached with the ~1 year default, capped by `maxEntryTTL`) and for responses without any TTL directive (still not cached, via the existing `Number.isFinite` guard).

## Tests

New `test/review-bugfixes-4-cache-immutable.js` (all fail before the fix where expected, pass after; `test/cache-advanced.js` still fully green — 93/93):

- `max-age=1, immutable` → served from cache within the window, goes back to origin after expiry
- `immutable` alone → still cached, TTL capped at `maxEntryTTL` (asserted via stored `deleteAt - cachedAt`)
- `s-maxage=60, immutable` → 60s TTL wins (asserted via stored `deleteAt - cachedAt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)