### PR TITLE
fix(proxy): deliver onError instead of hanging when reduceHeaders throws during upgrade

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -2,6 +2,8 @@ import net from 'node:net'
 import createError from 'http-errors'
 import { DecoratorHandler } from '../utils.js'
 
+function noop() {}
+
 // Accumulator used by reduceHeaders on the response path. Hoisted to module
 // scope so it is allocated once rather than on every onHeaders/onUpgrade call.
 /**
@@ -25,9 +27,9 @@ class Handler extends DecoratorHandler {
   }
 
   onUpgrade(statusCode, headers, socket) {
-    super.onUpgrade(
-      statusCode,
-      reduceHeaders(
+    let reduced
+    try {
+      reduced = reduceHeaders(
         {
           headers,
           httpVersion: this.#opts.httpVersion ?? this.#opts.req?.httpVersion,
@@ -39,9 +41,21 @@ class Handler extends DecoratorHandler {
         },
         copyHeader,
         {},
-      ),
-      socket,
-    )
+      )
+    } catch (err) {
+      // reduceHeaders throws on protocol errors (inbound Forwarded on a
+      // response → BadGateway, looping Via → LoopDetected). A throw must not
+      // escape onUpgrade: undici's H1 upgrade path nulls the request's queue
+      // slot before invoking onUpgrade and its catch only destroys the socket
+      // — no onError ever reaches the handler chain, leaving the caller
+      // waiting forever. Deliver the terminal error downstream ourselves
+      // (super.onError is once-guarded) and destroy the socket so it is not
+      // leaked; noop error listener since nothing downstream ever receives it.
+      socket.on('error', noop).destroy(err)
+      super.onError(err)
+      return
+    }
+    super.onUpgrade(statusCode, reduced, socket)
   }
 
   onHeaders(statusCode, headers, resume) {

--- a/test/review-bugfixes-4-proxy-upgrade-throw.js
+++ b/test/review-bugfixes-4-proxy-upgrade-throw.js
@@ -1,0 +1,165 @@
+// Regression tests for a hang in the proxy interceptor's onUpgrade:
+//  - proxy: reduceHeaders throwing during onUpgrade (e.g. an inbound Forwarded
+//    header on the 101 response → BadGateway) used to escape into undici's H1
+//    upgrade path, which has already nulled the request's queue slot and whose
+//    catch only destroys the socket — no onError ever reached the handler
+//    chain, so the upgrade caller waited forever. The fix catches the throw,
+//    delivers onError downstream and destroys the upgraded socket.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { compose, interceptors } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+// Every await in here must be bounded: the pre-fix failure mode is a hang
+// (neither onUpgrade nor onError is ever delivered), so a lost race must
+// surface as a bounded assertion failure rather than an infinite hang.
+function withTimeout(promise, ms, what) {
+  return Promise.race([
+    promise,
+    sleep(ms, undefined, { ref: false }).then(() => {
+      throw new Error(`timed out after ${ms}ms waiting for ${what}`)
+    }),
+  ])
+}
+
+async function startUpgradeServer(extraResponseHeaders) {
+  const server = createServer((req, res) => res.end())
+  const sockets = []
+  const teardowns = []
+  server.on('upgrade', (req, socket) => {
+    sockets.push(socket)
+    // Observe the client tearing the connection down. http.Server sockets are
+    // allowHalfOpen, so a client FIN surfaces as 'end' (not 'close'); an RST
+    // surfaces as 'error'. Keep reading so either is actually noticed.
+    teardowns.push(
+      new Promise((resolve) => {
+        socket.on('error', resolve).on('end', resolve).on('close', resolve)
+        socket.resume()
+      }),
+    )
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        extraResponseHeaders +
+        '\r\n',
+    )
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  return { server, sockets, teardowns }
+}
+
+function upgradeViaDispatch(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    dispatch(
+      { method: 'GET', path: '/', upgrade: 'websocket', proxy: {}, ...opts },
+      {
+        onConnect() {},
+        onUpgrade(statusCode, headers, socket) {
+          resolve({ statusCode, headers, socket })
+        },
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('unexpected onComplete for upgrade request'))
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+// ---------------------------------------------------------------------------
+// A 101 response carrying a Forwarded header (request-only per RFC 7239) makes
+// reduceHeaders throw BadGateway. The caller must receive that error via
+// onError within bounded time — pre-fix it hung forever — and the upgraded
+// socket must be destroyed rather than leaked.
+// ---------------------------------------------------------------------------
+
+test('proxy: reduceHeaders throw during onUpgrade is delivered as onError, not a hang', async (t) => {
+  t.plan(3)
+  const { server, sockets, teardowns } = await startUpgradeServer('Forwarded: for=192.0.2.1\r\n')
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.proxy())
+  const err = await withTimeout(
+    upgradeViaDispatch(dispatch, {
+      origin: `http://127.0.0.1:${server.address().port}`,
+    }).then(
+      () => {
+        throw new Error('upgrade unexpectedly succeeded')
+      },
+      (err) => err,
+    ),
+    5000,
+    'onError after reduceHeaders throw',
+  )
+
+  t.equal(err.statusCode, 502, 'BadGateway delivered to the caller via onError')
+  t.equal(sockets.length, 1, 'server saw exactly one upgrade')
+
+  // The client-side upgraded socket must have been destroyed — observe the
+  // TCP teardown (FIN or RST) from the server side, bounded.
+  await withTimeout(teardowns[0], 5000, 'server-side socket teardown')
+  t.ok(true, 'upgraded socket destroyed (server observed connection teardown)')
+})
+
+// ---------------------------------------------------------------------------
+// A looping Via (proxy.name matches an inbound Via segment) is the other
+// reduceHeaders throw site — same terminal delivery requirement.
+// ---------------------------------------------------------------------------
+
+test('proxy: Via loop during onUpgrade is delivered as onError, not a hang', async (t) => {
+  t.plan(1)
+  const { server } = await startUpgradeServer('Via: HTTP/1.1 myproxy\r\n')
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.proxy())
+  const err = await withTimeout(
+    upgradeViaDispatch(dispatch, {
+      origin: `http://127.0.0.1:${server.address().port}`,
+      proxy: { name: 'myproxy' },
+    }).then(
+      () => {
+        throw new Error('upgrade unexpectedly succeeded')
+      },
+      (err) => err,
+    ),
+    5000,
+    'onError after Via loop throw',
+  )
+
+  t.equal(err.statusCode, 508, 'LoopDetected delivered to the caller via onError')
+})
+
+// ---------------------------------------------------------------------------
+// A clean 101 (no offending headers) still upgrades through the proxy
+// interceptor, with hop-by-hop headers stripped and the socket usable.
+// ---------------------------------------------------------------------------
+
+test('proxy: clean upgrade still works through the proxy interceptor', async (t) => {
+  t.plan(4)
+  const { server } = await startUpgradeServer('X-Custom: keep\r\n')
+  t.teardown(server.close.bind(server))
+
+  const dispatch = compose(new undici.Agent(), interceptors.proxy())
+  const { statusCode, headers, socket } = await withTimeout(
+    upgradeViaDispatch(dispatch, {
+      origin: `http://127.0.0.1:${server.address().port}`,
+    }),
+    5000,
+    'onUpgrade for a clean 101',
+  )
+
+  t.equal(statusCode, 101, 'upgrade delivered with 101 status')
+  t.equal(headers['x-custom'], 'keep', 'non-hop-by-hop response header preserved')
+  t.notOk(headers.connection, 'hop-by-hop connection header stripped')
+  t.ok(socket && !socket.destroyed, 'upgraded socket delivered intact')
+
+  socket.destroy()
+})


### PR DESCRIPTION
## Problem

The proxy interceptor's `Handler.onUpgrade` runs `reduceHeaders` over the 101 response headers, and `reduceHeaders` can throw: `BadGateway` when the response carries a `Forwarded` header (request-only per RFC 7239), or `LoopDetected` when the inbound `Via` contains this proxy's name.

## Failure scenario

In undici's H1 upgrade path (`client-h1.js` `onUpgrade`), the request's queue slot is nulled **before** `request.onUpgrade(...)` is called, and the surrounding `catch` only does `util.destroy(socket, err)` — no `onError` is ever delivered to the handler chain. (`onHeaders` is safe by contrast: `core/request.js` catches and converts a throw to an abort.) So when the upstream answers an upgrade with e.g. a `Forwarded` response header, the throw escaped `onUpgrade` and the upgrade caller waited forever: neither `onUpgrade` nor `onError` arrived.

## Fix

Catch the `reduceHeaders` throw inside `onUpgrade`:

- deliver the terminal error downstream via `super.onError(err)` (`DecoratorHandler.onError` is once-guarded via `#errored`/`#completed`, so no double delivery — and nothing further follows from undici for this request since its queue slot is already nulled),
- destroy the upgraded socket with a noop `'error'` listener (repo pattern from `lib/request.js`) so it is neither leaked nor a source of an uncaught `'error'`.

The clean-upgrade path is unchanged.

## Tests

New `test/review-bugfixes-4-proxy-upgrade-throw.js` (all awaits bounded with `Promise.race` timeouts, so the pre-fix hang surfaces as a bounded failure):

- 101 with a `Forwarded` response header through the proxy interceptor → caller receives `BadGateway` (502) via `onError` within bounded time, and the server observes the upgraded socket being torn down.
- 101 with a looping `Via` (`proxy.name` match) → caller receives `LoopDetected` (508) via `onError`.
- clean 101 still upgrades: status/headers delivered, hop-by-hop stripped, socket intact.

Verified pre-fix: the two throw tests fail with bounded 5s timeouts (the hang), the clean-upgrade test passes. Post-fix: `tap test/review-bugfixes-4-proxy-upgrade-throw.js test/proxy-advanced.js` → 57/57 pass. eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)