### PR TITLE
fix: export SqliteCacheStore at runtime to match type declarations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ export const cache = {
 }
 
 export { parseHeaders } from './utils.js'
+export { SqliteCacheStore } from './sqlite-cache-store.js'
 export { Client, Pool, Agent, getGlobalDispatcher, setGlobalDispatcher } from '@nxtedition/undici'
 
 function defaultLookup(origin, opts, callback) {

--- a/test/review-bugfixes-4-exports.js
+++ b/test/review-bugfixes-4-exports.js
@@ -1,0 +1,12 @@
+import { test } from 'tap'
+import { SqliteCacheStore, cache } from '../lib/index.js'
+
+test('SqliteCacheStore is exported as a named export', (t) => {
+  t.equal(typeof SqliteCacheStore, 'function')
+  t.end()
+})
+
+test('named export matches cache.SqliteCacheStore', (t) => {
+  t.equal(SqliteCacheStore, cache.SqliteCacheStore)
+  t.end()
+})


### PR DESCRIPTION
## Problem

`lib/index.d.ts` declares `export class SqliteCacheStore ...` as a named export, but `lib/index.js` only exposes it as `cache.SqliteCacheStore` (a property on the exported `cache` object). TypeScript compiles

```ts
import { SqliteCacheStore } from '@nxtedition/nxt-undici'
```

without errors, but ESM linking fails at runtime with:

> The requested module ... does not provide an export named 'SqliteCacheStore'

## Fix

Add the runtime named re-export in `lib/index.js` (`export { SqliteCacheStore } from './sqlite-cache-store.js'`), matching the existing `export { parseHeaders } from './utils.js'` style. The `cache.SqliteCacheStore` property is kept for backward compatibility. `lib/index.d.ts` already declares both the named export and the `cache` property, so no type changes are needed.

## Tests

- New `test/review-bugfixes-4-exports.js` asserts `typeof SqliteCacheStore === 'function'` and `SqliteCacheStore === cache.SqliteCacheStore`.
- Verified the test fails without the fix (ESM linking error) and passes with it.
- `eslint` and `prettier --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)