### PR TITLE
fix(request-body-factory): destroy factory stream on pre-write failures

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -1,5 +1,5 @@
 import { Readable, finished } from 'node:stream'
-import { isStream } from '../utils.js'
+import { DecoratorHandler, isStream } from '../utils.js'
 
 function noop() {}
 
@@ -15,9 +15,12 @@ class FactoryStream extends Readable {
 
   _construct(callback) {
     this.#ac = new AbortController()
+    // Note: #ac is intentionally kept after the factory settles, so that a
+    // destroy with an error can still abort the factory's signal (see
+    // _destroy) — e.g. the request failing before undici started writing
+    // the body.
     Promise.resolve(this.#factory({ signal: this.#ac.signal })).then(
       (body) => {
-        this.#ac = null
         try {
           if (typeof body === 'string' || body instanceof Buffer) {
             this.push(body)
@@ -67,7 +70,13 @@ class FactoryStream extends Readable {
 
   _destroy(err, callback) {
     if (this.#ac) {
-      this.#ac.abort(err)
+      // Abort the factory's signal on any error, and on a premature destroy
+      // (destroyed before 'end'), so the factory can cancel whatever it is
+      // producing. A clean destroy after a fully consumed body (autoDestroy
+      // after 'end') must not abort — the factory finished normally.
+      if (err || !this.readableEnded) {
+        this.#ac.abort(err)
+      }
       this.#ac = null
     }
 
@@ -80,7 +89,37 @@ class FactoryStream extends Readable {
   }
 }
 
-export default () => (dispatch) => (opts, handler) =>
-  typeof opts.body !== 'function'
-    ? dispatch(opts, handler)
-    : dispatch({ ...opts, body: new FactoryStream(opts.body).on('error', noop) }, handler)
+class Handler extends DecoratorHandler {
+  #body
+
+  constructor(handler, body) {
+    super(handler)
+    this.#body = body
+  }
+
+  onError(err) {
+    // Undici only destroys a request body once it has started writing it. If
+    // the dispatch fails before that (connect error/timeout, DNS failure,
+    // abort while queued, sync throw from an inner interceptor), nobody else
+    // owns the FactoryStream — but the factory has already run on nextTick
+    // (side effects, e.g. an open fd from fs.createReadStream), so destroy it
+    // here. destroy() is idempotent: if undici already consumed or destroyed
+    // the stream this is a no-op.
+    this.#body.destroy(err)
+    super.onError(err)
+  }
+}
+
+export default () => (dispatch) => (opts, handler) => {
+  if (typeof opts.body !== 'function') {
+    return dispatch(opts, handler)
+  }
+
+  const body = new FactoryStream(opts.body).on('error', noop)
+  try {
+    return dispatch({ ...opts, body }, new Handler(handler, body))
+  } catch (err) {
+    body.destroy(err)
+    throw err
+  }
+}

--- a/test/review-bugfixes-4-body-factory-leak.js
+++ b/test/review-bugfixes-4-body-factory-leak.js
@@ -1,0 +1,133 @@
+/* eslint-disable */
+import { test } from 'tap'
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { request } from '../lib/index.js'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('pre-connect failure destroys factory stream and aborts factory signal', async (t) => {
+  const inner = new PassThrough()
+  let signal = null
+  let factoryCalls = 0
+
+  try {
+    await request('http://127.0.0.1:1', {
+      method: 'POST',
+      retry: false,
+      body: (opts) => {
+        factoryCalls++
+        signal = opts.signal
+        return inner
+      },
+    })
+    t.fail('should have thrown')
+  } catch (err) {
+    t.ok(err, 'request rejected')
+  }
+
+  // Destroy propagation can finish on a later tick.
+  await tick()
+
+  t.equal(factoryCalls, 1, 'factory called once')
+  t.equal(inner.destroyed, true, 'inner stream destroyed')
+  t.equal(signal.aborted, true, 'factory signal aborted')
+})
+
+test('every retry attempt destroys its factory stream', async (t) => {
+  const streams = []
+  const signals = []
+
+  try {
+    await request('http://127.0.0.1:1', {
+      // PUT so response-retry retries connection errors (POST is not
+      // idempotent by default).
+      method: 'PUT',
+      retry: 2,
+      body: ({ signal }) => {
+        const inner = new PassThrough()
+        streams.push(inner)
+        signals.push(signal)
+        return inner
+      },
+    })
+    t.fail('should have thrown')
+  } catch (err) {
+    t.ok(err, 'request rejected')
+  }
+
+  await tick()
+
+  t.equal(streams.length, 3, 'factory called once per attempt (1 initial + 2 retries)')
+  t.ok(
+    streams.every((stream) => stream.destroyed),
+    'every attempt stream destroyed',
+  )
+  t.ok(
+    signals.every((signal) => signal.aborted),
+    'every attempt signal aborted',
+  )
+})
+
+test('sync throw from inner dispatch destroys the factory stream', async (t) => {
+  const boom = new Error('sync dispatch boom')
+  const dispatch = requestBodyFactory()(() => {
+    throw boom
+  })
+
+  const inner = new PassThrough()
+  let signal = null
+
+  t.throws(
+    () =>
+      dispatch(
+        {
+          method: 'POST',
+          body: (opts) => {
+            signal = opts.signal
+            return inner
+          },
+        },
+        { onError() {} },
+      ),
+    boom,
+    'error propagates unchanged',
+  )
+
+  // The factory runs on nextTick after construction; destroy is deferred
+  // until _construct settles.
+  await tick()
+  await tick()
+
+  t.equal(inner.destroyed, true, 'inner stream destroyed')
+  t.equal(signal.aborted, true, 'factory signal aborted')
+})
+
+test('signal not aborted on a fully consumed body (happy path)', async (t) => {
+  const { createServer } = await import('node:http')
+
+  const server = createServer((req, res) => {
+    req.on('data', () => {})
+    req.on('end', () => {
+      res.end('ok')
+    })
+  })
+  t.teardown(server.close.bind(server))
+
+  await new Promise((resolve) => server.listen(0, resolve))
+
+  let signal = null
+  const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
+    method: 'POST',
+    body: (opts) => {
+      signal = opts.signal
+      return 'hello'
+    },
+  })
+  for await (const _ of body) {
+    // drain
+  }
+
+  await tick()
+
+  t.equal(signal.aborted, false, 'signal untouched after normal completion')
+})


### PR DESCRIPTION
## Problem

The `request-body-factory` interceptor swaps `opts.body` (a factory function) for a `FactoryStream`, but wraps no handler — so it has no cleanup path. Node invokes `_construct` (and therefore the user's factory) on `process.nextTick` after construction, whether or not anything ever reads the stream.

Undici only destroys a request body once it has started writing it, and the API layer's `RequestHandler.onError` destroys the ORIGINAL `opts.body` — the factory *function*, not the swapped-in `FactoryStream`.

## Failure scenario

Any failure before the body is written — `ECONNREFUSED`, connect timeout, DNS failure, sync throw from an inner interceptor, abort while queued — orphans a live `FactoryStream`:

- the factory has already run (side effects, e.g. an open fd from `fs.createReadStream`),
- the inner body stream is never destroyed, and
- the `{ signal }` handed to the factory never aborts.

Since `response-retry` sits outside this interceptor in the compose chain, every retry attempt re-enters it and creates a fresh `FactoryStream`. With the default `retry: 8`, that is up to **~9 leaked streams/fds per logical request** against a down origin.

Repro: `request('http://127.0.0.1:1', { method: 'POST', retry: false, body: ({ signal }) => inner })` → `{ factoryCalls: 1, innerDestroyed: false, signalAborted: false }`.

## Fix

- Wrap the downstream handler in a minimal `DecoratorHandler` subclass whose `onError` destroys the `FactoryStream` with the error. `destroy()` is idempotent — if undici already owns or destroyed the stream it is a no-op.
- Guard the `dispatch(...)` call itself: a sync throw from an inner interceptor destroys the just-created stream before rethrowing.
- Keep the factory's `AbortController` after the factory settles (it was previously nulled on resolve), so an error destroy still aborts the factory's `{ signal }`. A clean destroy after a fully consumed body (autoDestroy after `'end'`) does not abort — normal completion is unchanged.

`onComplete` intentionally does not destroy: normal completion means undici consumed/ended the body, and destroying on early-complete would change behavior for half-consumed bodies.

## Tests

New `test/review-bugfixes-4-body-factory-leak.js`:

1. Pre-connect failure (refused port, `retry: false`) → inner stream destroyed, factory signal aborted.
2. Retries enabled (`PUT`, `retry: 2`) → factory called once per attempt (3×), every attempt's stream destroyed and signal aborted.
3. Sync throw from inner dispatch → stream destroyed, signal aborted, error propagates unchanged.
4. Happy path → signal NOT aborted after a fully consumed body.

All new tests fail on `main` (6 failing assertions) and pass with the fix. Full suite: 923 total, 919 pass, 4 skips (empty test files), 0 failures. `eslint` and `prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)