### PR TITLE
fix(proxy): strip content-length/expect case-insensitively at dispatch

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -358,7 +358,10 @@ export default () => (dispatch) => (opts, handler) => {
       proxyName: opts.proxy.name,
     },
     (obj, key, val) => {
-      if (key === 'content-length' && !expectsPayload) {
+      // Case-insensitive (eqiLower) like reduceHeaders' capture above: the
+      // standalone interceptors.proxy() composition may pass mixed-case keys
+      // (the production path lowercases via parseHeaders first).
+      if (key.length === 14 && eqiLower(key, 'content-length') && !expectsPayload) {
         // https://tools.ietf.org/html/rfc7230#section-3.3.2
         // A user agent SHOULD NOT send a Content-Length header field when
         // the request message does not contain a payload body and the method
@@ -366,7 +369,7 @@ export default () => (dispatch) => (opts, handler) => {
         // undici will error if provided an unexpected content-length: 0 header.
       } else if (key[0] === ':') {
         // strip pseudo headers
-      } else if (key === 'expect') {
+      } else if (key.length === 6 && eqiLower(key, 'expect')) {
         // undici doesn't support expect header.
       } else {
         obj[key] = val

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -361,7 +361,7 @@ export default () => (dispatch) => (opts, handler) => {
       // Case-insensitive (eqiLower) like reduceHeaders' capture above: the
       // standalone interceptors.proxy() composition may pass mixed-case keys
       // (the production path lowercases via parseHeaders first).
-      if (key.length === 14 && eqiLower(key, 'content-length') && !expectsPayload) {
+      if (!expectsPayload && key.length === 14 && eqiLower(key, 'content-length')) {
         // https://tools.ietf.org/html/rfc7230#section-3.3.2
         // A user agent SHOULD NOT send a Content-Length header field when
         // the request message does not contain a payload body and the method

--- a/test/review-bugfixes-4-proxy-header-case.js
+++ b/test/review-bugfixes-4-proxy-header-case.js
@@ -1,0 +1,119 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { compose, interceptors } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+// Regression tests: the dispatch-time request-header accumulator in
+// lib/interceptor/proxy.js must strip `content-length` (on non-payload
+// methods) and `expect` case-INsensitively. The production pipeline
+// lowercases keys via parseHeaders first, but the standalone
+// interceptors.proxy() composition passes user headers through verbatim, so
+// mixed-case `Content-Length` / `Expect` used to leak into undici, which
+// rejects them (e.g. NotSupportedError for expect).
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.proxy())
+}
+
+function requestViaDispatch(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData() {},
+      onComplete() {
+        resolve(statusCode)
+      },
+      onError: reject,
+    })
+  })
+}
+
+test('proxy: mixed-case Content-Length is stripped on GET (standalone composition)', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.notOk(req.headers['content-length'], 'content-length stripped from GET')
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+  const statusCode = await requestViaDispatch(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { 'Content-Length': '0' },
+    proxy: {},
+  })
+  t.equal(statusCode, 200, 'request completes')
+})
+
+test('proxy: mixed-case Expect is stripped (standalone composition)', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.notOk(req.headers['expect'], 'expect header stripped')
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+  const statusCode = await requestViaDispatch(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { Expect: '100-continue' },
+    proxy: {},
+  })
+  t.equal(statusCode, 200, 'request completes without NotSupportedError')
+})
+
+test('proxy: lowercase content-length and expect keep being stripped', async (t) => {
+  t.plan(3)
+  const server = await startServer((req, res) => {
+    t.notOk(req.headers['content-length'], 'content-length stripped from GET')
+    t.notOk(req.headers['expect'], 'expect header stripped')
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+  const statusCode = await requestViaDispatch(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: { 'content-length': '0', expect: '100-continue' },
+    proxy: {},
+  })
+  t.equal(statusCode, 200, 'request completes')
+})
+
+test('proxy: mixed-case Content-Length is preserved on POST (payload method)', async (t) => {
+  t.plan(1)
+  const server = await startServer((req, res) => {
+    t.equal(req.headers['content-length'], '5', 'content-length preserved on POST')
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+  await requestViaDispatch(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: { 'Content-Length': '5' },
+    body: 'hello',
+    proxy: {},
+  })
+})

--- a/test/review-bugfixes-4-proxy-header-case.js
+++ b/test/review-bugfixes-4-proxy-header-case.js
@@ -6,7 +6,7 @@ import undici from '@nxtedition/undici'
 
 // Regression tests: the dispatch-time request-header accumulator in
 // lib/interceptor/proxy.js must strip `content-length` (on non-payload
-// methods) and `expect` case-INsensitively. The production pipeline
+// methods) and `expect` case-insensitively. The production pipeline
 // lowercases keys via parseHeaders first, but the standalone
 // interceptors.proxy() composition passes user headers through verbatim, so
 // mixed-case `Content-Length` / `Expect` used to leak into undici, which


### PR DESCRIPTION
## Problem

The dispatch-time request-header accumulator in `lib/interceptor/proxy.js` strips `content-length` (on non-payload methods) and `expect` with exact string comparison (`key === 'content-length'` / `key === 'expect'`).

Commit c77d4f3 already made `reduceHeaders`' special-header capture case-insensitive precisely because the standalone `interceptors.proxy()` composition passes mixed-case keys through verbatim (the production pipeline lowercases via `parseHeaders` first) — but this accumulator was missed.

## Failure scenario

Via the standalone composition (`compose(new undici.Agent(), interceptors.proxy())`):

- `Content-Length: 0` on a GET is forwarded into undici instead of being stripped, tripping undici's unexpected content-length handling.
- `Expect: 100-continue` is forwarded and undici throws `NotSupportedError` (undici does not support the expect header), failing the request instead of stripping the header.

Lowercase keys (and the default pipeline) were unaffected.

## Fix

Match both checks case-insensitively using the file's existing length-guarded `eqiLower` idiom (`key.length === 14 && eqiLower(key, 'content-length')`, `key.length === 6 && eqiLower(key, 'expect')`), mirroring the surrounding capture/retain loops. Two-line logic change.

## Tests

New `test/review-bugfixes-4-proxy-header-case.js` (fails without the fix, passes with it):

- Mixed-case `Content-Length: 0` on a GET via the standalone composition → request completes, header stripped.
- Mixed-case `Expect: 100-continue` → request completes (no NotSupportedError), header not forwarded.
- Lowercase variants keep being stripped (existing behavior).
- Mixed-case `Content-Length` on POST is still preserved (payload methods keep the header).

`npx tap test/review-bugfixes-4-proxy-header-case.js test/proxy-advanced.js` → 57/57 passing. eslint and prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)