### PR TITLE
fix(log): deregister handler when an inner interceptor throws at dispatch time

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -161,7 +161,46 @@ class Handler extends DecoratorHandler {
       this[kGlobalIndex] = -1
     }
   }
+
+  // Finalization for a request whose inner dispatch threw synchronously:
+  // undici never took ownership of the handler, so no terminal callback
+  // (onError/onComplete) will ever arrive. Log the failure and deregister
+  // from the in-flight registry. Deliberately does NOT forward onError —
+  // the dispatch entry below rethrows and an outer interceptor (lookup)
+  // delivers the error to the original handler chain, so forwarding here
+  // would double-deliver it.
+  onDispatchError(err) {
+    if (this[kGlobalIndex] === -1) {
+      // A terminal callback already ran before the error escaped dispatch
+      // (e.g. onError was delivered and the error was then rethrown):
+      // already logged and deregistered.
+      return
+    }
+
+    this.#timing.end = performance.now() - this.#created
+
+    this.#logger.error({ err, elapsedTime: this.#timing.end }, 'upstream request failed')
+
+    this.onDone()
+  }
 }
 
-export default (logOpts) => (dispatch) => (opts, handler) =>
-  opts.logger ? dispatch(opts, new Handler(logOpts, opts, { handler })) : dispatch(opts, handler)
+export default (logOpts) => (dispatch) => (opts, handler) => {
+  if (!opts.logger) {
+    return dispatch(opts, handler)
+  }
+
+  const logHandler = new Handler(logOpts, opts, { handler })
+
+  try {
+    return dispatch(opts, logHandler)
+  } catch (err) {
+    // An inner interceptor threw synchronously at dispatch time (e.g. proxy
+    // loop detection). The error escapes past the already-registered handler,
+    // which would otherwise stay in the global in-flight registry forever.
+    // Finalize it and rethrow so outer interceptors observe the same error
+    // as before.
+    logHandler.onDispatchError(err)
+    throw err
+  }
+}

--- a/test/review-bugfixes-4-log-sync-throw.js
+++ b/test/review-bugfixes-4-log-sync-throw.js
@@ -1,0 +1,209 @@
+/* eslint-disable */
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const kGlobalArray = Symbol.for('@nxtedition/nxt-undici#globalArray')
+
+function globalArrayLength() {
+  return globalThis[kGlobalArray]?.length ?? 0
+}
+
+function makeMockLogger() {
+  const calls = { debug: [], warn: [], error: [] }
+  const logger = {
+    calls,
+    debug(...args) {
+      calls.debug.push(args)
+    },
+    warn(...args) {
+      calls.warn.push(args)
+    },
+    error(...args) {
+      calls.error.push(args)
+    },
+    child() {
+      return logger
+    },
+  }
+  return logger
+}
+
+// ---------------------------------------------------------------------------
+// An inner interceptor that throws synchronously at dispatch time must not
+// leave the log handler registered in the global in-flight registry forever.
+// ---------------------------------------------------------------------------
+
+test('log: handler deregisters when an inner interceptor throws at dispatch time', async (t) => {
+  t.plan(8)
+
+  const boom = () => (dispatch) => (opts, handler) => {
+    throw new Error('boom')
+  }
+
+  const logger = makeMockLogger()
+  const dispatch = compose(new undici.Agent(), boom(), interceptors.log())
+
+  const before = globalArrayLength()
+
+  for (let i = 0; i < 3; i++) {
+    t.throws(
+      () =>
+        dispatch(
+          { origin: 'http://127.0.0.1:1', path: '/', method: 'GET', headers: {}, logger },
+          {
+            onConnect() {},
+            onHeaders() {
+              return true
+            },
+            onData() {},
+            onComplete() {},
+            onError() {},
+          },
+        ),
+      /boom/,
+      'sync dispatch throw is rethrown to the caller',
+    )
+  }
+
+  t.equal(globalArrayLength(), before, 'no zombie handlers left in the global registry')
+  t.equal(
+    logger.calls.debug.filter((args) => String(args[args.length - 1]).includes('started')).length,
+    3,
+    'each request logged a start line',
+  )
+  t.equal(
+    logger.calls.error.filter((args) => String(args[args.length - 1]).includes('failed')).length,
+    3,
+    'each start line got a terminal failure counterpart',
+  )
+  t.equal(
+    logger.calls.error.filter((args) => args[0]?.err?.message === 'boom').length,
+    3,
+    'the original error is included in the failure log',
+  )
+  t.ok(
+    logger.calls.error.every((args) => typeof args[0]?.elapsedTime === 'number'),
+    'failure log records elapsed time',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// With the outer lookup interceptor (as in the real pipeline), the request
+// must reject with the original error, delivered exactly once — the log
+// handler must only deregister, not forward a second onError.
+// ---------------------------------------------------------------------------
+
+test('log: sync dispatch throw under lookup rejects once and leaves no zombies', async (t) => {
+  t.plan(4)
+
+  const boom = () => (dispatch) => (opts, handler) => {
+    throw new Error('boom')
+  }
+
+  const logger = makeMockLogger()
+  const dispatch = compose(new undici.Agent(), boom(), interceptors.log(), interceptors.lookup())
+
+  const before = globalArrayLength()
+
+  let onErrorCalls = 0
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://127.0.0.1:1',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        logger,
+        lookup: (origin) => origin,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('unexpected onComplete'))
+        },
+        onError(err) {
+          onErrorCalls++
+          resolve(err)
+        },
+      },
+    )
+  })
+
+  // Give a microtask/turn for any erroneous double delivery to surface.
+  await new Promise((resolve) => setImmediate(resolve))
+
+  t.equal(err.message, 'boom', 'request fails with the original error')
+  t.equal(onErrorCalls, 1, 'onError is delivered exactly once')
+  t.equal(globalArrayLength(), before, 'no zombie handlers left in the global registry')
+  t.ok(
+    logger.calls.error.some((args) => String(args[args.length - 1]).includes('failed')),
+    'failure was logged',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Real-world repro: proxy loop detection throws synchronously at dispatch
+// time (inbound Via already names this proxy) — LoopDetected must propagate
+// and the log handler must not leak.
+// ---------------------------------------------------------------------------
+
+test('log: proxy loop detection at dispatch time does not leak handlers', async (t) => {
+  t.plan(3)
+
+  const logger = makeMockLogger()
+  const dispatch = compose(
+    new undici.Agent(),
+    interceptors.proxy(),
+    interceptors.log(),
+    interceptors.lookup(),
+  )
+
+  const before = globalArrayLength()
+
+  const errors = await Promise.all(
+    Array.from(
+      { length: 3 },
+      () =>
+        new Promise((resolve, reject) => {
+          dispatch(
+            {
+              origin: 'http://127.0.0.1:1',
+              path: '/',
+              method: 'GET',
+              headers: { via: 'HTTP/1.1 myproxy' },
+              proxy: { name: 'myproxy' },
+              logger,
+              lookup: (origin) => origin,
+            },
+            {
+              onConnect() {},
+              onHeaders() {
+                return true
+              },
+              onData() {},
+              onComplete() {
+                reject(new Error('unexpected onComplete'))
+              },
+              onError: resolve,
+            },
+          )
+        }),
+    ),
+  )
+
+  t.ok(
+    errors.every((err) => err.status === 508),
+    'each request rejects with LoopDetected',
+  )
+  t.equal(globalArrayLength(), before, 'no zombie handlers left in the global registry')
+  t.equal(
+    logger.calls.error.filter((args) => String(args[args.length - 1]).includes('failed')).length,
+    3,
+    'each failure was logged',
+  )
+})


### PR DESCRIPTION
## Problem

The log interceptor's `Handler` registers itself in the global in-flight registry (`globalThis[Symbol.for('@nxtedition/nxt-undici#globalArray')]`) in its constructor, but only deregisters in `onDone()`, which is reached via `onComplete`/`onError`/upgrade-socket-close. The dispatch entry had no try/catch around the inner `dispatch(opts, handler)` call.

## Failure scenario

Inner interceptors can throw **synchronously** at dispatch time — e.g. proxy's `reduceHeaders` throws `LoopDetected` (inbound `Via` already naming this proxy), `BadGateway` (duplicate host header, inbound `Forwarded` without socket), or response-retry throws on an invalid `opts.retry` type. The throw escapes past the already-constructed-and-registered log handler; the outer `lookup` interceptor catches it and delivers `onError` to the original handler chain, so the request fails cleanly — but the log `Handler` stays in the global array **forever**, pinning `opts` (headers, body, logger), and the `'upstream request started'` log line never gets a terminal counterpart. Reproduced: 3 requests with `proxy: { name: 'myproxy' }` + inbound `via: 'HTTP/1.1 myproxy'` → 3 zombie handlers in the registry.

## Fix

Wrap the inner `dispatch(...)` call in try/catch. On a synchronous throw, finalize the handler (`onDispatchError`): log `'upstream request failed'` with the error, deregister from the in-flight registry, and **rethrow** so outer interceptors observe exactly the same error as before. `onError` is deliberately **not** forwarded from the catch path — `lookup` already delivers it to the original handler chain, and forwarding would double-deliver. Finalization is idempotent with `onDone` (guarded on the registry index), so a terminal callback that was delivered before the error escaped dispatch is handled correctly.

## Tests

`test/review-bugfixes-4-log-sync-throw.js`:

- Stub inner interceptor throwing synchronously: error is rethrown to the caller, registry length returns to its pre-request value, each start line gets a terminal failure log with the original error.
- Same setup under the outer `lookup` interceptor (real pipeline shape): request rejects with the original error, `onError` delivered exactly once, no zombies.
- Real-world repro via proxy loop detection (`proxy: { name }` + inbound `via` naming it): rejects with 508 `LoopDetected`, no zombies.

All three fail on `main` (zombie handlers detected) and pass with the fix. Existing `test/log-advanced.js`, `proxy-advanced.js`, `lookup-advanced.js`, `compose.js`, `request.js` pass (94/94). eslint + prettier clean.

## Note

A concurrent PR (`fix/log-redact-secrets`) also modifies `lib/interceptor/log.js` (constructor bindings/sanitization). This diff is deliberately restricted to the dispatch entry + a new finalization method after `onDone()`, so the two merge with minimal conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)