### PR TITLE
fix(types): align index.d.ts with runtime (body factory signature, upgrade, missing options) and default path to /

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -55,17 +55,25 @@ export interface LoggerLike {
   info(obj: unknown, msg?: string): void
 }
 
+export type BodyFactoryResult =
+  | Readable
+  | Uint8Array
+  | string
+  | Iterable<unknown>
+  | AsyncIterable<unknown>
+
+/** Called with an options object (not a bare signal); the signal aborts when the
+ *  request is destroyed before the factory resolves. May be async. */
+export type BodyFactory = (opts: {
+  signal: AbortSignal
+}) => BodyFactoryResult | Promise<BodyFactoryResult>
+
 export interface DispatchOptions {
   id?: string | null
   origin?: string | null
   path?: string | null
   method?: string | null
-  body?:
-    | Readable
-    | Uint8Array
-    | string
-    | ((signal: AbortSignal) => Readable | Uint8Array | string | Iterable<unknown>)
-    | null
+  body?: Readable | Uint8Array | string | BodyFactory | null
   query?: Record<string, unknown> | null
   headers?: Record<string, string | string[] | null | undefined> | null
   signal?: AbortSignal | null
@@ -80,8 +88,13 @@ export interface DispatchOptions {
   retry?: RetryOptions | number | boolean | RetryFn | null
   proxy?: ProxyOptions | boolean | null
   cache?: CacheOptions | boolean | null
-  upgrade?: boolean | null
+  /** Protocol to upgrade to (e.g. 'websocket'). undici requires a string and the
+   *  dispatch handler must implement onUpgrade — only meaningful with raw
+   *  dispatch()/compose(); request() has no upgrade support (see RequestOptions). */
+  upgrade?: string | null
   follow?: number | FollowFn | boolean | null
+  /** Alias for `follow`; ignored when `follow` is also set. */
+  redirect?: number | FollowFn | boolean | null
   error?: boolean | null
   verify?: VerifyOptions | boolean | null
   logger?: LoggerLike | null
@@ -121,6 +134,8 @@ export interface ProxyOptions {
 export interface CacheOptions {
   store?: CacheStore
   maxEntrySize?: number
+  /** Upper bound on an entry's freshness lifetime, in seconds (default 30 days). */
+  maxEntryTTL?: number
 }
 
 export interface VerifyOptions {
@@ -247,10 +262,14 @@ export interface CacheStore {
   close(): void
 }
 
-export interface RequestOptions extends DispatchOptions {
+/** `upgrade` is omitted: request()'s internal handler has no onUpgrade, so any
+ *  upgrade attempt rejects with InvalidArgumentError — use dispatch() instead. */
+export interface RequestOptions extends Omit<DispatchOptions, 'upgrade'> {
   url?: URLLike | null
   dispatch?: DispatchFn | null
   dispatcher?: Dispatcher | null
+  /** highWaterMark for the response body readable (non-negative number). */
+  highWaterMark?: number | null
 }
 
 export interface ResponseData {

--- a/lib/request.js
+++ b/lib/request.js
@@ -201,7 +201,11 @@ export function request(dispatch, urlOrOpts, optsOrNully) {
 
   let path = url.path
   if (!path) {
-    path = url.search ? `${url.pathname}${url.search}` : url.pathname
+    // URLObject marks every field optional; default the path so e.g.
+    // request({ origin }) works instead of undici rejecting with
+    // "path must be a string".
+    const pathname = url.pathname || '/'
+    path = url.search ? `${pathname}${url.search}` : pathname
   }
 
   opts = {

--- a/test/review-bugfixes-2-core.js
+++ b/test/review-bugfixes-2-core.js
@@ -277,14 +277,36 @@ test('request-id: empty opts.id falls back to the request-id header', (t) => {
 })
 
 // ---------------------------------------------------------------------------
-// query: a path-less object URL fails with a clear message, not a cryptic
-// "Cannot read properties of undefined".
+// query: request() now defaults a path-less object URL to '/', so a query on
+// a path-less request works. The interceptor's clear non-string-path message
+// (instead of a cryptic "Cannot read properties of undefined") still guards
+// raw dispatch, which performs no such defaulting.
 // ---------------------------------------------------------------------------
 
-test('query: path-less request with query rejects with a clear message', async (t) => {
+test('query: path-less request with query resolves against /', async (t) => {
+  t.plan(2)
+  const server = createServer((req, res) => {
+    t.equal(req.url, '/?a=1', 'query appended to the defaulted /')
+    res.end('ok')
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(() => server.close())
+
+  const { statusCode, body } = await request({
+    origin: `http://127.0.0.1:${server.address().port}`,
+    query: { a: 1 },
+    retry: false,
+  })
+  await body.dump()
+  t.equal(statusCode, 200)
+})
+
+test('query: raw dispatch without a path rejects with a clear message', async (t) => {
   t.plan(1)
-  await t.rejects(
-    request({ origin: 'http://0.0.0.0:1', query: { a: 1 }, retry: false }),
+  const dispatch = compose((opts, handler) => handler.onComplete(), interceptors.query())
+  t.throws(
+    () => dispatch({ origin: 'http://0.0.0.0:1', query: { a: 1 } }, {}),
     /string path/,
     'clear error instead of a cryptic TypeError',
   )

--- a/test/review-bugfixes-4-request-defaults.js
+++ b/test/review-bugfixes-4-request-defaults.js
@@ -1,0 +1,77 @@
+// Regression tests for request() URL normalization: URLObject marks every
+// field optional, so request({ origin }) without a path must default the
+// path to '/' instead of undici rejecting with "path must be a string".
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { request } from '../lib/index.js'
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+test('request({ origin }) without a path defaults to /', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.equal(req.url, '/', 'server sees /')
+    res.end('ok')
+  })
+  t.teardown(() => server.close())
+
+  const { statusCode, body } = await request({
+    origin: `http://127.0.0.1:${server.address().port}`,
+  })
+  await body.dump()
+  t.equal(statusCode, 200)
+})
+
+test('request(url, opts) with origin-only URLObject defaults to /', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.equal(req.url, '/', 'server sees /')
+    res.end('ok')
+  })
+  t.teardown(() => server.close())
+
+  const { statusCode, body } = await request(
+    { origin: `http://127.0.0.1:${server.address().port}` },
+    { method: 'GET' },
+  )
+  await body.dump()
+  t.equal(statusCode, 200)
+})
+
+test('request({ origin, search }) without pathname keeps the query on /', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.equal(req.url, '/?a=1', 'server sees /?a=1')
+    res.end('ok')
+  })
+  t.teardown(() => server.close())
+
+  const { statusCode, body } = await request({
+    origin: `http://127.0.0.1:${server.address().port}`,
+    search: '?a=1',
+  })
+  await body.dump()
+  t.equal(statusCode, 200)
+})
+
+test('request({ origin, pathname }) still honors an explicit pathname', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    t.equal(req.url, '/explicit', 'server sees /explicit')
+    res.end('ok')
+  })
+  t.teardown(() => server.close())
+
+  const { statusCode, body } = await request({
+    origin: `http://127.0.0.1:${server.address().port}`,
+    pathname: '/explicit',
+  })
+  await body.dump()
+  t.equal(statusCode, 200)
+})


### PR DESCRIPTION
Aligns `lib/index.d.ts` with actual runtime behavior (four verified mismatches) plus one tiny runtime fix that the type declarations already promised.

## Type fixes (lib/index.d.ts)

1. **Body-factory signature.** Declared `(signal: AbortSignal) => ...`, but the runtime calls the factory with an options **object**: `this.#factory({ signal: this.#ac.signal })` (`lib/interceptor/request-body-factory.js:18`), and the repo's own tests destructure `({ signal }) => ...` (`test/request-body-factory.js:178`). The runtime also `Promise.resolve()`s the result and feeds non-stream results through `Readable.from()`, and the tests exercise `async () => ...` and `async function* ()` factories — so the new `BodyFactory` type takes `(opts: { signal: AbortSignal })` and may return (a promise of) `Readable | Uint8Array | string | Iterable | AsyncIterable`.

2. **`upgrade` was typed `boolean | null`.** undici requires a *string* protocol (`node_modules/@nxtedition/undici/lib/core/request.js:66-68` throws `upgrade must be a string`), so `upgrade: true` could never work. It is now `string | null` on `DispatchOptions`. On `request()` it can never work at all — the internal `RequestHandler` (`lib/request.js`) has no `onUpgrade`, so undici's handler validation rejects with `InvalidArgumentError` — so `RequestOptions` now extends `Omit<DispatchOptions, 'upgrade'>` with a doc comment pointing at raw `dispatch()`.

3. **Missing options the runtime honors:**
   - `highWaterMark?: number | null` on `RequestOptions` — validated and used by `RequestHandler` for the response-body readable (`lib/request.js:9,19-21,99`).
   - `maxEntryTTL?: number` on `CacheOptions` — read by the cache interceptor (`lib/interceptor/cache.js:32,354`); seconds, capped against `max-age`/`s-maxage`, default 30 days.
   - `redirect` alias for `follow` on `DispatchOptions` — `follow: opts.follow ?? opts.redirect ?? 8` (`lib/index.js:184`).

## Runtime fix (lib/request.js)

`URLObject` marks every field optional, but `request({ origin: 'http://...' })` without `path`/`pathname` left `opts.path` undefined and undici rejected with `path must be a string`. The URL normalization now defaults the pathname to `'/'` (also covers `pathname: ''` with a `search`).

The pre-existing test `query: path-less request with query rejects with a clear message` (`test/review-bugfixes-2-core.js`) asserted the old rejection; it now asserts the new behavior (query appended to the defaulted `/`), and the query interceptor's clear non-string-path message is still guarded via raw `dispatch()`, which performs no defaulting.

## Verification

- `tsc --noEmit --strict` (repo's own `node_modules/.bin/tsc`) passes on `lib/index.d.ts`, and on a throwaway `.ts` exercising every fixed signature — destructured `({ signal })` factories (sync/async/async-generator), `string` upgrade at dispatch level, `maxEntryTTL`, `highWaterMark`, `redirect` — including `@ts-expect-error` assertions that the old bare-signal factory, `upgrade: true`, and `upgrade` on `request()` now fail to typecheck (throwaway deleted; repo has no type-test convention).
- New tap regression file `test/review-bugfixes-4-request-defaults.js`: origin-only `request()` (both call forms) resolves with the server seeing `/`, `search` without `pathname` yields `/?a=1`, explicit `pathname` untouched.
- Full suite: `npx tap test --timeout=120 --disable-coverage --allow-empty-coverage` → 917 pass, 0 fail, 4 skip.
- `eslint` and `prettier --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)