### PR TITLE
feat(dns): negative-cache failed lookups (configurable negativeTTL, default 1s)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -130,7 +130,16 @@ export interface VerifyOptions {
 
 export interface DnsOptions {
   ttl?: number
+  /** How long (ms) a failed lookup is negative-cached; requests inside this
+   *  window fail fast without hitting the resolver again (default 1000). */
+  negativeTTL?: number
   balance?: 'hash'
+  /** Custom resolver, `dns.lookup`-compatible (called with `{ all: true }`). */
+  lookup?: (
+    hostname: string,
+    options: { all: boolean },
+    callback: (err: Error | null, addresses: { address: string; family: number }[]) => void,
+  ) => void
 }
 
 export interface LogInterceptorOptions {

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -44,6 +44,27 @@ class Handler extends DecoratorHandler {
 
 const SWEEP_INTERVAL = 30e3
 
+// A cached (or in-flight-shared) lookup error must never be handed to more
+// than one caller as-is: downstream decorateError call sites (response-retry,
+// response-error) mutate the error they receive (err.req, err.res,
+// err.statusCode), so a shared object would leak one request's decoration
+// into another's. Give each caller a fresh Error carrying the identifying
+// dns fields, with the original attached as `cause`.
+function makeLookupError(err) {
+  const wrapped = new Error(err.message, { cause: err })
+  wrapped.code = err.code
+  if (err.errno !== undefined) {
+    wrapped.errno = err.errno
+  }
+  if (err.syscall !== undefined) {
+    wrapped.syscall = err.syscall
+  }
+  if (err.hostname !== undefined) {
+    wrapped.hostname = err.hostname
+  }
+  return wrapped
+}
+
 // Error codes that mean the IP itself is unreachable/bad, so the selected
 // record should be invalidated immediately (expires = 0), forcing a re-resolve.
 // Anything else surfaced on the response path — a headers/body timeout, a
@@ -67,12 +88,16 @@ const CONNECTION_ERROR_CODES = new Set([
 
 export default () => (dispatch) => {
   const cache = new Map()
+  const negatives = new Map()
   const promises = new Map()
 
   // The `cache` Map is otherwise only ever written, never trimmed, so a process
   // touching many distinct hostnames over its lifetime would leak entries that
   // can never be selected again. Sweep dead entries (all records expired and
   // none in flight) at most once per SWEEP_INTERVAL to bound the O(n) cost.
+  // Negative entries are swept on the same cadence (they are also deleted
+  // eagerly on the next successful lookup / overwritten on the next failure,
+  // so the sweep only matters for hostnames that are never touched again).
   let lastSweep = 0
   function sweep(now) {
     if (now - lastSweep < SWEEP_INTERVAL) {
@@ -84,18 +109,33 @@ export default () => (dispatch) => {
         cache.delete(hostname)
       }
     }
+    for (const [hostname, negative] of negatives) {
+      if (negative.expires < now) {
+        negatives.delete(hostname)
+      }
+    }
   }
 
-  function resolve(hostname, { ttl }) {
+  function resolve(hostname, { ttl, negativeTTL, lookup }) {
     let promise = promises.get(hostname)
     if (!promise) {
       promise = new Promise((resolve) => {
-        dns.lookup(hostname, { all: true }, (err, records) => {
+        lookup(hostname, { all: true }, (err, records) => {
           promises.delete(hostname)
 
           if (err) {
+            // Negative cache: remember the failure for a short while so a hot
+            // caller of an unresolvable host fails fast instead of issuing a
+            // lookup storm (response-retry retries ENOTFOUND/EAI_AGAIN up to
+            // `retry` (default 8) times, so without this every logical
+            // request produced ~9 lookups). EAI_AGAIN is transient by
+            // definition, but the same small TTL applies — the window only
+            // needs to absorb a retry burst, and a short TTL keeps recovery
+            // fast either way.
+            negatives.set(hostname, { err, expires: getFastNow() + negativeTTL })
             resolve([err, null])
           } else {
+            negatives.delete(hostname)
             const now = getFastNow()
             const val = records.map(({ address }) => {
               return {
@@ -125,6 +165,8 @@ export default () => (dispatch) => {
       }
 
       const ttl = opts.dns.ttl ?? 2e3
+      const negativeTTL = opts.dns.negativeTTL ?? 1e3
+      const lookup = opts.dns.lookup ?? dns.lookup
       const url = new URL(opts.path ?? '', opts.origin)
       const balance = opts.dns.balance
 
@@ -141,9 +183,19 @@ export default () => (dispatch) => {
       let records = cache.get(hostname)
 
       if (records == null || records.every((x) => x.expires < now)) {
-        const [err, val] = await resolve(hostname, { ttl })
+        // A fresh negative entry means a lookup for this hostname failed less
+        // than negativeTTL ago — fail fast instead of hitting the resolver
+        // again. Fresh positive records (checked above) take precedence, so a
+        // failed pre-emptive refresh never fails requests that can still be
+        // served from cache.
+        const negative = negatives.get(hostname)
+        if (negative != null && negative.expires >= now) {
+          throw makeLookupError(negative.err)
+        }
+
+        const [err, val] = await resolve(hostname, { ttl, negativeTTL, lookup })
         if (err) {
-          throw err
+          throw makeLookupError(err)
         }
         records = val
       }
@@ -190,7 +242,7 @@ export default () => (dispatch) => {
       // refreshed records land in cache for the next request, smoothing
       // out DNS lookup latency. `resolve()` dedupes via `promises`.
       if (records.some((x) => x.expires < now + ttl / 2)) {
-        resolve(hostname, { ttl })
+        resolve(hostname, { ttl, negativeTTL, lookup })
       }
 
       url.hostname = net.isIPv6(record.address) ? `[${record.address}]` : record.address

--- a/test/review-bugfixes-4-dns-negative-cache.js
+++ b/test/review-bugfixes-4-dns-negative-cache.js
@@ -1,0 +1,181 @@
+// Regression tests for dns negative caching:
+//  - a failed lookup is negative-cached for `negativeTTL` (default 1000 ms),
+//    so a hot caller of an unresolvable host performs ONE underlying lookup
+//    per window instead of one per request. Without this, response-retry
+//    (which retries ENOTFOUND/EAI_AGAIN up to `retry` (default 8) times)
+//    turned every logical request into ~9 dns.lookup calls — a lookup storm.
+//  - the negative entry expires after negativeTTL; the next request performs
+//    a fresh lookup and succeeds if DNS has recovered.
+//  - each caller gets its OWN error object: decorateError call sites
+//    (response-retry, response-error) mutate the error they receive
+//    (err.req/err.res/err.statusCode), so handing the same cached object to
+//    N callers would cross-contaminate their decorations.
+import { test } from 'tap'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { interceptors } from '../lib/index.js'
+
+function run(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    dispatch(
+      { path: '/', method: 'GET', headers: {}, ...opts },
+      {
+        onConnect() {},
+        onHeaders(statusCode) {
+          resolve(statusCode)
+          return true
+        },
+        onData() {},
+        onComplete() {},
+        onError: reject,
+      },
+    )
+  })
+}
+
+function makeNotFoundError(hostname) {
+  return Object.assign(new Error(`getaddrinfo ENOTFOUND ${hostname}`), {
+    code: 'ENOTFOUND',
+    syscall: 'getaddrinfo',
+    hostname,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 1. All requests inside the negativeTTL window share one underlying lookup.
+// ---------------------------------------------------------------------------
+
+test('dns: lookup failures are negative-cached (one lookup per window)', async (t) => {
+  let lookups = 0
+  const lookup = (hostname, options, callback) => {
+    lookups++
+    process.nextTick(callback, makeNotFoundError(hostname))
+  }
+
+  const dispatch = interceptors.dns()(() => {
+    t.fail('dispatch must not be reached when lookup fails')
+  })
+
+  // getFastNow() (the interceptor clock) only ticks once per second, so use a
+  // window comfortably larger than the test's runtime plus one tick.
+  const dns = { negativeTTL: 5000, lookup }
+
+  for (let i = 0; i < 5; i++) {
+    const err = await run(dispatch, { origin: 'http://unresolvable.invalid', dns }).then(
+      () => null,
+      (err) => err,
+    )
+    t.ok(err, `request ${i} rejected`)
+    t.equal(err.code, 'ENOTFOUND', `request ${i} rejection carries ENOTFOUND`)
+  }
+
+  t.equal(lookups, 1, 'exactly one underlying lookup for all requests in the window')
+})
+
+// ---------------------------------------------------------------------------
+// 2. The negative entry expires; the next request re-resolves and recovers.
+// ---------------------------------------------------------------------------
+
+test('dns: negative entry expires after negativeTTL and the next lookup recovers', async (t) => {
+  let lookups = 0
+  let failing = true
+  const lookup = (hostname, options, callback) => {
+    lookups++
+    if (failing) {
+      process.nextTick(callback, makeNotFoundError(hostname))
+    } else {
+      process.nextTick(callback, null, [{ address: '127.0.0.1', family: 4 }])
+    }
+  }
+
+  const origins = []
+  const dispatch = interceptors.dns()((opts, handler) => {
+    origins.push(opts.origin)
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+
+  const dns = { negativeTTL: 50, lookup }
+
+  await t.rejects(
+    run(dispatch, { origin: 'http://recovers.invalid', dns }),
+    { code: 'ENOTFOUND' },
+    'first request fails with ENOTFOUND',
+  )
+  t.equal(lookups, 1, 'first request performed the lookup')
+
+  // getFastNow() advances only once per second, so sleep long enough to
+  // guarantee at least one tick lands past the 50 ms expiry.
+  failing = false
+  await sleep(1500)
+
+  const status = await run(dispatch, { origin: 'http://recovers.invalid', dns })
+  t.equal(status, 200, 'request succeeds once DNS recovers')
+  t.equal(lookups, 2, 'a fresh lookup was performed after the negative entry expired')
+  t.equal(origins[0], 'http://127.0.0.1', 'recovered request dispatched to the resolved address')
+})
+
+// ---------------------------------------------------------------------------
+// 3. Every rejection is a distinct object; mutating one (as decorateError
+//    does downstream) must not leak into another caller's error or into the
+//    cached original.
+// ---------------------------------------------------------------------------
+
+test('dns: each caller gets its own error object (no cross-contamination)', async (t) => {
+  const original = makeNotFoundError('cached.invalid')
+  const lookup = (hostname, options, callback) => {
+    process.nextTick(callback, original)
+  }
+
+  const dispatch = interceptors.dns()(() => {
+    t.fail('dispatch must not be reached when lookup fails')
+  })
+
+  const dns = { negativeTTL: 5000, lookup }
+  const opts = { origin: 'http://cached.invalid', dns }
+
+  // Concurrent callers share the in-flight resolve promise.
+  const [err1, err2] = await Promise.all([
+    run(dispatch, opts).then(
+      () => null,
+      (err) => err,
+    ),
+    run(dispatch, opts).then(
+      () => null,
+      (err) => err,
+    ),
+  ])
+  // A later caller is served from the negative cache.
+  const err3 = await run(dispatch, opts).then(
+    () => null,
+    (err) => err,
+  )
+
+  for (const [name, err] of [
+    ['err1', err1],
+    ['err2', err2],
+    ['err3', err3],
+  ]) {
+    t.ok(err, `${name} rejected`)
+    t.equal(err.code, 'ENOTFOUND', `${name} carries ENOTFOUND`)
+    t.equal(err.hostname, 'cached.invalid', `${name} carries the hostname`)
+    t.equal(err.cause, original, `${name} keeps the original as cause`)
+    t.not(err, original, `${name} is not the cached original`)
+  }
+
+  t.not(err1, err2, 'concurrent callers get distinct objects')
+  t.not(err2, err3, 'negative-cache hit gets a distinct object')
+  t.not(err1, err3, 'all rejections are distinct objects')
+
+  // Simulate the decorateError mutations performed by response-retry /
+  // response-error on one caller's error.
+  err1.statusCode = 503
+  err1.req = { path: '/mutated' }
+  err1.res = { statusCode: 503 }
+
+  t.equal(err2.statusCode, undefined, 'sibling error is unaffected by mutation')
+  t.equal(err2.req, undefined, 'sibling error req is unaffected')
+  t.equal(err3.res, undefined, 'later error res is unaffected')
+  t.equal(original.statusCode, undefined, 'cached original is unaffected')
+  t.equal(original.req, undefined, 'cached original req is unaffected')
+})


### PR DESCRIPTION
## Problem

The dns interceptor's cache only ever stored **successful** lookups; failures had nothing but in-flight promise dedupe. Combined with `response-retry`, which retries `ENOTFOUND`/`EAI_AGAIN` up to `retry` times (default **8**), a hot caller of an unresolvable host produced a `dns.lookup` **storm**: ~9 lookups per logical request, further amplified across concurrent callers — as soon as each shared in-flight promise settled, the next wave went straight back to the resolver.

## Design

- **Negative cache**: a failed lookup stores `{ err, expires }` for `dns.negativeTTL` ms (new option next to `dns.ttl`, **default 1000 ms** — long enough to absorb a retry burst, short enough to recover quickly). While fresh, requests fail immediately without touching the resolver; after expiry the next request re-resolves (recovery path).
- **`EAI_AGAIN`**: uses the same small default. It is transient by definition, but the window only needs to soak up a retry burst, and a short TTL keeps recovery fast either way — one knob, simple semantics.
- **Fresh error per caller**: `decorateError` call sites (`response-retry`, `response-error`) *mutate* the error they're given (`err.req`/`err.res`/`err.statusCode`), so handing the same cached object to N callers would cross-contaminate their decorations. Each caller gets a fresh `Error` with `code`/`errno`/`syscall`/`hostname` copied and the original as `cause` (so `err.code === 'ENOTFOUND'` checks, including response-retry's own, keep working). The error shared via the in-flight promise is wrapped the same way.
- **Precedence & hygiene**: fresh positive records win over a negative entry, so a failed pre-emptive half-TTL refresh never fails requests that are still servable from cache. A successful lookup deletes the negative entry, and the existing periodic sweep also evicts expired negatives (bounded memory). In-flight dedupe is unchanged.
- **Testability**: added a `dns.lookup` option (a `dns.lookup`-compatible function). The interceptor called the frozen `node:dns` namespace directly, which made lookup counting impossible to test deterministically; this mirrors the existing top-level `opts.lookup` injection pattern and is useful on its own.

`lib/index.d.ts`: `DnsOptions` gains `negativeTTL?: number` and `lookup?`. Kept minimal; may trivially conflict with the concurrent types-alignment PR if it touches `DnsOptions`.

## Tests

New `test/review-bugfixes-4-dns-negative-cache.js` (counting via injected lookup):

1. Always-failing `ENOTFOUND` lookup, 5 sequential requests inside the window → **exactly 1** underlying lookup, all 5 reject with `ENOTFOUND`-coded errors.
2. `negativeTTL: 50`, stub flips to success after expiry → fresh lookup (counter 1 → 2), request succeeds against the resolved address (recovery).
3. Concurrent (in-flight-shared) and negative-cache-served rejections are all **distinct objects** with `cause` = original; decorating one (`statusCode`/`req`/`res`) leaves siblings and the cached original untouched.

Verified test 1 fails on `origin/main` with the fix reverted (5 lookups instead of 1). Full run: `npx tap test/review-bugfixes-4-dns-negative-cache.js test/dns-advanced.js test/lookup-advanced.js` → **60/60 pass**; adjacent `retry-lookup`/`review-bugfixes-3`/`compose` suites also pass. eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)