### PR TITLE
fix(request-body-factory): support TypedArray/DataView factory results

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -19,6 +19,18 @@ class FactoryStream extends Readable {
       (body) => {
         this.#ac = null
         try {
+          // Normalize binary bodies to Buffer (zero-copy: reinterpret the same
+          // memory). Without this a TypedArray/DataView falls through to
+          // Readable.from(), which iterates e.g. a Uint8Array element-wise and
+          // push(number) then throws an uncaught ERR_INVALID_ARG_TYPE inside
+          // the 'data' emit. Mirrors utils.js isBuffer() treating Uint8Array
+          // as a buffer, extended to all ArrayBuffer views.
+          if (ArrayBuffer.isView(body) && !Buffer.isBuffer(body)) {
+            body = Buffer.from(body.buffer, body.byteOffset, body.byteLength)
+          } else if (body instanceof ArrayBuffer) {
+            body = Buffer.from(body)
+          }
+
           if (typeof body === 'string' || body instanceof Buffer) {
             this.push(body)
             this.push(null)

--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -31,7 +31,7 @@ class FactoryStream extends Readable {
             body = Buffer.from(body)
           }
 
-          if (typeof body === 'string' || body instanceof Buffer) {
+          if (typeof body === 'string' || Buffer.isBuffer(body)) {
             this.push(body)
             this.push(null)
           } else if (isStream(body)) {

--- a/test/review-bugfixes-4-body-factory-typedarray.js
+++ b/test/review-bugfixes-4-body-factory-typedarray.js
@@ -1,0 +1,147 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { request } from '../lib/index.js'
+
+test('body factory with Uint8Array', (t) => {
+  t.plan(1)
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      res.end(Buffer.concat(chunks))
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+      method: 'POST',
+      body: () => new Uint8Array([1, 2, 3]),
+    })
+    const chunks = []
+    for await (const chunk of body) {
+      chunks.push(chunk)
+    }
+    t.strictSame(Buffer.concat(chunks), Buffer.from([1, 2, 3]))
+  })
+})
+
+test('body factory with DataView', (t) => {
+  t.plan(1)
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      res.end(Buffer.concat(chunks))
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+      method: 'POST',
+      body: () => {
+        const view = new DataView(new ArrayBuffer(4))
+        view.setUint8(0, 0xde)
+        view.setUint8(1, 0xad)
+        view.setUint8(2, 0xbe)
+        view.setUint8(3, 0xef)
+        return view
+      },
+    })
+    const chunks = []
+    for await (const chunk of body) {
+      chunks.push(chunk)
+    }
+    t.strictSame(Buffer.concat(chunks), Buffer.from([0xde, 0xad, 0xbe, 0xef]))
+  })
+})
+
+test('body factory with async Uint8Array', (t) => {
+  t.plan(1)
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      res.end(Buffer.concat(chunks))
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+      method: 'POST',
+      body: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return new Uint8Array([4, 5, 6])
+      },
+    })
+    const chunks = []
+    for await (const chunk of body) {
+      chunks.push(chunk)
+    }
+    t.strictSame(Buffer.concat(chunks), Buffer.from([4, 5, 6]))
+  })
+})
+
+test('body factory with TypedArray view over larger buffer', (t) => {
+  t.plan(1)
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      res.end(Buffer.concat(chunks))
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+      method: 'POST',
+      body: () => {
+        // Subarray with non-zero byteOffset must send only its own bytes.
+        const full = new Uint8Array([9, 9, 1, 2, 3, 9, 9])
+        return full.subarray(2, 5)
+      },
+    })
+    const chunks = []
+    for await (const chunk of body) {
+      chunks.push(chunk)
+    }
+    t.strictSame(Buffer.concat(chunks), Buffer.from([1, 2, 3]))
+  })
+})
+
+test('body factory with ArrayBuffer', (t) => {
+  t.plan(1)
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      res.end(Buffer.concat(chunks))
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+      method: 'POST',
+      body: () => Uint8Array.from([7, 8]).buffer,
+    })
+    const chunks = []
+    for await (const chunk of body) {
+      chunks.push(chunk)
+    }
+    t.strictSame(Buffer.concat(chunks), Buffer.from([7, 8]))
+  })
+})


### PR DESCRIPTION
## Problem

A `body` factory returning a non-Buffer `TypedArray` (e.g. `Uint8Array`) or a `DataView` **crashes the process** with an uncaught `ERR_INVALID_ARG_TYPE` on first dispatch — not a failed request.

In `FactoryStream._construct`, only `typeof body === 'string'` and `body instanceof Buffer` take the direct-push path. Any other ArrayBuffer view falls through to `Readable.from(body)`, which iterates a `Uint8Array` **element-wise** (yielding numbers). The `'data'` handler then calls `this.push(number)`, which throws synchronously inside the emit path where no try/catch applies.

Realistic trigger:

```js
await request(url, {
  method: 'POST',
  body: async () => new Uint8Array(await crypto.subtle.digest('SHA-256', data)),
})
```

This was also inconsistent with the library's own `isBuffer()` in `lib/utils.js`, which already classifies `Uint8Array` as a buffer (e.g. for `bodyLength`).

## Fix

Normalize binary bodies before the direct-push branch in `_construct`:

- Any `ArrayBuffer.isView(body)` (TypedArrays, `DataView`) that isn't already a `Buffer` is wrapped zero-copy via `Buffer.from(body.buffer, body.byteOffset, body.byteLength)`.
- A bare `ArrayBuffer` is wrapped zero-copy via `Buffer.from(body)`.

Strings, Buffers, streams, and iterables behave exactly as before. `Blob` factory results remain out of scope for this PR: they were never supported by `FactoryStream` (they fail cleanly in `Readable.from` rather than crashing), and adding Blob support is a feature rather than a crash fix.

## Tests

New `test/review-bugfixes-4-body-factory-typedarray.js`:

- `body: () => new Uint8Array([1, 2, 3])` → server receives exactly those 3 bytes
- `body: () => new DataView(new ArrayBuffer(4))` → server receives the 4 bytes
- async factory returning `Uint8Array` → succeeds
- `Uint8Array#subarray` with non-zero `byteOffset` → only the view's own bytes are sent
- bare `ArrayBuffer` → succeeds

Verified all 5 new tests crash the tap child process (exit 1) with the fix reverted, and pass with it. Existing `test/request-body-factory.js` (8 tests) still passes; eslint and prettier are clean.

## Note

The concurrent PR `fix/body-factory-leak` touches the dispatch wrapper at the bottom of the same file. This change is restricted to the `_construct` body-type handling, so the two merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)