### PR TITLE
fix(utils): stop mutating caller-owned abort reasons in decorateError

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -10,6 +10,7 @@ class Handler extends DecoratorHandler {
   #body = ''
   #bodySize = 0
   #opts
+  #reason = null
 
   constructor(opts, { handler }) {
     super(handler)
@@ -23,8 +24,14 @@ class Handler extends DecoratorHandler {
     this.#headers = null
     this.#body = ''
     this.#bodySize = 0
+    this.#reason = null
 
-    super.onConnect(abort)
+    super.onConnect((reason) => {
+      // Remember the abort reason so onError can recognize it. The reason is
+      // owned by the caller (e.g. signal.reason) and must not be decorated.
+      this.#reason = reason ?? null
+      abort(reason)
+    })
   }
 
   onHeaders(statusCode, headers, resume) {
@@ -81,6 +88,16 @@ class Handler extends DecoratorHandler {
   }
 
   onError(err) {
+    // An abort reason is owned by the caller and may be shared by every
+    // request in flight on the same signal — decorating it in place would
+    // permanently mutate the caller's object and leak one request's req/res
+    // onto another request's rejection (last writer wins). Callers also rely
+    // on receiving the exact reason object, so pass it through untouched.
+    if (err != null && (err === this.#reason || err === this.#opts.signal?.reason)) {
+      super.onError(err)
+      return
+    }
+
     super.onError(
       decorateError(err, this.#opts, {
         statusCode: this.#statusCode || undefined,

--- a/test/review-bugfixes-4-decorate-error.js
+++ b/test/review-bugfixes-4-decorate-error.js
@@ -1,0 +1,130 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { request } from '../lib/index.js'
+
+// ---------------------------------------------------------------------------
+// Regression: decorateError used to mutate the error object it was given in
+// place. When one AbortController aborts N in-flight requests, signal.reason
+// is a SINGLE shared object — every request's error path decorated the SAME
+// instance (last writer wins), so request /one's rejection reported
+// err.req.path === '/two', and the caller's own reason object permanently
+// gained req/res properties.
+// ---------------------------------------------------------------------------
+
+test('abort: shared abort reason is not mutated or cross-contaminated', async (t) => {
+  let pending = 2
+  let onBothInFlight
+  const bothInFlight = new Promise((resolve) => {
+    onBothInFlight = resolve
+  })
+
+  const server = createServer(() => {
+    // Never respond — keep both requests in flight.
+    if (--pending === 0) {
+      onBothInFlight()
+    }
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const ac = new AbortController()
+  const reason = new Error('shared abort reason')
+
+  const p1 = request(`${origin}/one`, { signal: ac.signal, retry: false, headersTimeout: 30000 })
+  const p2 = request(`${origin}/two`, { signal: ac.signal, retry: false, headersTimeout: 30000 })
+
+  await bothInFlight
+  ac.abort(reason)
+
+  const [r1, r2] = await Promise.allSettled([p1, p2])
+  t.equal(r1.status, 'rejected', 'first request rejects')
+  t.equal(r2.status, 'rejected', 'second request rejects')
+
+  // The rejection must be the exact caller-owned reason, untouched.
+  t.equal(r1.reason, reason, 'first rejection is the exact abort reason')
+  t.equal(r2.reason, reason, 'second rejection is the exact abort reason')
+
+  // One request's decoration must never leak into another request's
+  // rejection (previously both reported req.path === '/two').
+  t.not(r1.reason?.req?.path, '/two', 'rejection for /one must not report /two')
+  t.not(r2.reason?.req?.path, '/one', 'rejection for /two must not report /one')
+
+  // The caller's reason object must not gain req/res/statusCode properties.
+  t.equal('req' in reason, false, 'reason must not gain req')
+  t.equal('res' in reason, false, 'reason must not gain res')
+  t.equal('statusCode' in reason, false, 'reason must not gain statusCode')
+})
+
+test('abort: default (reason-less) abort is shared per signal and not mutated', async (t) => {
+  let pending = 2
+  let onBothInFlight
+  const bothInFlight = new Promise((resolve) => {
+    onBothInFlight = resolve
+  })
+
+  const server = createServer(() => {
+    if (--pending === 0) {
+      onBothInFlight()
+    }
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const ac = new AbortController()
+
+  const p1 = request(`${origin}/one`, { signal: ac.signal, retry: false, headersTimeout: 30000 })
+  const p2 = request(`${origin}/two`, { signal: ac.signal, retry: false, headersTimeout: 30000 })
+
+  await bothInFlight
+  ac.abort()
+
+  const [r1, r2] = await Promise.allSettled([p1, p2])
+  t.equal(r1.status, 'rejected', 'first request rejects')
+  t.equal(r2.status, 'rejected', 'second request rejects')
+
+  // The default DOMException reason is also a single object shared by every
+  // request on the signal — it must not gain req/res either.
+  t.equal('req' in ac.signal.reason, false, 'signal.reason must not gain req')
+  t.equal('res' in ac.signal.reason, false, 'signal.reason must not gain res')
+})
+
+test('response-error: 4xx errors are still decorated with statusCode/req/res', async (t) => {
+  const server = createServer((req, res) => {
+    res.statusCode = 418
+    res.end('teapot')
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  try {
+    await request(`http://127.0.0.1:${server.address().port}/tea`, { retry: false })
+    t.fail('should have thrown')
+  } catch (err) {
+    t.equal(err.statusCode, 418, 'statusCode still decorated')
+    t.equal(err.req.path, '/tea', 'req still decorated')
+    t.ok(err.res, 'res still decorated')
+  }
+})
+
+test('response-error: network errors are still decorated with req info', async (t) => {
+  const server = createServer((req, res) => {
+    res.destroy()
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  try {
+    await request(`http://127.0.0.1:${server.address().port}/api`, { retry: false })
+    t.fail('should have thrown')
+  } catch (err) {
+    t.ok(err.req, 'err.req is set on network error')
+    t.equal(err.req.path, '/api', 'req.path still decorated on network error')
+  }
+})


### PR DESCRIPTION
## Problem

`decorateError` (lib/utils.js) writes `req`, `res`, `statusCode` etc. directly onto the error object it is given. The response-error interceptor calls it from `onError` with whatever error bubbles up — including the request's abort reason, which is an object the **caller** owns.

## Failure scenario (verified with a runtime repro)

When one `AbortController` aborts N in-flight requests, `signal.reason` is a **single shared object**. Every request's error path decorated the same instance, last writer wins:

- both rejections reported the identical `err.req` — e.g. the rejection for `/one` claimed `err.req.path === '/two'` (cross-request contamination), and
- the caller's own `reason` object was permanently mutated with `req`/`res`/`statusCode` properties.

The same applies to the default reason-less `ac.abort()`, whose auto-created `DOMException` is also one object per signal.

## Fix

In the response-error interceptor, track the abort reason via the `onConnect` abort wrapper and pass it through `onError` **untouched** instead of decorating it (also guarded by `err === opts.signal?.reason`).

Why this approach:
- test/signal-advanced.js pins the contract that the rejection is the **exact** abort-reason object (`t.equal(err, myReason)`), so cloning/wrapping the reason would be a breaking change — pass-through preserves identity while never mutating the caller's object.
- Errors the library creates itself are untouched by this change: 4xx http-errors (`onComplete` path) and undici network errors are still decorated in place exactly as before, so `err.statusCode`/`err.req`/`err.res` behavior on normal error paths is unchanged.
- `decorateError` itself keeps its semantics (its direct unit tests, including the frozen-error AggregateError path, are untouched); the fix lives at the one call site where a caller-owned object could arrive. The response-retry interceptor already short-circuits on abort before its `decorateError` call, so this was the only affected path.

## Tests

New `test/review-bugfixes-4-decorate-error.js`:
- one `AbortController`, two in-flight requests to `/one` and `/two` on a never-responding server; abort → both reject with the exact shared reason, neither rejection reports the other request's path, and the reason gains no `req`/`res`/`statusCode` properties (fails 5 assertions without the fix, passes with it)
- same invariant for the default reason-less abort (`DOMException` shared per signal)
- 4xx decoration unchanged (`statusCode`/`req`/`res`)
- network-error decoration unchanged (`err.req.path`)

Verified: `npx tap test/review-bugfixes-4-decorate-error.js test/errors.js test/response-error-advanced.js test/signal-advanced.js test/utils.js` → 168/168 assertions pass; full `npx tap test` → 925 pass, 0 fail; eslint and prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)