### PR TITLE
fix(sqlite-cache-store): hold store registry via WeakRef to avoid pinning unclosed stores

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -4,16 +4,41 @@ import { parseRangeHeader, getFastNow } from './utils.js'
 // Bump version when the URL key format or schema changes to invalidate old caches.
 const VERSION = 10
 
-/** @typedef {{ gc: () => void, clear: () => void } } */
+// Registry of live stores so process-level broadcasts (nxt:offPeak,
+// nxt:clearCache) can reach them. Stores are held via WeakRef so that a store
+// dropped without close() is not pinned forever (together with its open
+// DatabaseSync handle and page cache) — GC can still collect it. close()
+// remains the recommended, deterministic cleanup path.
+/** @type {Set<WeakRef<SqliteCacheStore>>} */
 const stores = new Set()
+
+// Removes a collected store's WeakRef entry once the store has been GC'd.
+// The callback runs after the store is already gone, so it must not (and
+// cannot) touch the store or its DatabaseSync — the native handle has its own
+// lifecycle and is released by GC/process exit. This only drops bookkeeping.
+const registry = new FinalizationRegistry((ref) => {
+  stores.delete(ref)
+})
+
+/**
+ * @param {(store: SqliteCacheStore) => void} fn
+ */
+function forEachStore(fn) {
+  for (const ref of stores) {
+    const store = ref.deref()
+    if (store === undefined) {
+      stores.delete(ref)
+    } else {
+      fn(store)
+    }
+  }
+}
 
 {
   const offPeakBC = new BroadcastChannel('nxt:offPeak')
   offPeakBC.unref()
   offPeakBC.onmessage = () => {
-    for (const store of stores) {
-      store.gc()
-    }
+    forEachStore((store) => store.gc())
   }
 }
 
@@ -21,9 +46,7 @@ const stores = new Set()
   const clearCacheBC = new BroadcastChannel('nxt:clearCache')
   clearCacheBC.unref()
   clearCacheBC.onmessage = () => {
-    for (const store of stores) {
-      store.clear()
-    }
+    forEachStore((store) => store.clear())
   }
 }
 
@@ -80,6 +103,11 @@ export class SqliteCacheStore {
   #insertBatch = []
   #insertSeq = 0
   #closed = false
+
+  /**
+   * @type {WeakRef<SqliteCacheStore>}
+   */
+  #ref
 
   /**
    * @param {import('undici-types/cache-interceptor.d.ts').default.SqliteCacheStoreOpts & { maxSize?: number } | undefined} opts
@@ -174,7 +202,11 @@ export class SqliteCacheStore {
       `DELETE FROM cacheInterceptorV${VERSION} WHERE id IN (SELECT id FROM cacheInterceptorV${VERSION} ORDER BY deleteAt ASC LIMIT ?)`,
     )
 
-    stores.add(this)
+    this.#ref = new WeakRef(this)
+    stores.add(this.#ref)
+    // The store itself doubles as the unregister token so close() can drop
+    // the registry entry deterministically.
+    registry.register(this, this.#ref, this)
   }
 
   gc() {
@@ -222,7 +254,8 @@ export class SqliteCacheStore {
   }
 
   close() {
-    stores.delete(this)
+    stores.delete(this.#ref)
+    registry.unregister(this)
     // Drain the entire batch synchronously before closing. A plain #flush()
     // only commits one time-budget slice and reschedules the rest via
     // setImmediate; that deferred flush would see #closed and discard the

--- a/test/review-bugfixes-4-sqlite-registry.js
+++ b/test/review-bugfixes-4-sqlite-registry.js
@@ -1,0 +1,261 @@
+/* eslint-disable */
+// Regression tests for the module-level store registry in SqliteCacheStore.
+//
+// The registry exists so that process-level broadcasts (nxt:offPeak,
+// nxt:clearCache) can reach every live store. It used to hold every
+// constructed store strongly, so a store dropped without close() — plus its
+// open DatabaseSync handle, prepared statements and (for :memory:) its whole
+// page cache — was pinned forever. It now holds stores via WeakRef with a
+// FinalizationRegistry cleaning up entries for collected stores.
+import { test } from 'tap'
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
+
+const storeModuleUrl = pathToFileURL(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'lib', 'sqlite-cache-store.js'),
+).href
+
+function makeKey(overrides = {}) {
+  return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
+}
+
+function makeValue(overrides = {}) {
+  const now = Date.now()
+  return {
+    body: Buffer.from('hello'),
+    start: 0,
+    end: 5,
+    statusCode: 200,
+    statusMessage: 'OK',
+    cachedAt: now,
+    deleteAt: now + 7200e3,
+    ...overrides,
+  }
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// Poll `fn` until it returns true or the deadline expires.
+async function waitFor(fn, timeout = 5000) {
+  const deadline = Date.now() + timeout
+  while (!fn()) {
+    if (Date.now() > deadline) {
+      return false
+    }
+    await flush()
+  }
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Broadcasts still reach live stores through the WeakRef registry.
+// ---------------------------------------------------------------------------
+
+test('nxt:offPeak broadcast reaches live stores', async (t) => {
+  const store = new SqliteCacheStore()
+  t.teardown(() => store.close())
+
+  let gcCalls = 0
+  // Instance property shadows the prototype method; the broadcast handler
+  // calls store.gc(), so this observes delivery deterministically.
+  store.gc = () => {
+    gcCalls++
+  }
+
+  const bc = new BroadcastChannel('nxt:offPeak')
+  t.teardown(() => bc.close())
+  bc.postMessage(null)
+
+  t.ok(await waitFor(() => gcCalls > 0), 'gc() invoked on live store via broadcast')
+  t.end()
+})
+
+test('nxt:clearCache broadcast clears live stores', async (t) => {
+  const store = new SqliteCacheStore()
+  t.teardown(() => store.close())
+
+  store.set(makeKey(), makeValue())
+  await flush()
+  t.ok(store.get(makeKey()), 'value cached before broadcast')
+
+  const bc = new BroadcastChannel('nxt:clearCache')
+  t.teardown(() => bc.close())
+  bc.postMessage(null)
+
+  t.ok(await waitFor(() => store.get(makeKey()) === undefined), 'cache cleared via broadcast')
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// close() removes the store from the registry deterministically: broadcasts
+// after close() must not touch the closed store.
+// ---------------------------------------------------------------------------
+
+test('broadcast does not reach closed stores', async (t) => {
+  const closedStores = []
+  for (let i = 0; i < 4; i++) {
+    const store = new SqliteCacheStore()
+    store.close()
+    let calls = 0
+    store.gc = () => {
+      calls++
+    }
+    store.clear = () => {
+      calls++
+    }
+    closedStores.push({
+      store,
+      get calls() {
+        return calls
+      },
+    })
+  }
+
+  // A live store acts as the completion signal: once the broadcast has
+  // reached it, the same dispatch loop has already skipped the closed ones.
+  const live = new SqliteCacheStore()
+  t.teardown(() => live.close())
+  let liveCalls = 0
+  live.gc = () => {
+    liveCalls++
+  }
+
+  const bc = new BroadcastChannel('nxt:offPeak')
+  t.teardown(() => bc.close())
+  bc.postMessage(null)
+
+  t.ok(await waitFor(() => liveCalls > 0), 'broadcast delivered to live store')
+  for (const entry of closedStores) {
+    t.equal(entry.calls, 0, 'closed store not invoked by broadcast')
+  }
+  t.end()
+})
+
+test('registry bookkeeping in close() is idempotent', async (t) => {
+  const store = new SqliteCacheStore()
+  store.close()
+  try {
+    store.close()
+    t.pass('double close did not throw')
+  } catch (err) {
+    // DatabaseSync.close() rejects an already-closed handle; that pre-existing
+    // behavior is unchanged. The registry bookkeeping (stores.delete /
+    // registry.unregister) must not be what throws.
+    t.match(err.message, /database is not open/i, 'only the db handle complains')
+  }
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// The core fix: a store dropped WITHOUT close() must be collectable. The old
+// code pinned it in the module-level Set forever. This runs in a child
+// process with --expose-gc so it works under a plain `tap test` invocation,
+// and is best-effort: an inconclusive GC skips rather than fails.
+// ---------------------------------------------------------------------------
+
+test('unclosed store is not pinned by the registry (GC can collect it)', async (t) => {
+  const script = `
+    import { SqliteCacheStore } from ${JSON.stringify(storeModuleUrl)}
+
+    // Construct in a helper so no stack slot of the top-level frame keeps the
+    // store alive; only the WeakRef escapes.
+    function make() {
+      const store = new SqliteCacheStore()
+      store.set(
+        { origin: 'https://example.com', method: 'GET', path: '/gc' },
+        {
+          body: Buffer.from('hello'),
+          start: 0,
+          end: 5,
+          statusCode: 200,
+          statusMessage: 'OK',
+          cachedAt: Date.now(),
+          deleteAt: Date.now() + 7200e3,
+        },
+      )
+      return new WeakRef(store)
+    }
+
+    const ref = make()
+    // Let the pending batch flush complete so no setImmediate callback closes
+    // over the store.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const deadline = Date.now() + 10000
+    while (ref.deref() !== undefined) {
+      if (Date.now() > deadline) {
+        console.error('INCONCLUSIVE: store not collected within deadline')
+        process.exit(2)
+      }
+      try {
+        // Async execution collects without scanning the current stack;
+        // synchronous gc() can conservatively treat stale stack slots as
+        // roots and never release the store.
+        await globalThis.gc({ type: 'major', execution: 'async' })
+      } catch {
+        globalThis.gc()
+      }
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+
+    // Broadcast after collection: the dispatch loop must skip/remove the dead
+    // WeakRef without throwing.
+    const bc = new BroadcastChannel('nxt:offPeak')
+    bc.postMessage(null)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    bc.close()
+    console.log('COLLECTED')
+    process.exit(0)
+  `
+
+  const { code, stdout, stderr } = await new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ['--expose-gc', '--input-type=module', '-e', script],
+      { timeout: 30000 },
+      (err, stdout, stderr) => {
+        resolve({ code: err ? (err.code ?? 1) : 0, stdout, stderr })
+      },
+    )
+  })
+
+  if (code === 2) {
+    // GC never collected the store within the deadline. With the WeakRef fix
+    // this should not happen, but GC timing is not guaranteed — skip rather
+    // than flake.
+    t.skip(`inconclusive GC run: ${stderr.trim()}`)
+  } else {
+    t.equal(code, 0, `child exited cleanly (stderr: ${stderr.trim()})`)
+    t.match(stdout, /COLLECTED/, 'store was collected while unclosed')
+  }
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Sanity: many construct+close cycles leave no observable trace — a broadcast
+// afterwards reaches only the surviving store.
+// ---------------------------------------------------------------------------
+
+test('construct/close churn leaves registry consistent', async (t) => {
+  for (let i = 0; i < 32; i++) {
+    const store = new SqliteCacheStore()
+    store.close()
+  }
+
+  const live = new SqliteCacheStore()
+  t.teardown(() => live.close())
+  let calls = 0
+  live.clear = () => {
+    calls++
+  }
+
+  const bc = new BroadcastChannel('nxt:clearCache')
+  t.teardown(() => bc.close())
+  bc.postMessage(null)
+
+  t.ok(await waitFor(() => calls > 0), 'broadcast reaches surviving store after churn')
+  t.equal(calls, 1, 'delivered exactly once')
+  t.end()
+})


### PR DESCRIPTION
## Problem

`lib/sqlite-cache-store.js` keeps a module-level `stores` Set so process-level `nxt:offPeak` / `nxt:clearCache` broadcasts can reach every live store. The Set held every constructed `SqliteCacheStore` **strongly** (added in the constructor, removed only in `close()`). A store dropped without `close()` — together with its open `DatabaseSync` handle, prepared statements, and (for `:memory:`) its entire page cache — was unreachable-but-pinned forever. Long-lived processes that create stores per-tenant or per-test without closing them leak memory and file handles.

## Fix

Keep the broadcast feature, stop the pinning:

- `stores` is now a `Set<WeakRef<SqliteCacheStore>>`. Broadcast dispatch (shared `forEachStore` helper) derefs each entry, skips and prunes dead refs.
- A `FinalizationRegistry` removes a collected store's Set entry. The callback **only drops bookkeeping** — it never touches the `DatabaseSync`: finalizers run after the store is already gone, and the native handle has its own lifecycle (released by GC/process exit).
- The store itself is the unregister token (`registry.register(store, weakRef, store)`), so `close()` still removes both the Set entry and the registry registration deterministically.

Behavior for stores that **are** properly closed is unchanged; explicit `close()` remains the recommended cleanup path. This PR just removes the artificial pin so GC *can* collect an abandoned store.

## GC-test strategy

GC-dependent assertions are inherently timing-sensitive, so the test suite splits them:

- **Deterministic tests** (no GC involved): broadcasts reach live stores (observed via instance-level `gc`/`clear` spies and actual cache clearing), broadcasts do **not** reach closed stores, registry bookkeeping in `close()` is idempotent, and 32x construct/close churn leaves dispatch consistent (delivered exactly once to the survivor).
- **GC test**: runs in a child process spawned with `--expose-gc` (so it works under a plain `tap test` with no tap/node flag config). It constructs a store in a helper scope, keeps only a caller-side `WeakRef`, then polls `gc({ type: 'major', execution: 'async' })` with a bounded deadline until `deref()` returns `undefined`. Async GC execution matters: synchronous `gc()` conservatively scans the current stack and can keep stale slots alive indefinitely (verified — even a plain `{x:1}` object never collects under the sync variant on Node 25). An inconclusive GC run exits with a sentinel code and the tap test **skips** instead of failing. After collection, the child fires an `nxt:offPeak` broadcast to prove the dead-ref path in the dispatcher doesn't throw.

Manual verification of the pin removal (same script against both versions):

```
=== new code (this branch) ===  COLLECTED: store was garbage collected
=== old code (origin/main) ===  PINNED: store never collected
```

## Tests

- `npx tap test/review-bugfixes-4-sqlite-registry.js test/sqlite-cache-store.js test/review-bugfixes-store.js --timeout=240 --disable-coverage --allow-empty-coverage` → **179/179 pass** (new file: 13 assertions, GC test runs for real, not skipped).
- New test file re-run 5x consecutively: no flakes.
- `eslint` + `prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)