### PR TITLE
fix(retry): deliver abort reason and cancel backoff timer when aborted between attempts

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import tp from 'node:timers/promises'
 import { DecoratorHandler, isDisturbed, decorateError, parseContentRange } from '../utils.js'
+import { RequestAbortedError } from '../errors.js'
 
 function noop() {}
 
@@ -23,6 +24,7 @@ class Handler extends DecoratorHandler {
   #aborted = false
   #reason
   #resume
+  #retryAbortController = null
 
   #pos
   #end
@@ -60,11 +62,17 @@ class Handler extends DecoratorHandler {
       super.onConnect((reason) => {
         if (!this.#aborted) {
           this.#aborted = true
-          if (this.#abort) {
-            this.#abort(reason)
-          } else {
-            this.#reason = reason
-          }
+          // Always remember the reason: a downstream abort can land during the
+          // backoff wait between attempts, when #abort still points at the
+          // finished attempt's abort which undici has made a no-op. Without
+          // the recorded reason there is nothing to deliver once the retry
+          // machinery observes #aborted. Mirrors redirect.js.
+          this.#reason = reason
+          this.#abort?.(reason)
+          // Wake a pending backoff wait so the terminal onError is delivered
+          // promptly and the ref'd retry timer (up to 60s for retry-after)
+          // does not hold the event loop.
+          this.#retryAbortController?.abort(reason)
         }
       })
     }
@@ -229,6 +237,18 @@ class Handler extends DecoratorHandler {
   }
 
   #maybeError(err) {
+    if (!err && this.#aborted) {
+      // Downstream aborted (e.g. during the backoff wait between attempts).
+      // The replay branches below are suppressed by the aborted
+      // DecoratorHandler, so without this no terminal event would ever reach
+      // downstream (raw dispatch would hang forever), or a generic
+      // 'Response retry failed' would replace the abort reason.
+      // DecoratorHandler.onError still forwards after an abort, so deliver
+      // the abort reason as the terminal onError (exactly once, guarded by
+      // #errorSent below).
+      err = this.#reason ?? new RequestAbortedError()
+    }
+
     if (err) {
       if (!this.#errorSent) {
         this.#errorSent = true
@@ -321,11 +341,36 @@ class Handler extends DecoratorHandler {
         }
       })
       .catch((err) => {
-        this.#maybeError(err)
+        // When the downstream abort cancelled the backoff timer, the timer's
+        // own AbortError rejection is just plumbing — deliver the recorded
+        // abort reason instead (falsy reasons are normalized in #maybeError).
+        this.#maybeError(this.#aborted ? this.#reason : err)
       })
   }
 
+  // Backoff wait that is abortable by the handler-chain abort (via the
+  // internal AbortController the onConnect wrapper aborts), not just by
+  // opts.signal — otherwise a downstream abort during the wait leaves a ref'd
+  // timer holding the event loop for up to 60s. opts.signal is chained only
+  // when it is a real AbortSignal; the library also accepts EventEmitter-style
+  // signals elsewhere and tp.setTimeout would throw on those.
+  #backoff(delay, opts) {
+    this.#retryAbortController ??= new AbortController()
+    const signal =
+      opts?.signal instanceof AbortSignal
+        ? AbortSignal.any([this.#retryAbortController.signal, opts.signal])
+        : this.#retryAbortController.signal
+    return tp.setTimeout(delay, true, { signal })
+  }
+
   async #retryFn(err, retryCount, opts) {
+    if (this.#aborted) {
+      // A user retry callback may invoke this after downstream has already
+      // aborted — don't start a backoff timer that nothing will cancel.
+      // #maybeRetry's promise chain observes #aborted and delivers #reason.
+      return false
+    }
+
     let retryOpts = opts?.retry
 
     if (!retryOpts) {
@@ -362,7 +407,7 @@ class Handler extends DecoratorHandler {
             Math.min(retryAfter, 60e3)
           : Math.min(10e3, retryCount * 1e3)
       this.#opts.logger?.debug({ statusCode, retryAfter, delay, retryCount }, 'retry delay')
-      return tp.setTimeout(delay, true, { signal: opts?.signal ?? undefined })
+      return this.#backoff(delay, opts)
     }
 
     if (
@@ -383,16 +428,12 @@ class Handler extends DecoratorHandler {
       ].includes(err.code)
     ) {
       this.#opts.logger?.debug({ err, retryCount }, 'retry delay')
-      return tp.setTimeout(Math.min(10e3, retryCount * 1e3), true, {
-        signal: opts?.signal ?? undefined,
-      })
+      return this.#backoff(Math.min(10e3, retryCount * 1e3), opts)
     }
 
     if (err?.message && ['other side closed'].includes(err.message)) {
       this.#opts.logger?.debug({ err, retryCount }, 'retry delay')
-      return tp.setTimeout(Math.min(10e3, retryCount * 1e3), true, {
-        signal: opts?.signal ?? undefined,
-      })
+      return this.#backoff(Math.min(10e3, retryCount * 1e3), opts)
     }
 
     return false

--- a/test/review-bugfixes-4-retry-abort-backoff.js
+++ b/test/review-bugfixes-4-retry-abort-backoff.js
@@ -1,0 +1,195 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import tp from 'node:timers/promises'
+import undici from '@nxtedition/undici'
+import { compose, interceptors, request } from '../lib/index.js'
+
+// Regression tests: a downstream abort that lands DURING the retry backoff
+// wait (after an attempt finished, before the next one is dispatched) must:
+//   - deliver exactly one terminal onError with the abort reason, promptly
+//     (previously raw dispatch never received a terminal event at all), and
+//   - cancel the pending backoff timer (previously a ref'd timer held the
+//     event loop for up to 60s of retry-after).
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function start503Server() {
+  return startServer((req, res) => {
+    res.statusCode = 503
+    res.setHeader('retry-after', '30')
+    res.end('unavailable')
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Raw dispatch: abort during backoff → prompt terminal onError(reason)
+// ---------------------------------------------------------------------------
+
+test('retry: abort during backoff delivers onError with the reason (raw dispatch)', async (t) => {
+  t.plan(4)
+
+  const server = await start503Server()
+  t.teardown(server.close.bind(server))
+
+  const firstAttempt = once(server, 'request')
+  const dispatch = compose(undici.getGlobalDispatcher(), interceptors.responseRetry())
+
+  const reason = new Error('user aborted during backoff')
+  let abort = null
+  let errorCount = 0
+
+  const onError = new Promise((resolve) => {
+    dispatch(
+      {
+        origin: `http://127.0.0.1:${server.address().port}`,
+        path: '/',
+        method: 'GET',
+        retry: true,
+      },
+      {
+        onConnect(a) {
+          abort ??= a
+        },
+        onHeaders() {
+          return true
+        },
+        onData() {
+          return true
+        },
+        onComplete() {
+          t.fail('should not complete')
+        },
+        onError(err) {
+          errorCount++
+          resolve(err)
+        },
+      },
+    )
+  })
+
+  // Let the first (503) attempt finish so the 30s retry-after backoff starts.
+  await firstAttempt
+  await tp.setTimeout(200)
+
+  t.ok(abort, 'abort captured from onConnect')
+
+  const abortedAt = Date.now()
+  abort(reason)
+
+  const err = await Promise.race([onError, tp.setTimeout(2000, null)])
+
+  t.equal(err, reason, 'onError receives the abort reason')
+  t.ok(Date.now() - abortedAt < 1500, 'terminal error is prompt, not after the 30s backoff')
+
+  // Give any duplicate terminal event a chance to fire.
+  await tp.setTimeout(100)
+  t.equal(errorCount, 1, 'exactly one onError')
+})
+
+// ---------------------------------------------------------------------------
+// Raw dispatch: abort with no reason → RequestAbortedError fallback
+// ---------------------------------------------------------------------------
+
+test('retry: reasonless abort during backoff falls back to RequestAbortedError', async (t) => {
+  t.plan(3)
+
+  const server = await start503Server()
+  t.teardown(server.close.bind(server))
+
+  const firstAttempt = once(server, 'request')
+  const dispatch = compose(undici.getGlobalDispatcher(), interceptors.responseRetry())
+
+  let abort = null
+
+  const onError = new Promise((resolve) => {
+    dispatch(
+      {
+        origin: `http://127.0.0.1:${server.address().port}`,
+        path: '/',
+        method: 'GET',
+        retry: true,
+      },
+      {
+        onConnect(a) {
+          abort ??= a
+        },
+        onHeaders() {
+          return true
+        },
+        onData() {
+          return true
+        },
+        onComplete() {
+          t.fail('should not complete')
+        },
+        onError(err) {
+          resolve(err)
+        },
+      },
+    )
+  })
+
+  await firstAttempt
+  await tp.setTimeout(200)
+
+  const abortedAt = Date.now()
+  abort()
+
+  const err = await Promise.race([onError, tp.setTimeout(2000, null)])
+
+  t.ok(err, 'terminal onError delivered')
+  t.equal(err?.code, 'UND_ERR_ABORTED', 'fallback is a RequestAbortedError')
+  t.ok(Date.now() - abortedAt < 1500, 'terminal error is prompt')
+})
+
+// ---------------------------------------------------------------------------
+// request(): AbortController abort during backoff → prompt rejection with the
+// abort reason (previously the timer's own AbortError or, without a real
+// AbortSignal, a 30s stall).
+// ---------------------------------------------------------------------------
+
+test('retry: signal abort during backoff rejects promptly with the abort reason', async (t) => {
+  t.plan(3)
+
+  let attempts = 0
+  const server = await startServer((req, res) => {
+    attempts++
+    res.statusCode = 503
+    res.setHeader('retry-after', '30')
+    res.end('unavailable')
+  })
+  t.teardown(server.close.bind(server))
+
+  const ac = new AbortController()
+  const reason = new Error('user aborted request')
+
+  const firstAttempt = once(server, 'request')
+  const started = Date.now()
+
+  const pending = request(`http://127.0.0.1:${server.address().port}`, {
+    signal: ac.signal,
+    retry: true,
+  })
+  // Swallow late rejections if assertions below fail first.
+  pending.catch(() => {})
+
+  await firstAttempt
+  await tp.setTimeout(200)
+  ac.abort(reason)
+
+  try {
+    await pending
+    t.fail('should have thrown')
+  } catch (err) {
+    t.equal(err, reason, 'rejects with the abort reason, not a generic error')
+  }
+
+  t.ok(Date.now() - started < 5000, 'rejects promptly, not after the 30s retry-after')
+  t.equal(attempts, 1, 'no further attempts after abort')
+})


### PR DESCRIPTION
## Problem

In `lib/interceptor/response-retry.js`, the `onConnect` abort wrapper only recorded the abort reason when `#abort` was unset. After an attempt errors or completes, `#abort` still points at the **dead attempt's** abort function, which undici turns into a no-op once the request is aborted/completed. So a downstream abort arriving **during the backoff wait** between attempts called a no-op and the reason was silently lost.

## Failure scenario

When the backoff timer fired, `#maybeRetry`'s promise chain hit `#maybeError(this.#reason /* undefined */)`:

- **Raw `dispatch()` callers hang forever** (`#headersSent === false`): the falsy-err branch of `#maybeError` replays headers via `super.onHeaders(...)`, which the aborted `DecoratorHandler` suppresses — no terminal `onError` is ever delivered, violating the abort → `onError` contract.
- **Wrong error** (`#headersSent === true`): the caller gets a generic `Error('Response retry failed')` instead of the abort reason. Via `request()` with an `AbortController`, the rejection was the backoff timer's internal `AbortError` plumbing rather than `signal.reason`.
- **Held event loop**: the backoff timer only observed `opts.signal`, so a handler-chain abort left a ref'd timer holding the event loop for up to 60 s (the `retry-after` clamp).

The redirect interceptor received exactly this fix earlier (`lib/interceptor/redirect.js`, "Always remember the latest reason…"); retry was missed.

## Fix

- Always record the abort reason in the `onConnect` wrapper before invoking `#abort` (calling a dead abort is a harmless no-op) — mirrors `redirect.js`.
- Cancel a pending backoff wait via an internal `AbortController` that the `onConnect` wrapper aborts; `opts.signal` is chained onto it with `AbortSignal.any` only when it is a real `AbortSignal` (the library accepts EventEmitter-style signals elsewhere; `tp.setTimeout` would throw on those). `#retryFn` also refuses to start a backoff after an abort, covering user retry callbacks that invoke the default retry late.
- `#maybeError` normalizes the aborted falsy-err path to deliver exactly one terminal `onError` with the recorded abort reason (falling back to `RequestAbortedError`), guarded by `#errorSent`. `DecoratorHandler.onError` still forwards after an abort, so the invariant holds: once downstream aborts during backoff, it receives exactly one prompt `onError(reason)` and the timer is cleared.

## Tests

New `test/review-bugfixes-4-retry-abort-backoff.js` (503 + `retry-after: 30`, abort during backoff):

1. Raw `dispatch()` with a custom handler → `onError` is delivered promptly (< 1.5 s, not after 30 s) with the exact abort reason, exactly once.
2. Raw `dispatch()` with a reasonless `abort()` → prompt `RequestAbortedError` (`UND_ERR_ABORTED`) fallback.
3. `request()` + `AbortController` → promise rejects promptly with `signal.reason`, not `'Response retry failed'` or the timer's own `AbortError`, and no further attempts are dispatched.

With the fix reverted, 7/10 assertions fail (raw dispatch never receives a terminal event; `request()` rejects with the wrong error) and the file takes 33 s (held event loop); with the fix, all pass in ~3.5 s. Full `test/retry.js`, `test/retry-deep.js`, `test/signal-advanced.js` suites pass (107/107). ESLint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)