### PR TITLE
fix(redirect): normalize origins before same-origin comparison (over-stripping auth headers)

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -118,7 +118,7 @@ class Handler extends DecoratorHandler {
       headers: cleanRequestHeaders(
         this.#opts.headers,
         statusCode === 303,
-        this.#opts.origin !== origin,
+        !isSameOrigin(this.#opts.origin, origin),
       ),
       path,
       origin,
@@ -188,6 +188,27 @@ class Handler extends DecoratorHandler {
 
   onError(error) {
     super.onError(error)
+  }
+}
+
+// `target` is always a WHATWG-normalized origin (it comes off a parsed URL:
+// lowercased host, default port elided, no path), while `optsOrigin` is
+// caller-provided and may not be (trailing slash, explicit `:80`/`:443`,
+// uppercase host — defaultLookup in index.js even produces `http://host:80`
+// for object-form origins). A raw string compare misclassifies such
+// same-origin redirects as cross-origin and strips authorization/cookie,
+// breaking authenticated redirect flows with a confusing 401. Normalize
+// through `new URL` before comparing; if optsOrigin is not parseable, keep
+// the raw-compare result (already false here), which fails toward stripping —
+// the safe direction.
+function isSameOrigin(optsOrigin, target) {
+  if (optsOrigin === target) {
+    return true
+  }
+  try {
+    return new URL(optsOrigin).origin === target
+  } catch {
+    return false
   }
 }
 

--- a/test/review-bugfixes-4-redirect-origin-compare.js
+++ b/test/review-bugfixes-4-redirect-origin-compare.js
@@ -1,0 +1,163 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { compose, interceptors } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+// ---------------------------------------------------------------------------
+// Regression: redirect.js compared the caller-configured `opts.origin` against
+// the WHATWG-normalized origin of the parsed Location URL with a RAW string
+// comparison. A trailing slash (`http://host:port/`), an explicit default port
+// (`http://host:80`) or an uppercase host made a SAME-origin redirect look
+// cross-origin, so authorization/cookie were stripped and authenticated
+// redirect flows broke with a 401. Both sides must be normalized before
+// comparing.
+// ---------------------------------------------------------------------------
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData() {},
+      onComplete() {
+        resolve(statusCode)
+      },
+      onError: reject,
+    })
+  })
+}
+
+test('redirect: trailing-slash origin keeps same-origin auth headers', async (t) => {
+  t.plan(3)
+  let authOnRedirect = null
+  let cookieOnRedirect = null
+  let hop = 0
+  const server = await startServer((req, res) => {
+    hop++
+    if (hop === 1) {
+      res.writeHead(301, { location: '/dest' })
+      res.end()
+    } else {
+      authOnRedirect = req.headers.authorization
+      cookieOnRedirect = req.headers.cookie
+      res.writeHead(200)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    // NOTE: trailing slash — normalizes to the same origin as the Location URL.
+    origin: `http://127.0.0.1:${server.address().port}/`,
+    path: '/start',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret', cookie: 'session=abc' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+  t.equal(authOnRedirect, 'Bearer secret', 'authorization preserved for same-origin redirect')
+  t.equal(cookieOnRedirect, 'session=abc', 'cookie preserved for same-origin redirect')
+})
+
+test('redirect: uppercase-host origin keeps same-origin auth headers', async (t) => {
+  t.plan(2)
+  let authOnRedirect = null
+  let hop = 0
+  const server = await startServer((req, res) => {
+    hop++
+    if (hop === 1) {
+      res.writeHead(301, { location: '/dest' })
+      res.end()
+    } else {
+      authOnRedirect = req.headers.authorization
+      res.writeHead(200)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    // NOTE: uppercase host — normalizes to http://localhost:PORT.
+    origin: `http://LOCALHOST:${server.address().port}`,
+    path: '/start',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+  t.equal(authOnRedirect, 'Bearer secret', 'authorization preserved for same-origin redirect')
+})
+
+test('redirect: trailing-slash origin still strips on genuine cross-origin', async (t) => {
+  t.plan(3)
+  const serverB = await startServer((req, res) => {
+    t.notOk(req.headers.authorization, 'authorization header must be stripped on cross-origin')
+    t.notOk(req.headers.cookie, 'cookie header must be stripped on cross-origin')
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(serverB.close.bind(serverB))
+
+  const serverA = await startServer((req, res) => {
+    res.writeHead(301, { location: `http://127.0.0.1:${serverB.address().port}/dest` })
+    res.end()
+  })
+  t.teardown(serverA.close.bind(serverA))
+
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    origin: `http://127.0.0.1:${serverA.address().port}/`,
+    path: '/start',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret', cookie: 'session=abc' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+})
+
+test('redirect: URL-object opts.origin treated as same-origin', async (t) => {
+  t.plan(2)
+  let authOnRedirect = 'unset'
+  let hop = 0
+  const server = await startServer((req, res) => {
+    hop++
+    if (hop === 1) {
+      res.writeHead(301, {
+        location: `http://127.0.0.1:${server.address().port}/dest`,
+      })
+      res.end()
+    } else {
+      authOnRedirect = req.headers.authorization
+      res.writeHead(200)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const port = server.address().port
+  const dispatch = compose(new undici.Agent(), interceptors.redirect())
+  const status = await rawRequest(dispatch, {
+    // NOTE: URL object, not a string — must still normalize for the compare.
+    origin: new URL(`http://127.0.0.1:${port}/`),
+    path: '/start',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    follow: 5,
+  })
+  t.equal(status, 200)
+  t.equal(authOnRedirect, 'Bearer secret', 'URL-object origin treated as same-origin')
+})


### PR DESCRIPTION
## Problem

`lib/interceptor/redirect.js` decides whether to strip `authorization`/`cookie` on a redirect hop with a raw string comparison:

```js
this.#opts.origin !== origin
```

`origin` comes off a parsed Location URL, so it is always WHATWG-normalized (lowercase host, default port elided, no trailing slash). `opts.origin` is caller-provided and often is not.

## Failure scenario

Any of these makes a **same-origin** redirect look cross-origin, so auth headers are stripped and authenticated redirect flows break with a confusing 401:

- trailing slash: `origin: 'http://api.example.com/'`
- explicit default port: `http://host:80` — which `defaultLookup` in `lib/index.js` produces for object-form origins
- uppercase host: `http://HOST:port`

Reproduced at runtime: with `origin: 'http://127.0.0.1:PORT/'` the second hop saw `auth: null, cookie: null`; the normalized form preserved both. The bug fails safe (over-strips) but breaks real flows.

## Fix

Normalize both sides before comparing: a small `isSameOrigin(optsOrigin, target)` helper short-circuits on raw equality, otherwise compares `new URL(optsOrigin).origin` against the already-normalized target. If `opts.origin` is not URL-parseable, the raw-compare result stands (strip), preserving the fail-safe direction. Also handles `opts.origin` being a `URL` object.

## Tests

New `test/review-bugfixes-4-redirect-origin-compare.js` (tap):

- trailing-slash origin → `authorization` and `cookie` preserved on the second hop
- uppercase-host origin (`http://LOCALHOST:port`) → `authorization` preserved
- trailing-slash origin with a genuine cross-origin redirect → still stripped
- `URL`-object origin → treated as same-origin

Verified the new same-origin tests fail with the fix reverted (4 failures) and pass with it. Full run: `npx tap test/review-bugfixes-4-redirect-origin-compare.js test/redirect.js test/redirect-advanced.js` → 81/81 pass. eslint and prettier clean.

Note: `fix/redirect-proxy-authorization` touches the neighboring `shouldRemoveHeader`; if it lands first this branch may need a trivial conflict resolution (the changes are logically independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)