### PR TITLE
fix(sqlite-cache-store): drop stale schema-version tables on startup

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -131,11 +131,18 @@ export class SqliteCacheStore {
     // reuse, so no VACUUM is needed. SQLite drops the table's indexes and its
     // sqlite_sequence row along with it.
     try {
+      // LIKE is only a coarse pre-filter; the regexp restricts matches to
+      // digit-only version suffixes so user tables sharing the prefix (e.g.
+      // "cacheInterceptorVBackup") in a shared database file are never dropped.
       const staleTables = this.#db
         .prepare(
-          `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%' AND name <> 'cacheInterceptorV${VERSION}'`,
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
         )
         .all()
+        .filter(
+          ({ name }) =>
+            /^cacheInterceptorV\d+$/.test(name) && name !== `cacheInterceptorV${VERSION}`,
+        )
       if (staleTables.length > 0) {
         this.#db.exec('BEGIN')
         try {

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -122,6 +122,43 @@ export class SqliteCacheStore {
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
     `)
 
+    // Drop tables left behind by previous schema versions. gc(), clear() and
+    // the SQLITE_FULL eviction only ever touch the current version's table, so
+    // after a VERSION bump the old table's pages would otherwise stay allocated
+    // to its b-tree forever while max_page_count caps the whole file — new
+    // inserts hit SQLITE_FULL almost immediately and eviction frees nothing.
+    // Dropping returns the pages to SQLite's freelist, which subsequent inserts
+    // reuse, so no VACUUM is needed. SQLite drops the table's indexes and its
+    // sqlite_sequence row along with it.
+    try {
+      const staleTables = this.#db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%' AND name <> 'cacheInterceptorV${VERSION}'`,
+        )
+        .all()
+      if (staleTables.length > 0) {
+        this.#db.exec('BEGIN')
+        try {
+          for (const { name } of staleTables) {
+            // name comes from sqlite_master; quote it defensively anyway.
+            this.#db.exec(`DROP TABLE IF EXISTS "${String(name).replaceAll('"', '""')}"`)
+          }
+          this.#db.exec('COMMIT')
+        } catch (err) {
+          try {
+            this.#db.exec('ROLLBACK')
+          } catch {
+            // already rolled back automatically
+          }
+          throw err
+        }
+      }
+    } catch (err) {
+      // A failed cleanup must not brick construction — the current version's
+      // table still works, the stale one just keeps occupying pages.
+      process.emitWarning(err)
+    }
+
     this.#getValuesQuery = this.#db.prepare(`
       SELECT
         id,

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -1,0 +1,130 @@
+/* eslint-disable */
+// Regression tests: stale cacheInterceptorV{N} tables from older schema
+// versions must be dropped on startup. gc()/clear()/eviction only touch the
+// current version's table, so without the cleanup a VERSION bump on a
+// max_page_count-capped file leaves the old table's pages allocated forever
+// and new inserts starve with SQLITE_FULL.
+import { test } from 'tap'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
+
+function makeKey(overrides = {}) {
+  return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
+}
+
+function makeValue(overrides = {}) {
+  const now = Date.now()
+  return {
+    body: Buffer.from('hello'),
+    start: 0,
+    end: 5,
+    statusCode: 200,
+    statusMessage: 'OK',
+    cachedAt: now,
+    deleteAt: now + 7200e3,
+    ...overrides,
+  }
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+function tmpDb(t, prefix) {
+  const dbPath = path.join(
+    os.tmpdir(),
+    `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
+  )
+  t.teardown(() => {
+    for (const ext of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(dbPath + ext)
+      } catch {}
+    }
+  })
+  return dbPath
+}
+
+test('old-version cacheInterceptorV{N} tables are dropped on startup', async (t) => {
+  const dbPath = tmpDb(t, 'stale-tables')
+
+  // Seed the file with tables from two older schema versions, each with rows
+  // and an index — as left behind by a real VERSION bump.
+  const seed = new DatabaseSync(dbPath)
+  seed.exec(`
+    CREATE TABLE cacheInterceptorV8 (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url TEXT NOT NULL,
+      body BLOB NULL
+    );
+    CREATE INDEX idx_cacheInterceptorV8_url ON cacheInterceptorV8(url);
+    INSERT INTO cacheInterceptorV8 (url, body) VALUES ('https://old.example.com/a', x'deadbeef');
+    CREATE TABLE cacheInterceptorV9 (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url TEXT NOT NULL,
+      body BLOB NULL
+    );
+    CREATE INDEX idx_cacheInterceptorV9_url ON cacheInterceptorV9(url);
+    INSERT INTO cacheInterceptorV9 (url, body) VALUES ('https://old.example.com/b', x'deadbeef');
+  `)
+  seed.close()
+
+  const store = new SqliteCacheStore({ location: dbPath })
+
+  // The current version's table must be fully functional.
+  store.set(makeKey({ path: '/fresh' }), makeValue({ body: Buffer.from('fresh'), end: 5 }))
+  await flush()
+  const result = store.get(makeKey({ path: '/fresh' }))
+  t.ok(result, 'current table works after cleanup')
+  t.equal(result.body.toString(), 'fresh')
+  store.close()
+
+  const check = new DatabaseSync(dbPath, { readOnly: true })
+  t.teardown(() => check.close())
+  const tables = check
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+    .all()
+    .map((row) => row.name)
+  t.notOk(tables.includes('cacheInterceptorV8'), 'V8 table dropped')
+  t.notOk(tables.includes('cacheInterceptorV9'), 'V9 table dropped')
+  t.ok(
+    tables.some((name) => /^cacheInterceptorV\d+$/.test(name)),
+    'current version table exists',
+  )
+  const staleIndexes = check
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'index' AND (name LIKE 'idx_cacheInterceptorV8%' OR name LIKE 'idx_cacheInterceptorV9%')`,
+    )
+    .all()
+  t.equal(staleIndexes.length, 0, 'stale indexes dropped along with their tables')
+  t.end()
+})
+
+test('unrelated user tables in the same file are not dropped', async (t) => {
+  const dbPath = tmpDb(t, 'stale-tables-user')
+
+  const seed = new DatabaseSync(dbPath)
+  seed.exec(`
+    CREATE TABLE cacheInterceptorV9 (id INTEGER PRIMARY KEY, url TEXT);
+    INSERT INTO cacheInterceptorV9 (url) VALUES ('https://old.example.com/');
+    CREATE TABLE userData (k TEXT PRIMARY KEY, v TEXT);
+    INSERT INTO userData (k, v) VALUES ('keep', 'me');
+  `)
+  seed.close()
+
+  const store = new SqliteCacheStore({ location: dbPath })
+  store.close()
+
+  const check = new DatabaseSync(dbPath, { readOnly: true })
+  t.teardown(() => check.close())
+  const tables = check
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+    .all()
+    .map((row) => row.name)
+  t.notOk(tables.includes('cacheInterceptorV9'), 'stale cache table dropped')
+  t.ok(tables.includes('userData'), 'user table preserved')
+  const row = check.prepare('SELECT v FROM userData WHERE k = ?').get('keep')
+  t.equal(row.v, 'me', 'user table rows intact')
+  t.end()
+})

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -49,24 +49,28 @@ function tmpDb(t, prefix) {
 test('old-version cacheInterceptorV{N} tables are dropped on startup', async (t) => {
   const dbPath = tmpDb(t, 'stale-tables')
 
-  // Seed the file with tables from two older schema versions, each with rows
-  // and an index — as left behind by a real VERSION bump.
+  // Seed the file with tables from two other schema versions, each with rows
+  // and an index — as left behind by a real VERSION bump. Version numbers are
+  // huge so they can never collide with the store's current VERSION, plus a
+  // non-digit-suffix table that only shares the prefix and must survive.
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
-    CREATE TABLE cacheInterceptorV8 (
+    CREATE TABLE cacheInterceptorV99998 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       url TEXT NOT NULL,
       body BLOB NULL
     );
-    CREATE INDEX idx_cacheInterceptorV8_url ON cacheInterceptorV8(url);
-    INSERT INTO cacheInterceptorV8 (url, body) VALUES ('https://old.example.com/a', x'deadbeef');
-    CREATE TABLE cacheInterceptorV9 (
+    CREATE INDEX idx_cacheInterceptorV99998_url ON cacheInterceptorV99998(url);
+    INSERT INTO cacheInterceptorV99998 (url, body) VALUES ('https://old.example.com/a', x'deadbeef');
+    CREATE TABLE cacheInterceptorV99999 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       url TEXT NOT NULL,
       body BLOB NULL
     );
-    CREATE INDEX idx_cacheInterceptorV9_url ON cacheInterceptorV9(url);
-    INSERT INTO cacheInterceptorV9 (url, body) VALUES ('https://old.example.com/b', x'deadbeef');
+    CREATE INDEX idx_cacheInterceptorV99999_url ON cacheInterceptorV99999(url);
+    INSERT INTO cacheInterceptorV99999 (url, body) VALUES ('https://old.example.com/b', x'deadbeef');
+    CREATE TABLE cacheInterceptorVBackup (k TEXT PRIMARY KEY, v TEXT);
+    INSERT INTO cacheInterceptorVBackup (k, v) VALUES ('keep', 'me');
   `)
   seed.close()
 
@@ -86,15 +90,21 @@ test('old-version cacheInterceptorV{N} tables are dropped on startup', async (t)
     .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
     .all()
     .map((row) => row.name)
-  t.notOk(tables.includes('cacheInterceptorV8'), 'V8 table dropped')
-  t.notOk(tables.includes('cacheInterceptorV9'), 'V9 table dropped')
+  t.notOk(tables.includes('cacheInterceptorV99998'), 'V99998 table dropped')
+  t.notOk(tables.includes('cacheInterceptorV99999'), 'V99999 table dropped')
+  t.ok(tables.includes('cacheInterceptorVBackup'), 'non-digit-suffix table preserved')
+  t.equal(
+    check.prepare('SELECT v FROM cacheInterceptorVBackup WHERE k = ?').get('keep').v,
+    'me',
+    'non-digit-suffix table rows intact',
+  )
   t.ok(
     tables.some((name) => /^cacheInterceptorV\d+$/.test(name)),
     'current version table exists',
   )
   const staleIndexes = check
     .prepare(
-      `SELECT name FROM sqlite_master WHERE type = 'index' AND (name LIKE 'idx_cacheInterceptorV8%' OR name LIKE 'idx_cacheInterceptorV9%')`,
+      `SELECT name FROM sqlite_master WHERE type = 'index' AND (name LIKE 'idx_cacheInterceptorV99998%' OR name LIKE 'idx_cacheInterceptorV99999%')`,
     )
     .all()
   t.equal(staleIndexes.length, 0, 'stale indexes dropped along with their tables')
@@ -106,8 +116,8 @@ test('unrelated user tables in the same file are not dropped', async (t) => {
 
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
-    CREATE TABLE cacheInterceptorV9 (id INTEGER PRIMARY KEY, url TEXT);
-    INSERT INTO cacheInterceptorV9 (url) VALUES ('https://old.example.com/');
+    CREATE TABLE cacheInterceptorV99999 (id INTEGER PRIMARY KEY, url TEXT);
+    INSERT INTO cacheInterceptorV99999 (url) VALUES ('https://old.example.com/');
     CREATE TABLE userData (k TEXT PRIMARY KEY, v TEXT);
     INSERT INTO userData (k, v) VALUES ('keep', 'me');
   `)
@@ -122,7 +132,7 @@ test('unrelated user tables in the same file are not dropped', async (t) => {
     .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
     .all()
     .map((row) => row.name)
-  t.notOk(tables.includes('cacheInterceptorV9'), 'stale cache table dropped')
+  t.notOk(tables.includes('cacheInterceptorV99999'), 'stale cache table dropped')
   t.ok(tables.includes('userData'), 'user table preserved')
   const row = check.prepare('SELECT v FROM userData WHERE k = ?').get('keep')
   t.equal(row.v, 'me', 'user table rows intact')


### PR DESCRIPTION
## Problem

The schema is versioned via `VERSION` and the constructor creates `cacheInterceptorV${VERSION}`, but `gc()`, `clear()` and the SQLITE_FULL eviction query are all scoped to the **current** version's table — nothing ever drops older `cacheInterceptorV{N}` tables. Meanwhile `PRAGMA max_page_count = maxSize / 4096` caps the whole file.

Consequence (verified live: after open + `gc()` + `clear()`, an old-version table still exists with all rows intact): after a `VERSION` bump on a full disk-backed cache file, the old table's pages stay allocated to its b-tree forever. New inserts hit `SQLITE_FULL` almost immediately, `#flush` evicts rows from the nearly-empty *new* table (×3 retries), frees nothing, and drops the batch with `process.emitWarning` — the cache is permanently disabled (or thrashes) until someone deletes the file by hand.

## Fix

On startup, after opening the DB, query `sqlite_master` for tables matching `cacheInterceptorV%` whose name is not the current `cacheInterceptorV${VERSION}` and `DROP TABLE` each inside a single transaction. SQLite drops the table's indexes and its `sqlite_sequence` row along with it. A failed cleanup emits a warning (matching the file's existing error-handling style) and does not prevent construction — the current version's table still works.

## Why no VACUUM

`DROP TABLE` returns the table's pages to SQLite's freelist, and inserts constrained by `max_page_count` reuse freelist pages before growing the file — so the space is immediately available to the new table without rewriting the database. A VACUUM would only shrink the file on disk, which is unnecessary here.

## Tests

New `test/review-bugfixes-4-sqlite-stale-tables.js`:
- Seeds a DB file with fake `cacheInterceptorV8`/`cacheInterceptorV9` tables (rows + indexes) via raw `node:sqlite`, opens `SqliteCacheStore` on it → stale tables and their indexes are gone from `sqlite_master`, the current table exists and a set/get round-trip works.
- An unrelated user table (with rows) in the same file is not dropped.
- Both fail without the fix (4 assertion failures) and pass with it.
- Full suite: `npx tap test/review-bugfixes-4-sqlite-stale-tables.js test/sqlite-cache-store.js test/review-bugfixes-store.js` → 175/175 pass. eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)