### PR TITLE
feat(cache): RFC 9111 revalidation, stale-while-revalidate, stale-if-error, invalidation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -134,8 +134,15 @@ export interface ProxyOptions {
 export interface CacheOptions {
   store?: CacheStore
   maxEntrySize?: number
-  /** Upper bound on an entry's freshness lifetime, in seconds (default 30 days). */
+  /** Upper bound on an entry's freshness lifetime AND retention, in seconds
+   *  (default 30 days). */
   maxEntryTTL?: number
+  /** Opt-in RFC 9111 §4.2.2 heuristic freshness (10% of time since
+   *  Last-Modified) for 200 responses without explicit expiration. */
+  heuristic?: boolean
+  /** Opt-in fallback freshness lifetime in seconds for 200 responses without
+   *  any expiration information. */
+  defaultTTL?: number
 }
 
 export interface VerifyOptions {
@@ -245,6 +252,7 @@ export interface CacheValue {
   etag?: string
   vary?: Record<string, string | string[]>
   cachedAt: number
+  staleAt: number
   deleteAt?: number
 }
 
@@ -257,6 +265,7 @@ export interface CacheGetResult {
   cacheControlDirectives?: Record<string, unknown>
   vary?: Record<string, string | string[]>
   cachedAt: number
+  staleAt: number
   deleteAt: number
 }
 
@@ -266,6 +275,9 @@ export interface CacheStore {
     key: CacheKey,
     value: CacheValue & { body: null | Buffer | Buffer[]; start: number; end: number },
   ): void
+  /** RFC 9111 §4.4 invalidation — optional; the cache interceptor
+   *  feature-detects it and skips invalidation when absent. */
+  delete?(key: CacheKey): void
   gc(): void
   clear(): void
   close(): void
@@ -338,6 +350,8 @@ export class SqliteCacheStore implements CacheStore {
     key: CacheKey,
     value: CacheValue & { body: null | Buffer | Buffer[]; start: number; end: number },
   ): void
+  /** RFC 9111 §4.4: invalidates every stored response for the key's URI. */
+  delete(key: CacheKey): void
   gc(): void
   clear(): void
   close(): void

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,17 +1,209 @@
 import undici from '@nxtedition/undici'
+import { stringify } from 'fast-querystring'
 import {
   DecoratorHandler,
-  getFastNow,
   isStream,
   parseCacheControl,
   parseContentRange,
+  parseHeaders,
+  parseHttpDate,
 } from '../utils.js'
+import { isHopByHop } from './proxy.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
 
 let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
-const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600
+const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600 // seconds
+// Bounded retention for entries kept solely for conditional revalidation
+// (zero/expired freshness but a usable validator): long enough that the
+// "always validate" origin pattern pays a 304 instead of a full 200, short
+// enough not to pin dead content. Mirrors undici PR #5515 (24h).
+const REVALIDATION_RETENTION = 24 * 3600 // seconds
+// RFC 8246 'immutable' has no lifetime of its own; this is the customary
+// 1-year default, capped by maxEntryTTL below.
+const IMMUTABLE_LIFETIME = 31556952 // seconds
 const NOOP = () => {}
+
+// In-flight background stale-while-revalidate refreshes keyed by
+// method + url, so a hot stale key spawns one refresh, not a herd.
+const backgroundRefreshes = new Set()
+
+/**
+ * Explicit (or opt-in heuristic) freshness lifetime in seconds, or null when
+ * the response carries no usable expiration information. RFC 9111 §4.2.1
+ * priority for a shared cache: s-maxage > max-age > Expires. immutable
+ * (RFC 8246) and the opt-in heuristics only apply when no explicit lifetime
+ * is present. `explicit` marks origin-provided expiration — required for the
+ * stale-on-arrival store-and-revalidate path (never keep heuristically-stale
+ * content around for revalidation).
+ *
+ * @returns {{ lifetime: number, explicit: boolean } | null}
+ */
+function determineLifetime(
+  statusCode,
+  headers,
+  cacheControlDirectives,
+  { heuristic, defaultTTL },
+  now,
+) {
+  const explicit = cacheControlDirectives['s-maxage'] ?? cacheControlDirectives['max-age']
+  if (explicit != null) {
+    return { lifetime: explicit, explicit: true }
+  }
+
+  if (headers.expires != null) {
+    // RFC 9111 §5.3: an invalid Expires (notably `Expires: 0`) means already
+    // expired — the parse failure must surface as lifetime 0, not fall through
+    // to heuristics. Arrays (duplicated, potentially conflicting Expires field
+    // lines) are treated the same way.
+    const expires = typeof headers.expires === 'string' ? parseHttpDate(headers.expires) : undefined
+    if (!expires) {
+      return { lifetime: 0, explicit: true }
+    }
+    const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+    return {
+      lifetime: Math.floor((expires.getTime() - (date ? date.getTime() : now)) / 1000),
+      explicit: true,
+    }
+  }
+
+  if (cacheControlDirectives.immutable) {
+    return { lifetime: IMMUTABLE_LIFETIME, explicit: false }
+  }
+
+  // Heuristic freshness and defaultTTL are per-request client opt-ins and
+  // deliberately restricted to plain 200s — heuristically extending 206/307
+  // would cache partials and temporary redirects without origin consent.
+  if (statusCode === 200) {
+    if (heuristic && typeof headers['last-modified'] === 'string') {
+      // RFC 9111 §4.2.2 suggested heuristic: 10% of time since Last-Modified.
+      // §4.2.2 forbids heuristics when an explicit expiration exists; Expires
+      // was handled (including the invalid form) above, so this is reached
+      // only when none does.
+      const lastModified = parseHttpDate(headers['last-modified'])
+      if (lastModified && lastModified.getTime() < now) {
+        return { lifetime: Math.floor((now - lastModified.getTime()) / 10 / 1000), explicit: false }
+      }
+    }
+    if (typeof defaultTTL === 'number' && defaultTTL > 0) {
+      return { lifetime: defaultTTL, explicit: false }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Corrected initial age in whole seconds per RFC 9111 §4.2.3 (simplified):
+ * the larger of the Age header and the apparent age (receipt time minus the
+ * origin Date). A response relayed through intermediaries that don't add Age
+ * would otherwise get an over-extended TTL and be served stale.
+ */
+function determineAge(headers, now) {
+  const rawAge = headers.age
+  // A duplicated Age header arrives as an array; take the first value like
+  // upstream — Number(array) would yield NaN and silently read as age 0.
+  const age = parseInt(Array.isArray(rawAge) ? rawAge[0] : rawAge, 10)
+  const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+  const apparentAge = date ? Math.max(0, Math.floor((now - date.getTime()) / 1000)) : 0
+  return Math.max(Number.isFinite(age) && age > 0 ? age : 0, apparentAge)
+}
+
+/**
+ * Computes the entry's absolute times, or null when it shouldn't be stored.
+ *
+ * cachedAt is backdated by the corrected initial age so all downstream age
+ * math (served Age header, freshness and request-directive checks) reduces to
+ * `now - cachedAt`; the origin Age header is stripped before storing to match.
+ *
+ * staleAt splits freshness from retention: entries are RETAINED past staleAt
+ * (deleteAt) so a stale hit can be revalidated with a conditional request
+ * instead of refetched in full. Retention is 2x the freshness lifetime
+ * (undici PR #4913's revalidation buffer), extended by stale-while-revalidate
+ * / stale-if-error windows (RFC 5861) and to REVALIDATION_RETENTION for
+ * validator-bearing entries; everything is capped by maxEntryTTL, measured
+ * from (backdated) cachedAt.
+ */
+function computeEntryTimes(
+  lifetime,
+  explicit,
+  age,
+  cacheControlDirectives,
+  maxEntryTTL,
+  hasValidator,
+  now,
+) {
+  if (!Number.isFinite(lifetime)) {
+    return null
+  }
+
+  const freshness = Math.min(lifetime, maxEntryTTL) // seconds; may be <= 0
+  if (freshness - age <= 0 && !(hasValidator && explicit)) {
+    // Stale on arrival and no cheap way to revalidate — not worth storing.
+    return null
+  }
+
+  const cachedAt = now - age * 1000
+  const staleAt = cachedAt + freshness * 1000
+
+  const swr = cacheControlDirectives['stale-while-revalidate']
+  const sie = cacheControlDirectives['stale-if-error']
+  const staleOffset = Math.max(freshness, 0)
+  let retention = staleOffset * 2
+  if (typeof swr === 'number' && swr > 0) {
+    retention = Math.max(retention, staleOffset + swr)
+  }
+  if (typeof sie === 'number' && sie > 0) {
+    retention = Math.max(retention, staleOffset + sie)
+  }
+  if (hasValidator && explicit) {
+    retention = Math.max(retention, age + REVALIDATION_RETENTION)
+  }
+  retention = Math.min(retention, maxEntryTTL)
+
+  const deleteAt = cachedAt + retention * 1000
+  if (deleteAt <= now) {
+    return null
+  }
+
+  return { cachedAt, staleAt, deleteAt }
+}
+
+/**
+ * RFC 9111 §5.2.2.2 / §5.2.2.8 (and undici PR #5511): must-revalidate and
+ * proxy-revalidate (we are a shared cache) veto every stale-serving path —
+ * max-stale, stale-while-revalidate and stale-if-error.
+ */
+function forbidsServingStale(entry) {
+  const directives = entry.cacheControlDirectives
+  return directives?.['must-revalidate'] === true || directives?.['proxy-revalidate'] === true
+}
+
+/**
+ * Conditional request headers for revalidating a stored entry (RFC 9111
+ * §4.3.1). Per RFC 9110 §13.1.3 and undici PR #5512, If-Modified-Since echoes
+ * the stored Last-Modified VERBATIM when available (nginx's default
+ * `if_modified_since exact` requires a byte-identical value), falling back to
+ * the response Date, then to the (backdated) receipt time.
+ *
+ * The stored vary values need no replay: the store only returns entries whose
+ * selecting headers already match this request.
+ */
+function conditionalHeaders(headers, entry) {
+  const condHeaders = { ...headers }
+  if (entry.etag) {
+    condHeaders['if-none-match'] = entry.etag
+  }
+  const lastModified = entry.headers?.['last-modified']
+  const date = entry.headers?.date
+  condHeaders['if-modified-since'] =
+    typeof lastModified === 'string'
+      ? lastModified
+      : typeof date === 'string'
+        ? date
+        : new Date(entry.cachedAt).toUTCString()
+  return condHeaders
+}
 
 class CacheHandler extends DecoratorHandler {
   #key
@@ -20,8 +212,10 @@ class CacheHandler extends DecoratorHandler {
   #logger
   #maxEntrySize
   #maxEntryTTL
+  #heuristic
+  #defaultTTL
 
-  constructor(key, { store, logger, handler, maxEntrySize, maxEntryTTL }) {
+  constructor(key, { store, logger, handler, maxEntrySize, maxEntryTTL, heuristic, defaultTTL }) {
     super(handler)
 
     this.#key = key
@@ -30,6 +224,8 @@ class CacheHandler extends DecoratorHandler {
     this.#store = store
     this.#maxEntrySize = maxEntrySize ?? store.maxEntrySize ?? DEFAULT_MAX_ENTRY_SIZE
     this.#maxEntryTTL = maxEntryTTL ?? store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL
+    this.#heuristic = heuristic ?? false
+    this.#defaultTTL = defaultTTL ?? null
   }
 
   onConnect(abort) {
@@ -94,11 +290,30 @@ class CacheHandler extends DecoratorHandler {
 
     const cacheControlDirectives = parseCacheControl(headers['cache-control']) ?? {}
 
-    if (this.#key.headers.authorization && !cacheControlDirectives.public) {
-      return super.onHeaders(statusCode, headers, resume)
+    // RFC 9111 §3.5: a shared cache may store a response to a request with
+    // Authorization only when the response explicitly allows it: public,
+    // s-maxage, or must-revalidate (safe because such entries are never
+    // served stale without successful revalidation). Must stay in lockstep
+    // with the serve-side gate in the interceptor below. A duplicated
+    // (array) authorization header is refused outright.
+    const authorization = this.#key.headers.authorization
+    if (authorization != null) {
+      if (
+        typeof authorization !== 'string' ||
+        !(
+          cacheControlDirectives.public === true ||
+          cacheControlDirectives['s-maxage'] != null ||
+          cacheControlDirectives['must-revalidate'] === true
+        )
+      ) {
+        return super.onHeaders(statusCode, headers, resume)
+      }
     }
 
-    if (cacheControlDirectives.private || cacheControlDirectives['no-store']) {
+    // Unqualified private forbids shared-cache storage entirely; the
+    // qualified form (private="field") only forbids storing the listed
+    // fields, which are stripped below (RFC 9111 §5.2.2.7).
+    if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -110,16 +325,11 @@ class CacheHandler extends DecoratorHandler {
       // Do nothing. We don't transform responses...
     }
 
-    if (
-      cacheControlDirectives['must-revalidate'] ||
-      cacheControlDirectives['proxy-revalidate'] ||
-      cacheControlDirectives['stale-while-revalidate'] ||
-      cacheControlDirectives['stale-if-error'] ||
-      cacheControlDirectives['no-cache']
-    ) {
-      // TODO (fix): Support all cache control directives...
-      return super.onHeaders(statusCode, headers, resume)
-    }
+    // must-revalidate / proxy-revalidate / unqualified no-cache /
+    // stale-while-revalidate / stale-if-error responses ARE stored: the
+    // directives constrain how the entry may be reused (validate first, never
+    // serve stale, ...), which the read path enforces from the persisted
+    // cacheControlDirectives.
 
     // Null prototype: selector names come from the response Vary header and
     // request header names are caller-controlled — on a plain `{}` a
@@ -144,26 +354,38 @@ class CacheHandler extends DecoratorHandler {
       }
     }
 
-    // RFC 8246: 'immutable' means the body won't change during the freshness
-    // lifetime — it does not define or extend that lifetime. An explicit
-    // s-maxage/max-age always wins; immutable only supplies a (long) default
-    // when no explicit lifetime is present. Capped by maxEntryTTL below.
-    const ttl = Number(
-      cacheControlDirectives['s-maxage'] ??
-        cacheControlDirectives['max-age'] ??
-        (cacheControlDirectives.immutable ? 31556952 : NaN),
+    const now = Date.now()
+
+    let lifetimeInfo = determineLifetime(
+      statusCode,
+      headers,
+      cacheControlDirectives,
+      { heuristic: this.#heuristic, defaultTTL: this.#defaultTTL },
+      now,
     )
-    if (!ttl || !Number.isFinite(ttl) || ttl <= 0) {
+    if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
+      // Store-and-revalidate (undici PR #5515): no expiration information at
+      // all, but unqualified no-cache plus a validator means every reuse can
+      // cost a 304 instead of a full 200.
+      lifetimeInfo = { lifetime: 0, explicit: true }
+    }
+    if (lifetimeInfo == null) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    // RFC 9111 §4.2.3: a response relayed by an upstream/shared cache may
-    // already be partway through its freshness lifetime. Subtract the
-    // advertised Age so we don't over-extend the TTL and serve stale content.
-    const age = Number(headers.age)
-    const lifetime = Math.min(ttl, this.#maxEntryTTL) - (Number.isFinite(age) && age > 0 ? age : 0)
-    if (lifetime <= 0) {
-      // Already stale on arrival — not worth caching.
+    const etag = typeof headers.etag === 'string' && isEtagUsable(headers.etag) ? headers.etag : ''
+    const hasValidator = etag !== '' || typeof headers['last-modified'] === 'string'
+    const age = determineAge(headers, now)
+    const times = computeEntryTimes(
+      lifetimeInfo.lifetime,
+      lifetimeInfo.explicit,
+      age,
+      cacheControlDirectives,
+      this.#maxEntryTTL,
+      hasValidator,
+      now,
+    )
+    if (times == null) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -175,7 +397,6 @@ class CacheHandler extends DecoratorHandler {
     const end = contentRange ? contentRange.end : this.#key.method === 'HEAD' ? 0 : contentLength
 
     if (end == null || end - start <= this.#maxEntrySize) {
-      const cachedAt = Date.now()
       // Snapshot the headers: the same object is delivered downstream to the
       // caller (request() resolves with it before the body finishes), and the
       // entry isn't serialized to the store until onComplete. Without a copy,
@@ -188,23 +409,58 @@ class CacheHandler extends DecoratorHandler {
       // plain `{}` a header literally named `__proto__` would hit the
       // Object.prototype setter instead of becoming a data property (silent
       // drop / prototype-pollution vector).
+      //
+      // Stripped while copying (RFC 9111 §3.1): hop-by-hop fields, fields
+      // listed in the Connection header, fields named by qualified
+      // no-cache=/private= directives (§5.2.2.4/§5.2.2.7), and Age — cachedAt
+      // is backdated by the corrected initial age, so the served Age is fully
+      // recomputed and a stored Age would double-count.
+      const excludedHeaders = new Set(['age'])
+      const connection = headers.connection
+      if (typeof connection === 'string') {
+        for (const name of connection.split(',')) {
+          excludedHeaders.add(name.trim().toLowerCase())
+        }
+      } else if (Array.isArray(connection)) {
+        for (const line of connection) {
+          for (const name of `${line}`.split(',')) {
+            excludedHeaders.add(name.trim().toLowerCase())
+          }
+        }
+      }
+      if (Array.isArray(cacheControlDirectives['no-cache'])) {
+        for (const name of cacheControlDirectives['no-cache']) {
+          excludedHeaders.add(name)
+        }
+      }
+      if (Array.isArray(cacheControlDirectives.private)) {
+        for (const name of cacheControlDirectives.private) {
+          excludedHeaders.add(name)
+        }
+      }
+
       const storedHeaders = Object.create(null)
       for (const name of Object.keys(headers)) {
+        if (isHopByHop(name) || excludedHeaders.has(name.toLowerCase())) {
+          continue
+        }
         const val = headers[name]
         storedHeaders[name] = Array.isArray(val) ? val.slice() : val
       }
+
       this.#value = {
         body: [],
         start,
         end,
-        deleteAt: cachedAt + lifetime * 1e3,
+        cachedAt: times.cachedAt,
+        staleAt: times.staleAt,
+        deleteAt: times.deleteAt,
         statusCode,
         statusMessage: '',
         headers: storedHeaders,
         cacheControlDirectives,
-        etag: isEtagUsable(headers.etag) ? headers.etag : '',
+        etag,
         vary,
-        cachedAt,
         // Handler state.
         size: 0,
       }
@@ -246,24 +502,423 @@ class CacheHandler extends DecoratorHandler {
   }
 }
 
-export default () => (dispatch) => (opts, handler) => {
-  if (!opts.cache || opts.upgrade) {
-    return dispatch(opts, handler)
+/**
+ * Drives a conditional (revalidation) request to the origin for a stale
+ * stored entry (RFC 9111 §4.3). Decision at response headers:
+ * - 304: the entry is valid — freshen it (§4.3.4) and serve it.
+ * - 5xx within the stale-if-error window (RFC 5861 §4, incl. undici PR
+ *   #5513's pre-response connection errors): discard the error and serve the
+ *   stale entry.
+ * - anything else: a real replacement — stream it through a CacheHandler to
+ *   the user handler, storing it on the way.
+ *
+ * The user handler's response callbacks are DEFERRED until that decision, but
+ * onConnect is forwarded eagerly with a bridging abort — the user (e.g. a
+ * signal listener in request()) must be able to tear down the in-flight
+ * conditional request; nothing below the cache observes opts.signal
+ * mid-flight. Delivery paths re-invoke onConnect (serveFromCache / the pass
+ * CacheHandler drive their own connect), which handlers in this pipeline
+ * already tolerate — the retry interceptor re-connects the same handler on
+ * every attempt.
+ */
+class RevalidationHandler {
+  #key
+  #entry
+  #store
+  #logger
+  #opts
+  #cacheOpts
+  #userHandler
+  #allowStaleOnError
+  #noStore
+  /** @type {null | 'pass' | 'validated' | 'stale'} */
+  #mode = null
+  /** @type {CacheHandler | import('../utils.js').DecoratorHandler | object | null} */
+  #inner = null
+  /** @type {((reason?: any) => void) | null} */
+  #abort = null
+  /** @type {Record<string, string | string[]> | null} */
+  #headers304 = null
+  #delivered = false
+  #userAborted = false
+  #userAbortReason = null
+
+  constructor(key, entry, opts, { store, logger, handler, allowStaleOnError, noStore, cacheOpts }) {
+    this.#key = key
+    this.#entry = entry
+    this.#store = store
+    this.#logger = logger
+    this.#opts = opts
+    this.#cacheOpts = cacheOpts
+    this.#userHandler = handler
+    this.#allowStaleOnError = allowStaleOnError
+    this.#noStore = noStore ?? false
   }
 
-  if (opts.method !== 'GET' && opts.method !== 'HEAD') {
-    return dispatch(opts, handler)
+  onConnect(abort) {
+    this.#abort = abort
+    // Eager connect: hand the user a bridging abort so a caller abort (e.g.
+    // a signal firing in request()) tears down the in-flight conditional
+    // request instead of being silently ignored until the origin answers.
+    this.#userHandler.onConnect((reason) => {
+      if (!this.#delivered && !this.#userAborted) {
+        this.#userAborted = true
+        this.#userAbortReason = reason
+        this.#abort?.(reason)
+      }
+    })
   }
 
-  // TODO (fix): enable range requests
+  onUpgrade(statusCode, headers, socket) {
+    // Upgrades are gated out before the cache interceptor engages; nothing to
+    // do but not crash if one slips through.
+    socket?.destroy?.()
+  }
 
+  onHeaders(statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // Informational (1xx) interim responses — e.g. 103 Early Hints — are
+      // not the revalidation answer; stay undecided and keep reading.
+      return true
+    }
+
+    if (statusCode === 304) {
+      this.#mode = 'validated'
+      this.#headers304 = headers
+      return true
+    }
+
+    if (this.#allowStaleOnError && statusCode >= 500 && statusCode <= 504) {
+      this.#mode = 'stale'
+      // Drain and discard the error body.
+      return true
+    }
+
+    this.#mode = 'pass'
+    // RFC 9111 §5.2.1.5: a request no-store forbids storing the replacement
+    // response — stream it to the user handler without the CacheHandler wrap.
+    this.#inner = this.#noStore
+      ? this.#userHandler
+      : new CacheHandler(this.#key, {
+          ...this.#cacheOpts,
+          store: this.#store,
+          logger: this.#logger,
+          handler: this.#userHandler,
+        })
+    this.#inner.onConnect((reason) => this.#abort?.(reason))
+    return this.#inner.onHeaders(statusCode, headers, resume)
+  }
+
+  onData(chunk) {
+    return this.#mode === 'pass' ? this.#inner.onData(chunk) : true
+  }
+
+  onComplete(trailers) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onComplete(trailers)
+    }
+    // Freshen even when the user aborted mid-flight — the 304 validated the
+    // entry either way, and the store write benefits every other caller.
+    this.#deliver(this.#mode === 'validated' ? this.#freshen() : this.#entry)
+  }
+
+  onError(err) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onError(err)
+    }
+    if (this.#userAborted) {
+      // The (probable) cause of this error is the user's own abort — a
+      // stale-if-error serve would convert their cancellation into a
+      // successful response.
+      return this.#fail(this.#userAbortReason ?? err)
+    }
+    if (this.#mode === 'validated') {
+      // The 304 already validated the entry; a broken tail on the (empty)
+      // validation response doesn't invalidate it.
+      return this.#deliver(this.#freshen())
+    }
+    if (this.#mode === 'stale' || this.#allowStaleOnError) {
+      // Pre-response connection errors (ECONNREFUSED, reset, ...) count as
+      // origin errors for stale-if-error — RFC 5861's definition explicitly
+      // covers an unreachable origin (undici PR #5513). Mid-body failures of
+      // a replacement response are 'pass' mode and propagate above.
+      return this.#deliver(this.#entry)
+    }
+    this.#fail(err)
+  }
+
+  #deliver(entry) {
+    if (this.#delivered) {
+      return
+    }
+    this.#delivered = true
+    if (this.#userAborted) {
+      this.#userHandler.onError(this.#userAbortReason ?? new Error('aborted'))
+    } else {
+      serveFromCache(entry, this.#opts, this.#userHandler)
+    }
+  }
+
+  #fail(err) {
+    if (!this.#delivered) {
+      this.#delivered = true
+      this.#userHandler.onError(err)
+    }
+  }
+
+  /**
+   * RFC 9111 §4.3.4: merge the 304's headers over the stored ones and reset
+   * the freshness clock. Returns the entry to serve; the store is only
+   * updated when the merged response is still storable.
+   */
+  #freshen() {
+    const entry = this.#entry
+    const headers304 = this.#headers304 ?? {}
+    try {
+      const now = Date.now()
+
+      // Same exclusions as at store time — hop-by-hop, fields listed in the
+      // 304's Connection header — plus Set-Cookie (must never enter a shared
+      // entry) and the body-describing fields, for which the stored body is
+      // authoritative.
+      const excludedHeaders = new Set(['age', 'set-cookie', 'content-length', 'content-range'])
+      const connection = headers304.connection
+      if (typeof connection === 'string') {
+        for (const name of connection.split(',')) {
+          excludedHeaders.add(name.trim().toLowerCase())
+        }
+      } else if (Array.isArray(connection)) {
+        for (const line of connection) {
+          for (const name of `${line}`.split(',')) {
+            excludedHeaders.add(name.trim().toLowerCase())
+          }
+        }
+      }
+
+      const merged = Object.create(null)
+      for (const name of Object.keys(entry.headers ?? {})) {
+        merged[name] = entry.headers[name]
+      }
+      for (const name of Object.keys(headers304)) {
+        const lower = name.toLowerCase()
+        if (isHopByHop(lower) || excludedHeaders.has(lower)) {
+          continue
+        }
+        const val = headers304[name]
+        merged[lower] = Array.isArray(val) ? val.slice() : val
+      }
+
+      // RFC 9110 §6.6.1: a 304 without a Date header is assigned the receipt
+      // time. Without this, the stored (old) Date drives the corrected age
+      // below and the freshened entry lands stale-on-arrival — permanently
+      // revalidating on every hit despite the origin granting freshness.
+      if (headers304.date == null) {
+        merged.date = new Date(now).toUTCString()
+      }
+
+      const cacheControlDirectives = parseCacheControl(merged['cache-control']) ?? {}
+      if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
+        // The origin has withdrawn (shared-)cacheability: serve this one
+        // validated use, but don't freshen the stored entry — it stays stale
+        // and keeps revalidating until it ages out.
+        return { ...entry, headers: merged }
+      }
+
+      // Qualified no-cache=/private= field lists (possibly newly added by
+      // the 304) must not survive in the stored — or served — headers, even
+      // when the named field came from the original stored response.
+      for (const directive of ['no-cache', 'private']) {
+        if (Array.isArray(cacheControlDirectives[directive])) {
+          for (const name of cacheControlDirectives[directive]) {
+            delete merged[name]
+          }
+        }
+      }
+
+      const etag =
+        typeof merged.etag === 'string' && isEtagUsable(merged.etag)
+          ? merged.etag
+          : (entry.etag ?? '')
+      const hasValidator = etag !== '' || typeof merged['last-modified'] === 'string'
+
+      let lifetimeInfo = determineLifetime(
+        entry.statusCode,
+        merged,
+        cacheControlDirectives,
+        this.#cacheOpts,
+        now,
+      )
+      if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
+        lifetimeInfo = { lifetime: 0, explicit: true }
+      }
+      if (lifetimeInfo == null) {
+        return { ...entry, headers: merged }
+      }
+
+      // Clamp the corrected age to the stored entry's own current age
+      // (now - cachedAt already includes the original initial age, RFC 9111
+      // §4.2.3): a skewed/old Date on the 304 must not push the freshened
+      // entry further into the past than the response it just validated.
+      const age = Math.min(
+        determineAge(merged, now),
+        Math.max(0, Math.floor((now - entry.cachedAt) / 1000)),
+      )
+      const times = computeEntryTimes(
+        lifetimeInfo.lifetime,
+        lifetimeInfo.explicit,
+        age,
+        cacheControlDirectives,
+        this.#cacheOpts.maxEntryTTL ?? this.#store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL,
+        hasValidator,
+        now,
+      )
+      if (times == null) {
+        return { ...entry, headers: merged }
+      }
+
+      const freshened = {
+        // 206 entries never take the revalidation path, so the stored body is
+        // the full representation: start 0, end = byte length (0 for HEAD).
+        body: entry.body ?? null,
+        start: 0,
+        end: entry.body ? entry.body.byteLength : 0,
+        statusCode: entry.statusCode,
+        statusMessage: entry.statusMessage ?? '',
+        headers: merged,
+        cacheControlDirectives,
+        etag,
+        vary: entry.vary,
+        cachedAt: times.cachedAt,
+        staleAt: times.staleAt,
+        deleteAt: times.deleteAt,
+      }
+
+      // RFC 9111 §5.2.1.5: a request no-store forbids storing any part of
+      // this request's response — serve the freshened value, don't write it.
+      if (!this.#noStore) {
+        try {
+          this.#store.set(this.#key, freshened)
+        } catch (err) {
+          if (err.message === 'database is locked') {
+            this.#logger?.debug({ err }, 'failed to freshen cache entry')
+          } else {
+            this.#logger?.error({ err }, 'failed to freshen cache entry')
+          }
+        }
+      }
+
+      return freshened
+    } catch (err) {
+      // Freshening must never break delivery of a validated entry.
+      this.#logger?.error({ err }, 'failed to freshen cache entry')
+      return entry
+    }
+  }
+}
+
+/**
+ * RFC 9111 §4.4: a non-error response to an unsafe method invalidates the
+ * stored entries for the target URI and any same-origin Location /
+ * Content-Location URIs (undici PR #5514). Cross-origin targets are skipped —
+ * honoring an attacker-influenced Location against another origin's entries
+ * would be a cache-poisoning vector.
+ */
+class InvalidationHandler extends DecoratorHandler {
+  #key
+  #store
+  #logger
+
+  constructor(key, { store, logger, handler }) {
+    super(handler)
+    this.#key = key
+    this.#store = store
+    this.#logger = logger
+  }
+
+  onHeaders(statusCode, headers, resume) {
+    if (statusCode >= 200 && statusCode <= 399) {
+      // Invalidation failures must never break the actual response. Deletes
+      // are idempotent, so a retry re-driving onHeaders is harmless.
+      try {
+        this.#invalidate(headers)
+      } catch (err) {
+        if (err.message === 'database is locked') {
+          this.#logger?.debug({ err }, 'failed to invalidate cache entry')
+        } else {
+          this.#logger?.error({ err }, 'failed to invalidate cache entry')
+        }
+      }
+    }
+    return super.onHeaders(statusCode, headers, resume)
+  }
+
+  #invalidate(headers) {
+    this.#store.delete(this.#key)
+
+    const invalidated = new Set([this.#key.path])
+    let base
+    for (const name of ['location', 'content-location']) {
+      let value = headers[name]
+      if (Array.isArray(value)) {
+        value = value[0]
+      }
+      if (typeof value !== 'string' || value === '') {
+        continue
+      }
+
+      base ??= new URL(this.#key.path, this.#key.origin)
+      let target
+      try {
+        target = new URL(value, base)
+      } catch {
+        continue
+      }
+      if (target.origin !== base.origin) {
+        continue
+      }
+
+      const path = target.pathname + target.search
+      if (!invalidated.has(path)) {
+        invalidated.add(path)
+        this.#store.delete({ ...this.#key, path })
+      }
+    }
+  }
+}
+
+function getStore(opts) {
+  return opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
+}
+
+function tryGetEntry(store, key, logger) {
+  try {
+    return store.get(key)
+  } catch (err) {
+    if (err.message === 'database is locked') {
+      // Database is busy. We don't bother trying again...
+      logger?.debug({ err }, 'failed to get cache entry')
+    } else {
+      logger?.error({ err }, 'failed to get cache entry')
+    }
+  }
+}
+
+/**
+ * Builds the cache key shared by the get and set paths.
+ */
+function makeKey(opts) {
   // Build the key the same way for lookups and stores: makeCacheKey
   // stringifies the origin (e.g. URL objects), so using raw opts on the get
   // path while the set path normalizes would make the cache permanently miss.
-  const key = undici.util.cache.makeCacheKey(opts)
+  // The flat name/value array form of opts.headers (legal at the undici
+  // client level) makes makeCacheKey throw — normalize it through
+  // parseHeaders first (which also lowercases the names).
+  const key = undici.util.cache.makeCacheKey(
+    Array.isArray(opts.headers) ? { ...opts, headers: parseHeaders(opts.headers) } : opts,
+  )
 
   // makeCacheKey preserves request header names verbatim. Vary selector names
-  // are lowercased (in onHeaders and matchesValue), so lowercase the key's
+  // are lowercased (in CacheHandler and matchesValue), so lowercase the key's
   // header names once here — the same key feeds both the get and set paths, so
   // this keeps Vary matching symmetric even when a caller supplies non-lowercase
   // header names (the standalone interceptors.cache() composition; the wrapped
@@ -279,6 +934,122 @@ export default () => (dispatch) => (opts, handler) => {
     key.headers = lower
   }
 
+  // The vendored makeCacheKey ignores opts.query. The wrapped pipeline is
+  // immune (the query interceptor rewrites path before the cache sees it),
+  // but a standalone interceptors.cache() composition would silently collide
+  // distinct query strings onto one entry and serve the wrong response
+  // (undici issue #4209 / PR #5081) — fold the query into the key path.
+  if (
+    opts.query &&
+    typeof key.path === 'string' &&
+    !key.path.includes('?') &&
+    !key.path.includes('#')
+  ) {
+    const qs = stringify(opts.query)
+    if (qs) {
+      key.path = `${key.path || '/'}?${qs}`
+    }
+  }
+
+  return key
+}
+
+function cacheOptsOf(opts) {
+  return {
+    maxEntrySize: opts.cache.maxEntrySize,
+    maxEntryTTL: opts.cache.maxEntryTTL,
+    heuristic: opts.cache.heuristic,
+    defaultTTL: opts.cache.defaultTTL,
+  }
+}
+
+/**
+ * Fire-and-forget background refresh for stale-while-revalidate (RFC 5861
+ * §3): the caller was already served the stale entry; only the store observes
+ * the outcome. Re-enters the dispatch chain below the cache interceptor.
+ */
+function backgroundRefresh(dispatch, opts, key, store, entry) {
+  const refreshKey = `${key.method}:${key.origin}${key.path}`
+  if (backgroundRefreshes.has(refreshKey)) {
+    return
+  }
+  backgroundRefreshes.add(refreshKey)
+
+  let finished = false
+  const done = () => {
+    if (!finished) {
+      finished = true
+      backgroundRefreshes.delete(refreshKey)
+    }
+  }
+
+  const silentHandler = {
+    onConnect: NOOP,
+    onHeaders: () => true,
+    onData: () => true,
+    onComplete: done,
+    onError: (err) => {
+      done()
+      opts.logger?.debug({ err }, 'cache: background revalidation failed')
+    },
+  }
+
+  try {
+    // Strip caller-specific request state: the body (already consumed or
+    // owned by the caller) and the signal (a caller abort after being served
+    // stale must not kill the shared refresh).
+    const bgOpts = {
+      ...opts,
+      headers: conditionalHeaders(key.headers ?? {}, entry),
+      body: null,
+      signal: undefined,
+    }
+    dispatch(
+      bgOpts,
+      new RevalidationHandler(key, entry, bgOpts, {
+        store,
+        logger: opts.logger,
+        handler: silentHandler,
+        allowStaleOnError: false,
+        noStore: false,
+        cacheOpts: cacheOptsOf(opts),
+      }),
+    )
+  } catch (err) {
+    done()
+    opts.logger?.debug({ err }, 'cache: background revalidation failed')
+  }
+}
+
+export default () => (dispatch) => (opts, handler) => {
+  if (!opts.cache || opts.upgrade) {
+    return dispatch(opts, handler)
+  }
+
+  if (opts.method !== 'GET' && opts.method !== 'HEAD') {
+    // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
+    // must not invalidate either. Every other method (POST/PUT/DELETE/...)
+    // invalidates the target URI on a non-error response (RFC 9111 §4.4).
+    if (opts.method === 'OPTIONS' || opts.method === 'TRACE') {
+      return dispatch(opts, handler)
+    }
+
+    const store = getStore(opts)
+    if (typeof store.delete !== 'function') {
+      // User-supplied store without invalidation support.
+      return dispatch(opts, handler)
+    }
+
+    return dispatch(
+      opts,
+      new InvalidationHandler(makeKey(opts), { store, logger: opts.logger, handler }),
+    )
+  }
+
+  // TODO (fix): enable range requests
+
+  const key = makeKey(opts)
+
   // All request-directive and conditional-header guards below MUST read from
   // the lowercased key.headers, not raw opts.headers — otherwise a caller
   // supplying capitalized names (e.g. `Authorization`, `Cache-Control` via the
@@ -287,67 +1058,81 @@ export default () => (dispatch) => (opts, handler) => {
   // cached response to an authorized request (RFC 9111 §3.5).
   const headers = key.headers ?? {}
 
-  // Cache-Control is a list-typed field: duplicated field lines arrive as an
-  // array and combine into a single comma-separated value per RFC 9110 §5.2,
-  // keeping the raw-string directive checks below working.
-  let rawCacheControl = headers['cache-control']
-  if (Array.isArray(rawCacheControl)) {
-    rawCacheControl = rawCacheControl.join(', ')
-  }
-  const cacheControlDirectives = parseCacheControl(rawCacheControl) ?? {}
-  // cache-control-parser does not recognise 'only-if-cached', so check the raw string.
-  const onlyIfCached =
-    typeof rawCacheControl === 'string' && rawCacheControl.includes('only-if-cached')
+  const rawCacheControl = headers['cache-control']
+  const requestCacheControl = parseCacheControl(rawCacheControl) ?? {}
 
   // RFC 9111 Section 5.4: Pragma: no-cache should be treated as
   // Cache-Control: no-cache when Cache-Control is absent.
   if (rawCacheControl == null && headers.pragma === 'no-cache') {
-    cacheControlDirectives['no-cache'] = true
+    requestCacheControl['no-cache'] = true
   }
 
-  if (cacheControlDirectives['no-transform']) {
+  if (requestCacheControl['no-transform']) {
     // Do nothing. We don't transform requests...
   }
 
-  if (
-    // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
-    cacheControlDirectives['max-age'] != null ||
-    cacheControlDirectives['no-cache'] ||
-    cacheControlDirectives['stale-if-error'] != null ||
-    // cache-control-parser does not recognise 'max-stale'/'min-fresh', so
-    // check the raw string like we do for 'only-if-cached'.
-    (typeof rawCacheControl === 'string' &&
-      (rawCacheControl.includes('max-stale') || rawCacheControl.includes('min-fresh')))
-  ) {
-    // TODO (fix): Support all cache control directives...
-    return dispatch(opts, handler)
-  }
+  const onlyIfCached = requestCacheControl['only-if-cached'] === true
+  const store = getStore(opts)
 
-  const store =
-    opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
+  let entry = tryGetEntry(store, key, opts.logger)
 
-  let entry
-  try {
-    entry = store.get(key)
-  } catch (err) {
-    if (err.message === 'database is locked') {
-      // Database is busy. We don't bother trying again...
-      opts.logger?.debug({ err }, 'failed to get cache entry')
-    } else {
-      opts.logger?.error({ err }, 'failed to get cache entry')
+  // RFC 9111 §3.5 serve-side authorization gate: a shared cache must not
+  // reuse a stored response for a request with Authorization unless the
+  // response allowed it (public, s-maxage or must-revalidate — the mirror of
+  // the store-side gate in CacheHandler; both sites must stay in lockstep).
+  if (entry && headers.authorization != null) {
+    const directives = entry.cacheControlDirectives
+    if (
+      typeof headers.authorization !== 'string' ||
+      !(
+        directives?.public === true ||
+        directives?.['s-maxage'] != null ||
+        directives?.['must-revalidate'] === true
+      )
+    ) {
+      entry = undefined
     }
   }
 
-  // RFC 9111 Section 3.5: A shared cache must not use a cached response to a
-  // request with Authorization unless the response includes a public directive.
-  if (entry && headers.authorization && !entry.cacheControlDirectives?.public) {
-    entry = undefined
-  }
+  // Freshness for THIS request: the entry's staleAt, tightened by the
+  // caller's max-age / min-fresh (RFC 9111 §5.2.1.1 / §5.2.1.3). Date.now()
+  // rather than getFastNow(): zero-TTL revalidation entries (staleAt ==
+  // cachedAt) would read as fresh for up to a second on the lagging clock.
+  //
+  // requestAccepts is tracked separately from origin freshness because it
+  // constrains EVERY serving path below, including the stale-serving windows
+  // (max-stale, stale-while-revalidate, stale-if-error): those directives
+  // relax the response-computed staleness bound, they must not un-reject an
+  // entry the caller's own age bounds refused — otherwise an origin emitting
+  // stale-while-revalidate would silently disable clients' max-age=0.
+  const now = Date.now()
+  const requestAccepts =
+    entry == null ||
+    // `!= null`: max-age=0 parses to 0 (falsy) but still demands a response
+    // no older than 0 seconds.
+    ((requestCacheControl['max-age'] == null ||
+      (now - entry.cachedAt) / 1000 < requestCacheControl['max-age']) &&
+      (requestCacheControl['min-fresh'] == null ||
+        entry.staleAt - now > requestCacheControl['min-fresh'] * 1000))
+  const fresh = entry != null && now < entry.staleAt && requestAccepts
 
-  // RFC 9110 Section 13: Evaluate conditional request headers against cached entry.
+  // Validation demanded regardless of freshness: the request's no-cache (or
+  // Pragma), or the stored response's unqualified no-cache (§5.2.2.4).
+  const mustRevalidate =
+    entry != null &&
+    (requestCacheControl['no-cache'] === true ||
+      entry.cacheControlDirectives?.['no-cache'] === true)
+
+  // RFC 9110 Section 13: Evaluate conditional request headers against cached
+  // entry — only against a FRESH entry that doesn't demand validation;
+  // answering 304 from a stale entry without validating would violate RFC
+  // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
+  // where the caller's own validators do the validation (a 304 flows through
+  // to the caller; a 200 replacement is stored by CacheHandler).
   // typeof guards: duplicated conditional headers arrive as arrays — treat
   // them as non-matching and bypass to origin rather than crashing.
-  if (entry && headers['if-none-match']) {
+  const servableFromCache = entry != null && fresh && !mustRevalidate
+  if (servableFromCache && headers['if-none-match']) {
     if (
       typeof headers['if-none-match'] === 'string' &&
       entry.etag &&
@@ -361,7 +1146,7 @@ export default () => (dispatch) => (opts, handler) => {
     }
     // Etag didn't match — bypass to origin.
     entry = undefined
-  } else if (entry && headers['if-modified-since']) {
+  } else if (servableFromCache && headers['if-modified-since']) {
     const lastModified = entry.headers?.['last-modified']
     if (
       typeof headers['if-modified-since'] === 'string' &&
@@ -376,6 +1161,8 @@ export default () => (dispatch) => (opts, handler) => {
     }
     // No last-modified or modified since — bypass to origin.
     entry = undefined
+  } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
+    entry = undefined
   }
 
   if (headers['if-match'] || headers['if-unmodified-since'] || headers['if-range']) {
@@ -383,22 +1170,101 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  if (!entry && !onlyIfCached) {
-    return dispatch(
-      opts,
-      cacheControlDirectives['no-store']
-        ? handler
-        : new CacheHandler(key, {
-            maxEntrySize: opts.cache.maxEntrySize,
-            maxEntryTTL: opts.cache.maxEntryTTL,
-            store,
-            logger: opts.logger,
-            handler,
-          }),
-    )
+  const cacheHandler = () =>
+    new CacheHandler(key, {
+      ...cacheOptsOf(opts),
+      store,
+      logger: opts.logger,
+      handler,
+    })
+
+  if (!entry) {
+    if (onlyIfCached) {
+      // RFC 9111 §5.2.1.7: no stored response usable without contacting the
+      // origin — 504.
+      return serveFromCache({ statusCode: 504 }, opts, handler)
+    }
+    // Request directives (no-cache, max-age, ...) constrain REUSE of a stored
+    // response, not storage of a fresh one (undici PR #5510): every miss path
+    // keeps the CacheHandler write-back so one client's freshness override
+    // doesn't disable caching of the URL for everyone. Only the request's
+    // no-store forbids storing.
+    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
   }
 
-  return serveFromCache(entry ?? { statusCode: 504 }, opts, handler)
+  if (fresh && !mustRevalidate) {
+    return serveFromCache(entry, opts, handler)
+  }
+
+  // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
+  // max-stale parses to Infinity: any staleness) — vetoed by the response's
+  // must-revalidate/proxy-revalidate (§5.2.2.2) and by the caller's own
+  // max-age/min-fresh bounds (requestAccepts).
+  if (
+    !mustRevalidate &&
+    requestAccepts &&
+    requestCacheControl['max-stale'] != null &&
+    !forbidsServingStale(entry) &&
+    now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
+  ) {
+    return serveFromCache(entry, opts, handler)
+  }
+
+  if (onlyIfCached) {
+    // Stale (or validation-demanding) entry and the origin is off-limits.
+    return serveFromCache({ statusCode: 504 }, opts, handler)
+  }
+
+  if (entry.statusCode === 206) {
+    // Range entries can't be revalidated as a whole representation — refetch.
+    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
+  }
+
+  // RFC 5861 §3 stale-while-revalidate: serve the stale entry immediately and
+  // refresh in the background — unless validation is demanded, the response
+  // forbids serving stale, or the caller's own max-age/min-fresh bounds
+  // rejected the entry (they demand a validated/younger response NOW).
+  if (
+    !mustRevalidate &&
+    requestAccepts &&
+    !forbidsServingStale(entry) &&
+    typeof entry.cacheControlDirectives?.['stale-while-revalidate'] === 'number' &&
+    now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
+  ) {
+    try {
+      serveFromCache(entry, opts, handler)
+    } finally {
+      backgroundRefresh(dispatch, opts, key, store, entry)
+    }
+    return
+  }
+
+  // Synchronous revalidation (RFC 9111 §4.3): conditional request; 304
+  // freshens and serves the entry, an error within the stale-if-error window
+  // (RFC 5861 §4: response directive first, request directive fallback —
+  // vetoed by must-revalidate/proxy-revalidate) serves the stale entry, and
+  // anything else replaces it.
+  const staleIfError =
+    entry.cacheControlDirectives?.['stale-if-error'] ?? requestCacheControl['stale-if-error']
+  const allowStaleOnError =
+    !mustRevalidate &&
+    requestAccepts &&
+    !forbidsServingStale(entry) &&
+    typeof staleIfError === 'number' &&
+    staleIfError > 0 &&
+    now <= entry.staleAt + staleIfError * 1000
+
+  return dispatch(
+    { ...opts, headers: conditionalHeaders(headers, entry) },
+    new RevalidationHandler(key, entry, opts, {
+      store,
+      logger: opts.logger,
+      handler,
+      allowStaleOnError,
+      noStore: requestCacheControl['no-store'] === true,
+      cacheOpts: cacheOptsOf(opts),
+    }),
+  )
 }
 
 function serveFromCache(entry, opts, handler) {
@@ -406,13 +1272,13 @@ function serveFromCache(entry, opts, handler) {
 
   let headers = entry.headers
   if (entry.cachedAt != null) {
-    // RFC 9111 §5.1: every response served from cache must carry an Age header
-    // reflecting time spent in this cache plus any age it arrived with —
-    // otherwise downstream caches treat it as fresh-from-origin.
-    // getFastNow has 1s resolution — Age is whole seconds, so that's enough.
-    const residentAge = Math.max(0, Math.floor((getFastNow() - entry.cachedAt) / 1000))
-    const originAge = Number(headers?.age)
-    const age = Number.isFinite(originAge) && originAge > 0 ? originAge + residentAge : residentAge
+    // RFC 9111 §5.1: every response served from cache must carry an Age
+    // header. cachedAt is backdated by the corrected initial age at store
+    // time (§4.2.3) and the origin's Age header is stripped, so resident time
+    // IS the response's age — no origin-Age addition. Date.now(), not
+    // getFastNow(): the lagging clock would understate a relayed response's
+    // initial age by up to a second.
+    const age = Math.max(0, Math.floor((Date.now() - entry.cachedAt) / 1000))
     headers = { ...headers, age: `${age}` }
   }
 

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -108,10 +108,13 @@ function eqiLower(a, b) {
 // allocation-free and letting the common (non-hop) header bail out in a single
 // comparison.
 /**
+ * Exported for reuse by the cache interceptor: RFC 9111 §3.1 forbids storing
+ * hop-by-hop fields, which is the same set a proxy must not retransmit.
+ *
  * @param {string} key
  * @returns {boolean}
  */
-function isHopByHop(key) {
+export function isHopByHop(key) {
   switch (key.length) {
     case 2:
       return eqiLower(key, 'te')

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
-const VERSION = 10
+const VERSION = 11
 
 // Registry of live stores so process-level broadcasts (nxt:offPeak,
 // nxt:clearCache) can reach them. Stores are held via WeakRef so that a store
@@ -51,8 +51,9 @@ function forEachStore(fn) {
 }
 
 /**
- * @typedef {import('undici-types/cache-interceptor.d.ts').default.CacheStore} CacheStore
- * @implements {CacheStore}
+ * Synchronous get/set/delete cache store backed by node:sqlite. Note: this is
+ * NOT undici's stream-based CacheStore interface (createWriteStream); the
+ * cache interceptor in this package drives it directly.
  *
  * @typedef {{
  *  id: Readonly<number>,
@@ -66,6 +67,7 @@ function forEachStore(fn) {
  *  etag?: string
  *  cacheControlDirectives?: string
  *  cachedAt: number
+ *  staleAt: number
  *  deleteAt: number
  * }} SqliteStoreValue
  */
@@ -99,6 +101,21 @@ export class SqliteCacheStore {
    * @type {import('node:sqlite').StatementSync}
    */
   #evictQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #deleteByUrlQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #supersedeFullQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #supersede206Query
 
   #insertBatch = []
   #insertSeq = 0
@@ -136,6 +153,7 @@ export class SqliteCacheStore {
         body BLOB NULL,
         start INTEGER NOT NULL,
         end INTEGER NOT NULL,
+        staleAt INTEGER NOT NULL,
         deleteAt INTEGER NOT NULL,
         statusCode INTEGER NOT NULL,
         statusMessage TEXT NOT NULL,
@@ -200,6 +218,7 @@ export class SqliteCacheStore {
         body,
         start,
         end,
+        staleAt,
         deleteAt,
         statusCode,
         statusMessage,
@@ -215,7 +234,7 @@ export class SqliteCacheStore {
         AND start <= ?
         AND deleteAt > ?
       ORDER BY
-        cachedAt DESC, id DESC
+        id DESC
     `)
 
     this.#insertValueQuery = this.#db.prepare(`
@@ -225,6 +244,7 @@ export class SqliteCacheStore {
         body,
         start,
         end,
+        staleAt,
         deleteAt,
         statusCode,
         statusMessage,
@@ -233,7 +253,7 @@ export class SqliteCacheStore {
         cacheControlDirectives,
         vary,
         cachedAt
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     this.#deleteExpiredValuesQuery = this.#db.prepare(
@@ -244,6 +264,35 @@ export class SqliteCacheStore {
     // without requiring expired entries to already exist.
     this.#evictQuery = this.#db.prepare(
       `DELETE FROM cacheInterceptorV${VERSION} WHERE id IN (SELECT id FROM cacheInterceptorV${VERSION} ORDER BY deleteAt ASC LIMIT ?)`,
+    )
+
+    // RFC 9111 §4.4 invalidation: a successful unsafe request invalidates every
+    // stored response for the URI, across methods and vary variants.
+    this.#deleteByUrlQuery = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ?`,
+    )
+
+    // Supersede queries: a newly flushed row replaces prior rows for the same
+    // representation so hot keys don't accumulate dead duplicates until gc.
+    // Receipt order (insertion order), NOT cachedAt, decides who wins — the
+    // same semantics as upstream undici's update-in-place set(). cachedAt is
+    // backdated by the corrected initial age (RFC 9111 §4.2.3), so a
+    // replacement fetched through a relay advertising a large Age (or a 304
+    // freshening with a skewed origin Date) can carry an OLDER cachedAt than
+    // the stale row it replaces; keying supersede or the read sort on
+    // cachedAt would let the stale row win every read, forever. `vary IS ?`
+    // is NULL-safe and compares the serialized-JSON text, deterministic
+    // because both sides are produced by the same CacheHandler code path
+    // (key order = Vary header order). A new full (non-206) representation
+    // supersedes all prior full ones regardless of byte window; a 206 only
+    // supersedes the exact same window so distinct partials coexist, and
+    // never a 200 row (matchesValue routes range and non-range requests to
+    // different rows).
+    this.#supersedeFullQuery = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ? AND method = ? AND vary IS ? AND statusCode != 206`,
+    )
+    this.#supersede206Query = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ? AND method = ? AND vary IS ? AND statusCode = 206 AND start = ? AND end = ?`,
     )
 
     this.#ref = new WeakRef(this)
@@ -371,7 +420,7 @@ export class SqliteCacheStore {
       setImmediate(this.#flush)
     }
 
-    this.#insertBatch.push({
+    const entry = {
       // Monotonic per-store sequence used only to break cachedAt ties in
       // #findValue (newest write wins). Not persisted — #flush ignores it.
       seq: this.#insertSeq++,
@@ -380,6 +429,7 @@ export class SqliteCacheStore {
       body,
       start: value.start,
       end: value.end,
+      staleAt: value.staleAt,
       deleteAt: value.deleteAt,
       statusCode: value.statusCode,
       statusMessage: value.statusMessage,
@@ -390,7 +440,56 @@ export class SqliteCacheStore {
         : null,
       vary: value.vary ? JSON.stringify(value.vary) : null,
       cachedAt: value.cachedAt,
-    })
+    }
+
+    // Coalesce within the pending batch: a stampede of identical misses would
+    // otherwise commit N identical rows. Receipt order wins (see the
+    // #supersede* query comments): the entry being added supersedes every
+    // pending entry for the same representation.
+    for (let i = this.#insertBatch.length - 1; i >= 0; i--) {
+      const other = this.#insertBatch[i]
+      if (
+        other.url === entry.url &&
+        other.method === entry.method &&
+        other.vary === entry.vary &&
+        (entry.statusCode !== 206
+          ? other.statusCode !== 206
+          : other.statusCode === 206 && other.start === entry.start && other.end === entry.end)
+      ) {
+        this.#insertBatch.splice(i, 1)
+      }
+    }
+
+    this.#insertBatch.push(entry)
+  }
+
+  /**
+   * Invalidates every stored response for the key's URI (RFC 9111 §4.4) —
+   * across methods and vary variants. Pending batched inserts for the URI are
+   * dropped as well: a batch entry flushed after the DELETE would otherwise
+   * resurrect the invalidated response. Note this only covers THIS process's
+   * batch — with a shared on-disk store, another process's in-flight batch
+   * can still transiently resurrect an entry (bounded by its ~10ms flush
+   * slice); cross-process invalidation is inherently best-effort.
+   *
+   * @param {import('undici-types/cache-interceptor.d.ts').default.CacheKey} key
+   */
+  delete(key) {
+    assertCacheKey(key)
+
+    if (this.#closed) {
+      return
+    }
+
+    const url = makeValueUrl(key)
+
+    for (let i = this.#insertBatch.length - 1; i >= 0; i--) {
+      if (this.#insertBatch[i].url === url) {
+        this.#insertBatch.splice(i, 1)
+      }
+    }
+
+    this.#deleteByUrlQuery.run(url)
   }
 
   #flush = (final = false) => {
@@ -412,6 +511,7 @@ export class SqliteCacheStore {
               body,
               start,
               end,
+              staleAt,
               deleteAt,
               statusCode,
               statusMessage,
@@ -421,12 +521,21 @@ export class SqliteCacheStore {
               vary,
               cachedAt,
             } = this.#insertBatch[n++]
+            // Supersede prior rows for the same representation (see the
+            // #supersede* query comments) inside the same transaction, so a
+            // re-cache replaces instead of accumulating.
+            if (statusCode === 206) {
+              this.#supersede206Query.run(url, method, vary, start, end)
+            } else {
+              this.#supersedeFullQuery.run(url, method, vary)
+            }
             this.#insertValueQuery.run(
               url,
               method,
               body,
               start,
               end,
+              staleAt,
               deleteAt,
               statusCode,
               statusMessage,
@@ -534,16 +643,14 @@ export class SqliteCacheStore {
       return undefined
     }
 
-    // Newest representation wins. cachedAt is millisecond-resolution, so a
-    // re-cache within the same millisecond produces a tie; break it
-    // deterministically toward the freshest write: pending batch entries
-    // (tagged with a monotonic seq) are always newer than any flushed DB row,
-    // and within each source a higher seq/id wins.
+    // Most recently WRITTEN representation wins — receipt order, not
+    // cachedAt (see the #supersede* query comments: cachedAt is backdated by
+    // the corrected initial age, so a fresher write can carry an older
+    // cachedAt). Pending batch entries (tagged with a monotonic seq) are
+    // always newer than any flushed DB row, and within each source a higher
+    // seq/id wins.
     if (values.length > 1) {
       values.sort((a, b) => {
-        if (a.cachedAt !== b.cachedAt) {
-          return b.cachedAt - a.cachedAt
-        }
         const aBatch = a.seq != null
         const bBatch = b.seq != null
         if (aBatch !== bBatch) {
@@ -657,6 +764,7 @@ function makeResult(value) {
       ? JSON.parse(value.cacheControlDirectives)
       : undefined,
     cachedAt: value.cachedAt,
+    staleAt: value.staleAt,
     deleteAt: value.deleteAt,
   }
 }
@@ -696,7 +804,7 @@ function assertCacheValue(value) {
     throw new TypeError(`expected value to be object, got ${printType(value)}`)
   }
 
-  for (const property of ['statusCode', 'cachedAt', 'deleteAt']) {
+  for (const property of ['statusCode', 'cachedAt', 'staleAt', 'deleteAt']) {
     if (typeof value[property] !== 'number') {
       throw new TypeError(
         `expected value.${property} to be number, got ${printType(value[property])} [${value[property]}]`,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-import cacheControlParser from 'cache-control-parser'
 import stream from 'node:stream'
 import assert from 'node:assert'
 import { util } from '@nxtedition/undici'
@@ -14,14 +13,283 @@ export function getFastNow() {
   return fastNow
 }
 
-export function parseCacheControl(str) {
-  if (Array.isArray(str)) {
-    // Cache-Control is a list-typed field, so duplicated field lines are legal
-    // (e.g. CDN + origin each adding one) and combine into a single
-    // comma-separated value per RFC 9110 §5.2.
-    str = str.join(', ')
+/**
+ * Vendored from undici's parseCacheControlHeader (lib/util/cache.js) with two
+ * deliberate deviations, both toward the conservative reading of RFC 9111:
+ * - duplicated max-age keeps the SMALLER value (§4.2.1 says a cache is free to
+ *   pick, so pick the one that revalidates sooner), upstream keeps the larger;
+ * - a bare (valueless) max-stale is represented as Infinity per §5.2.1.2
+ *   ("willing to accept a stale response of any age"), upstream drops it.
+ *
+ * Qualified no-cache/private (e.g. `no-cache="set-cookie"`) parse to an array
+ * of the listed field names; the unqualified forms parse to `true`. Callers
+ * that mean "unqualified" must check `=== true`, not truthiness.
+ *
+ * Keeps the historical wrapper contract: '', [], and non-strings return null
+ * (call sites rely on `?? {}`); an array of field lines is accepted directly
+ * (Cache-Control is list-typed, duplicated lines are legal per RFC 9110 §5.2).
+ *
+ * @param {string | string[] | null | undefined} header
+ * @returns {Record<string, boolean | number | string[]> | null}
+ */
+export function parseCacheControl(header) {
+  let directives
+  if (Array.isArray(header)) {
+    directives = []
+    for (const line of header) {
+      if (typeof line !== 'string') {
+        return null
+      }
+      directives.push(...line.split(','))
+    }
+    if (directives.length === 0) {
+      return null
+    }
+  } else if (header && typeof header === 'string') {
+    directives = header.split(',')
+  } else {
+    return null
   }
-  return str && typeof str === 'string' ? cacheControlParser.parse(str) : null
+
+  const output = {}
+
+  for (let i = 0; i < directives.length; i++) {
+    const directive = directives[i].toLowerCase()
+    const keyValueDelimiter = directive.indexOf('=')
+
+    let key
+    let value
+    if (keyValueDelimiter !== -1) {
+      key = directive.substring(0, keyValueDelimiter).trim()
+      value = directive.substring(keyValueDelimiter + 1)
+    } else {
+      key = directive.trim()
+    }
+
+    switch (key) {
+      case 'min-fresh':
+      case 'max-stale':
+      case 'max-age':
+      case 's-maxage':
+      case 'stale-while-revalidate':
+      case 'stale-if-error': {
+        if (value === undefined) {
+          if (key === 'max-stale') {
+            // Bare max-stale: any staleness is acceptable (RFC 9111
+            // §5.2.1.2). Number semantics keep call-site math
+            // (`staleAt + max-stale * 1000`) working unchanged.
+            output[key] = Infinity
+          }
+          continue
+        }
+        if (value[0] === ' ') {
+          continue
+        }
+
+        if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
+          value = value.substring(1, value.length - 1)
+        }
+
+        const parsedValue = parseInt(value, 10)
+        if (Number.isNaN(parsedValue)) {
+          continue
+        }
+
+        if (key === 'max-age' && key in output && output[key] <= parsedValue) {
+          // Duplicate max-age: keep the smaller (sooner-stale) value.
+          continue
+        }
+
+        output[key] = parsedValue
+
+        break
+      }
+      case 'private':
+      case 'no-cache': {
+        if (value) {
+          // Qualified form: a quoted, possibly comma-separated list of field
+          // names (`no-cache="set-cookie, warning"`). The split-by-comma above
+          // may have cut the quoted list apart, so scan forward until the part
+          // that carries the closing quote. https://www.rfc-editor.org/rfc/rfc9111.html#name-no-cache-2
+          //
+          // The unqualified form is strictly more restrictive (forbids
+          // storing / demands validation for the WHOLE response), so when
+          // both forms appear (`private, private="x"` — invalid but seen in
+          // the wild), the qualified form must never clobber the `true`.
+          value = value.trim()
+          if (value[0] === '"') {
+            const headerNames = [value.substring(1)]
+
+            // length > 1: a lone `"` is an opening quote, not a closed list.
+            let foundEndingQuote = value.length > 1 && value[value.length - 1] === '"'
+            if (!foundEndingQuote) {
+              for (let j = i + 1; j < directives.length; j++) {
+                // Trim before the closing-quote check: optional whitespace
+                // between the quote and the next comma (`no-cache="a, b" ,x`)
+                // must not defeat the scan.
+                const nextPart = directives[j].trim()
+                headerNames.push(nextPart)
+                if (nextPart.length !== 0 && nextPart[nextPart.length - 1] === '"') {
+                  foundEndingQuote = true
+                  // Consume the scanned parts so a quoted fragment (e.g. a
+                  // literal `max-age=1` inside the field list) is not
+                  // re-parsed as a real directive.
+                  i = j
+                  break
+                }
+              }
+            }
+
+            if (foundEndingQuote) {
+              const lastHeader = headerNames[headerNames.length - 1]
+              if (lastHeader[lastHeader.length - 1] === '"') {
+                headerNames[headerNames.length - 1] = lastHeader.substring(0, lastHeader.length - 1)
+              }
+              if (output[key] !== true) {
+                const fields = headerNames.map((name) => name.trim().toLowerCase())
+                output[key] = Array.isArray(output[key]) ? output[key].concat(fields) : fields
+              }
+            } else {
+              // Unterminated quoted list (invalid header). Fail restrictive:
+              // treat as the unqualified form, and consume the remaining
+              // parts — they are fragments of the broken quoted string, not
+              // real directives.
+              output[key] = true
+              i = directives.length
+            }
+          } else if (output[key] !== true) {
+            const fieldName = value.toLowerCase()
+            output[key] = Array.isArray(output[key]) ? output[key].concat(fieldName) : [fieldName]
+          }
+
+          break
+        }
+      }
+      // eslint-disable-next-line no-fallthrough
+      case 'public':
+      case 'no-store':
+      case 'must-revalidate':
+      case 'proxy-revalidate':
+      case 'immutable':
+      case 'no-transform':
+      case 'must-understand':
+      case 'only-if-cached':
+        if (value) {
+          // Qualified when not allowed to be — skip.
+          continue
+        }
+
+        output[key] = true
+        break
+      default:
+        // Unknown directives are ignored per RFC 9111 §5.2.3.
+        continue
+    }
+  }
+
+  return output
+}
+
+const HTTP_DATE_MONTHS = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+}
+
+const HTTP_DATE_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const HTTP_DATE_FULL_DAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+]
+
+// IMF-fixdate:  Sun, 06 Nov 1994 08:49:37 GMT
+const IMF_DATE_RE =
+  /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+// obsolete RFC 850: Sunday, 06-Nov-94 08:49:37 GMT
+const RFC850_DATE_RE =
+  /^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+// ANSI C asctime(): Sun Nov  6 08:49:37 1994 (day space-padded)
+const ASCTIME_DATE_RE =
+  /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([ \d]\d) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/
+
+/**
+ * Strict HTTP-date parser per RFC 9110 §5.6.7 (the three accepted formats
+ * only). Deliberately NOT `new Date(str)`: V8 accepts many non-HTTP formats,
+ * and RFC 9111 §5.3 requires an invalid Expires (notably `Expires: 0`) to be
+ * treated as already expired rather than silently ignored — which needs the
+ * parse failure to be observable.
+ *
+ * @param {string} date
+ * @returns {Date | undefined} undefined when not a valid HTTP-date
+ */
+export function parseHttpDate(date) {
+  if (typeof date !== 'string') {
+    return undefined
+  }
+
+  let weekday
+  let day
+  let month
+  let year
+  let hour
+  let minute
+  let second
+
+  let m = IMF_DATE_RE.exec(date)
+  if (m) {
+    weekday = HTTP_DATE_DAYS.indexOf(m[1])
+    day = Number(m[2])
+    month = HTTP_DATE_MONTHS[m[3]]
+    year = Number(m[4])
+    hour = Number(m[5])
+    minute = Number(m[6])
+    second = Number(m[7])
+  } else if ((m = RFC850_DATE_RE.exec(date))) {
+    weekday = HTTP_DATE_FULL_DAYS.indexOf(m[1])
+    day = Number(m[2])
+    month = HTTP_DATE_MONTHS[m[3]]
+    // RFC 6265 §5.1.1 two-digit year windowing: 70-99 → 19xx, 00-69 → 20xx.
+    year = Number(m[4])
+    year += year < 70 ? 2000 : 1900
+    hour = Number(m[5])
+    minute = Number(m[6])
+    second = Number(m[7])
+  } else if ((m = ASCTIME_DATE_RE.exec(date))) {
+    weekday = HTTP_DATE_DAYS.indexOf(m[1])
+    month = HTTP_DATE_MONTHS[m[2]]
+    day = Number(m[3].trim())
+    hour = Number(m[4])
+    minute = Number(m[5])
+    second = Number(m[6])
+    year = Number(m[7])
+  } else {
+    return undefined
+  }
+
+  if (day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
+    return undefined
+  }
+
+  const result = new Date(Date.UTC(year, month, day, hour, minute, second))
+  // Date.UTC normalizes out-of-range components (Feb 30 → Mar 2) and the named
+  // weekday must match the actual date — both are rejected by the same check
+  // upstream uses (getUTCDay comparison catches normalization only by luck;
+  // check the day-of-month explicitly as well).
+  return result.getUTCDate() === day && result.getUTCDay() === weekday ? result : undefined
 }
 
 export function isDisturbed(body) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtedition/nxt-undici",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "license": "MIT",
   "author": "Robert Nagy <robert.nagy@boffins.se>",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@nxtedition/scheduler": "^4.1.1",
     "@nxtedition/undici": "^11.1.4",
-    "cache-control-parser": "^2.2.0",
     "fast-querystring": "^1.1.2",
     "http-errors": "^2.0.1",
     "xxhash-wasm": "^1.1.0"

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -439,13 +439,14 @@ test('cache: only-if-cached returns cached entry when one exists', async (t) => 
 // Authorization header
 // ---------------------------------------------------------------------------
 
-test('cache: authorization header prevents caching unless response has public directive', async (t) => {
+test('cache: authorization header prevents caching unless response permits it (public/s-maxage/must-revalidate)', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    // s-maxage but no 'public' — should not be cached when request has authorization
-    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    // max-age only — RFC 9111 §3.5 requires public, s-maxage or
+    // must-revalidate for a shared cache to store an authorized response.
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
     res.end('private')
   })
   t.teardown(server.close.bind(server))
@@ -495,11 +496,13 @@ test('cache: authorization header allows caching when response has public direct
 // Response directives that prevent caching
 // ---------------------------------------------------------------------------
 
-test('cache: must-revalidate response directive prevents caching', async (t) => {
+test('cache: must-revalidate response is stored and served while fresh', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
+    // must-revalidate only constrains STALE reuse (RFC 9111 §5.2.2.2); a
+    // fresh entry serves normally.
     res.writeHead(200, { 'cache-control': 's-maxage=60, must-revalidate' })
     res.end('body')
   })
@@ -517,10 +520,10 @@ test('cache: must-revalidate response directive prevents caching', async (t) => 
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'must-revalidate responses are not cached')
+  t.equal(hits, 1, 'must-revalidate response is served from cache while fresh')
 })
 
-test('cache: proxy-revalidate response directive prevents caching', async (t) => {
+test('cache: proxy-revalidate response is stored and served while fresh', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
@@ -542,14 +545,22 @@ test('cache: proxy-revalidate response directive prevents caching', async (t) =>
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'proxy-revalidate responses are not cached')
+  t.equal(hits, 1, 'proxy-revalidate response is served from cache while fresh')
 })
 
-test('cache: no-cache response directive prevents caching', async (t) => {
-  t.plan(1)
+test('cache: no-cache response directive forces origin validation on every reuse', async (t) => {
+  t.plan(2)
   let hits = 0
+  let conditional = 0
   const server = await startServer((req, res) => {
     hits++
+    // Unqualified no-cache: the response may be stored, but must be
+    // validated with the origin before every reuse (RFC 9111 §5.2.2.4). This
+    // origin never answers 304, so every request pays a full round-trip —
+    // but the second one must arrive as a conditional request.
+    if (req.headers['if-modified-since']) {
+      conditional++
+    }
     res.writeHead(200, { 'cache-control': 'max-age=60, no-cache' })
     res.end('body')
   })
@@ -567,7 +578,8 @@ test('cache: no-cache response directive prevents caching', async (t) => {
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'no-cache responses are not cached')
+  t.equal(hits, 2, 'every reuse goes to the origin')
+  t.equal(conditional, 1, 'the reuse validated instead of serving from cache')
 })
 
 // ---------------------------------------------------------------------------
@@ -1802,8 +1814,10 @@ test('cache: authorized request not cached without public directive', async (t) 
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
+    // max-age only — does not permit shared-cache storage of an authorized
+    // response (s-maxage/public/must-revalidate would, RFC 9111 §3.5).
     res.writeHead(200, {
-      'cache-control': 's-maxage=60',
+      'cache-control': 'max-age=60',
       'content-type': 'text/plain',
     })
     res.end('secret')
@@ -1963,9 +1977,10 @@ test('cache: cached non-public response is not served to request with Authorizat
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    // First request has no Authorization, so response gets cached.
-    // Response has no 'public' directive.
-    res.writeHead(200, { 'cache-control': 's-maxage=60', 'content-type': 'text/plain' })
+    // First request has no Authorization, so response gets cached. Response
+    // has no directive permitting authorized reuse (max-age doesn't count;
+    // public/s-maxage/must-revalidate would).
+    res.writeHead(200, { 'cache-control': 'max-age=60', 'content-type': 'text/plain' })
     res.end('data')
   })
   t.teardown(server.close.bind(server))

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -1,0 +1,1000 @@
+/* eslint-disable */
+// Stale-path behavior: origin revalidation (conditional requests, 304
+// freshening), stale-while-revalidate, stale-if-error, and local evaluation
+// of freshness-overriding request directives. Stale entries are seeded
+// directly into the store (no sleeps) so every test is deterministic.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc, h) {
+        statusCode = sc
+        headers = h
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, headers, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function origin(server) {
+  return `http://0.0.0.0:${server.address().port}`
+}
+
+// Seeds a (typically stale) entry the way CacheHandler would have stored it.
+function seedEntry(
+  store,
+  originStr,
+  {
+    path = '/',
+    method = 'GET',
+    body = 'cached-body',
+    headers = {},
+    cacheControlDirectives = {},
+    etag = '',
+    // Offsets relative to now, in ms.
+    cachedAtOffset = -10e3,
+    staleAtOffset = -5e3,
+    deleteAtOffset = 3600e3,
+  } = {},
+) {
+  const now = Date.now()
+  const buf = Buffer.from(body)
+  store.set(
+    { origin: originStr, method, path, headers: {} },
+    {
+      body: buf,
+      start: 0,
+      end: buf.byteLength,
+      statusCode: 200,
+      statusMessage: '',
+      headers,
+      cacheControlDirectives,
+      etag,
+      vary: {},
+      cachedAt: now + cachedAtOffset,
+      staleAt: now + staleAtOffset,
+      deleteAt: now + deleteAtOffset,
+    },
+  )
+}
+
+// Bounded poll — never waits forever (see global waiting guidelines).
+async function waitFor(cond, { timeout = 2000, interval = 10 } = {}) {
+  const deadline = Date.now() + timeout
+  while (!cond()) {
+    if (Date.now() > deadline) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval))
+  }
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// ---------------------------------------------------------------------------
+// Conditional revalidation: 304 serves and freshens the stored entry
+// ---------------------------------------------------------------------------
+
+test('revalidation: stale entry with etag revalidates with if-none-match; 304 serves cached body', async (t) => {
+  t.plan(6)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { 'cache-control': 'max-age=5', 'last-modified': 'Sat, 04 Jul 2026 10:00:00 GMT' },
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.statusCode, 200, 'client sees 200, not the 304')
+  t.equal(first.body, 'cached-body', 'validated cached body is served')
+  t.equal(seen.length, 1, 'origin was asked once')
+  t.equal(seen[0]['if-none-match'], '"v1"', 'if-none-match carries the stored etag')
+  t.equal(
+    seen[0]['if-modified-since'],
+    'Sat, 04 Jul 2026 10:00:00 GMT',
+    'if-modified-since echoes the stored last-modified verbatim',
+  )
+
+  // The 304's max-age=60 freshened the entry: next request never hits origin.
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(seen.length, 1, 'freshened entry is served without contacting the origin')
+})
+
+test('revalidation: freshening resets the Age', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -100e3,
+    staleAtOffset: -95e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.ok(second.headers.age != null, 'age header present')
+  t.ok(Number(second.headers.age) <= 1, `age is reset after freshening (got ${second.headers.age})`)
+})
+
+test('revalidation: replacement 200 is delivered and stored', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('new-body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.body, 'new-body', 'replacement body is delivered')
+
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'new-body', 'replacement was stored')
+  t.equal(hits, 1, 'second request served from cache')
+})
+
+test('revalidation: entry without etag falls back to if-modified-since from cachedAt', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200)
+  t.equal(seen[0]['if-none-match'], undefined, 'no etag, no if-none-match')
+  t.ok(seen[0]['if-modified-since'].endsWith(' GMT'), 'if-modified-since derived from cachedAt')
+})
+
+// ---------------------------------------------------------------------------
+// Store-and-revalidate: response no-cache with a validator
+// ---------------------------------------------------------------------------
+
+test('revalidation: no-cache + etag response is stored and revalidated on every hit (#5515)', async (t) => {
+  t.plan(6)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match'] === '"v1"') {
+      conditional++
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200, { 'cache-control': 'no-cache', etag: '"v1"' })
+      res.end('validated-body')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.body, 'validated-body')
+  await flush()
+
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'validated-body', 'cached body served after 304 validation')
+  t.equal(hits, 2, 'every reuse revalidates with the origin')
+  t.equal(conditional, 1, 'second request was conditional')
+
+  // The freshened (post-304) entry must keep the no-cache semantics: a third
+  // request revalidates again from the entry the 304 re-stored.
+  await flush()
+  const third = await rawRequest(dispatch, opts)
+  t.equal(third.body, 'validated-body', 'freshened entry still serves the cached body')
+  t.equal(conditional, 2, 'the freshened entry is validated again, not served blindly')
+})
+
+test('revalidation: entry no-cache directive forces validation even while fresh', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh (staleAt in the future) but marked no-cache.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'no-cache': true, 'max-age': 70 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'fresh no-cache entry still validated with origin')
+})
+
+// ---------------------------------------------------------------------------
+// stale-if-error (RFC 5861 §4)
+// ---------------------------------------------------------------------------
+
+test('stale-if-error: origin 503 during revalidation serves the stale entry', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end('boom')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200, 'stale entry served instead of the 503')
+  t.equal(res.body, 'cached-body')
+})
+
+test('stale-if-error: without the directive the 503 is passed through', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end('boom')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 503, '503 replacement is delivered')
+  t.equal(res.body, 'boom')
+})
+
+test('stale-if-error: connection error before response serves the stale entry (#5513)', async (t) => {
+  t.plan(2)
+  // Port 1 (tcpmux) is privileged and never bound in practice — connecting
+  // yields a deterministic ECONNREFUSED without the port-reuse race of
+  // binding-then-closing a listener under parallel test load.
+  const originStr = 'http://127.0.0.1:1'
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, originStr, {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+  })
+  const opts = { origin: originStr, path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200, 'unreachable origin within stale-if-error serves stale')
+  t.equal(res.body, 'cached-body')
+})
+
+test('stale-if-error: request directive works as fallback window', async (t) => {
+  t.plan(1)
+  const server = await startServer((req, res) => {
+    res.writeHead(500)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'stale-if-error=60' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200, 'request stale-if-error honored on origin 5xx')
+})
+
+test('stale-if-error: must-revalidate vetoes serving stale (#5511)', async (t) => {
+  t.plan(1)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60, 'must-revalidate': true },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 503, 'must-revalidate forbids the stale-if-error serve')
+})
+
+// ---------------------------------------------------------------------------
+// stale-while-revalidate (RFC 5861 §3)
+// ---------------------------------------------------------------------------
+
+test('stale-while-revalidate: stale entry within window is served immediately, refreshed in background', async (t) => {
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(200, { 'cache-control': 'max-age=60, stale-while-revalidate=60', etag: '"v2"' })
+    res.end('refreshed')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.statusCode, 200)
+  t.equal(first.body, 'cached-body', 'stale body served without waiting for the origin')
+
+  await waitFor(() => seen.length === 1)
+  t.equal(seen[0]['if-none-match'], '"v1"', 'background refresh is a conditional request')
+
+  // Give the refresh time to store, then confirm the entry was replaced.
+  await waitFor(() => {
+    const entry = store.get({ origin: origin(server), method: 'GET', path: '/', headers: {} })
+    return entry?.etag === '"v2"'
+  })
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'refreshed', 'refreshed entry served afterwards')
+  t.equal(seen.length, 1, 'no additional origin hit for the refreshed entry')
+  t.end()
+})
+
+test('stale-while-revalidate: outside the window revalidates synchronously', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stale by 100s, swr window only 60s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -110e3,
+    staleAtOffset: -100e3,
+    cacheControlDirectives: { 'max-age': 10, 'stale-while-revalidate': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.body, 'cached-body', '304 validated the entry')
+  t.equal(seen.length, 1, 'origin consulted before serving (synchronous revalidation)')
+})
+
+// ---------------------------------------------------------------------------
+// Request directives evaluated locally
+// ---------------------------------------------------------------------------
+
+test('request no-cache: revalidates a fresh entry instead of serving it', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'no-cache' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200)
+  t.equal(res.body, 'cached-body', 'validated body served')
+  t.equal(seen.length, 1, 'origin was consulted despite the entry being fresh')
+})
+
+test('request no-cache on a cache miss still stores the response (write-back, #5510)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'no-cache' } })
+  t.equal(hits, 1)
+  await flush()
+
+  // The no-cache fetch must not have disabled caching for everyone else.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 1, 'plain request is served from the entry stored by the no-cache fetch')
+})
+
+test('request max-age=0 forces validation and exceeded max-age keeps write-back (undici #5504)', async (t) => {
+  t.plan(4)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match']) {
+      conditional++
+    }
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('hello')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  // The exact #5504 repro shape: populate, then request with max-age=0
+  // (what fetch cache:'no-cache' sends) — must NOT be a silent cache hit.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-age=0' } })
+  t.equal(hits, 2, 'max-age=0 contacted the origin (not a falsy-dropped directive)')
+  t.equal(conditional, 1, 'and did so with a conditional request')
+
+  // Secondary #5504 claim: the response fetched because of the max-age bypass
+  // must still update the store — the next plain request is a cache hit.
+  await flush()
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'replacement was stored (write-back preserved)')
+  t.pass('write-back verified')
+})
+
+test('request max-age=0: revalidates a fresh entry', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=0' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'max-age=0 demanded validation')
+})
+
+test('request max-stale: serves a stale entry within the tolerance without origin contact', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stale by 5s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  const res = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'max-stale=30' },
+  })
+  t.equal(res.body, 'cached-body', 'stale-by-5s entry served under max-stale=30')
+  t.equal(hits, 0, 'origin not contacted')
+
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-stale=2' } })
+  t.equal(hits, 1, 'staleness beyond max-stale=2 revalidates')
+})
+
+test('request bare max-stale accepts any staleness', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -1000e3,
+    staleAtOffset: -995e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-stale' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(hits, 0, 'bare max-stale served an arbitrarily stale entry')
+})
+
+test('request max-stale: must-revalidate vetoes serving stale', async (t) => {
+  t.plan(1)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(1)
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'must-revalidate': true },
+  })
+
+  await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-stale=300' },
+    cache: { store },
+  })
+  t.equal(seen.length, 1, 'must-revalidate entry validated despite max-stale')
+})
+
+test('only-if-cached: stale entry without max-stale returns 504', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'only-if-cached' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 504, 'stale entry is not usable for only-if-cached')
+  t.equal(hits, 0, 'origin never contacted')
+})
+
+test('caller conditionals against a stale entry are forwarded to the origin', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    if (req.headers['if-none-match'] === '"v1"') {
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200)
+      res.end('fresh')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'if-none-match': '"v1"' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 304, "origin's 304 flows to the caller")
+  t.equal(seen.length, 1, 'stale entry did not answer the conditional locally')
+  t.equal(seen[0]['if-none-match'], '"v1"', "caller's own validator was forwarded")
+})
+
+// ---------------------------------------------------------------------------
+// Review regressions: request bounds vs stale-serving windows, 304 freshening
+// edge cases, aborts, HEAD
+// ---------------------------------------------------------------------------
+
+test('request max-age is not nullified by max-stale (review)', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=3600' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Origin-fresh entry (staleAt far in the future) aged 300s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -300e3,
+    staleAtOffset: 3300e3,
+    cacheControlDirectives: { 'max-age': 3600 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=10, max-stale=600' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200)
+  t.equal(seen.length, 1, 'entry older than the request max-age was validated, not served blindly')
+})
+
+test('request max-age=0 is not nullified by response stale-while-revalidate (review)', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60, stale-while-revalidate=300' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh entry aged 30s with a wide SWR window.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -30e3,
+    staleAtOffset: 30e3,
+    cacheControlDirectives: { 'max-age': 60, 'stale-while-revalidate': 300 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=0' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'max-age=0 validated synchronously despite the SWR window')
+})
+
+test('freshening: 304 without a Date header restarts the freshness clock (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.sendDate = false
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stored 300s ago with the origin's original Date header.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { date: new Date(Date.now() - 300e3).toUTCString() },
+    cachedAtOffset: -300e3,
+    staleAtOffset: -295e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'the 304 granted 60s of freshness — second request never hit the origin')
+
+  const entry = store.get({ origin: origin(server), method: 'GET', path: '/', headers: {} })
+  t.ok(entry.staleAt > Date.now(), 'freshened entry is actually fresh')
+})
+
+test('freshening: 304 headers are merged with store-time exclusions (set-cookie, content-length) (review)', async (t) => {
+  t.plan(4)
+  const server = await startServer((req, res) => {
+    res.writeHead(304, {
+      'cache-control': 'max-age=60',
+      'set-cookie': 'session=leak',
+      'content-length': '9999',
+      'x-fresh': 'merged',
+    })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { 'x-old': 'kept' },
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.headers['set-cookie'], undefined, '304 Set-Cookie never reaches the shared entry')
+  t.equal(res.headers['x-fresh'], 'merged', 'new 304 fields are merged in')
+  t.equal(res.headers['x-old'], 'kept', 'stored fields survive the merge')
+  t.equal(res.body, 'cached-body', 'stored body served (304 content-length ignored)')
+})
+
+test('revalidation: HEAD entry freshens and serves an empty body (review)', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const now = Date.now()
+  store.set(
+    { origin: origin(server), method: 'HEAD', path: '/', headers: {} },
+    {
+      body: null,
+      start: 0,
+      end: 0,
+      statusCode: 200,
+      statusMessage: '',
+      headers: { 'content-length': '5' },
+      cacheControlDirectives: { 'max-age': 5 },
+      etag: '"v1"',
+      vary: {},
+      cachedAt: now - 10e3,
+      staleAt: now - 5e3,
+      deleteAt: now + 3600e3,
+    },
+  )
+  const opts = { origin: origin(server), path: '/', method: 'HEAD', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200)
+  t.equal(res.body, '', 'HEAD serves no body')
+
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'freshened HEAD entry served without another origin hit')
+})
+
+test('only-if-cached combined with max-stale serves a stale entry (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'only-if-cached, max-stale=30' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body', 'max-stale makes the stale entry usable for only-if-cached')
+  t.equal(hits, 0, 'origin never contacted')
+})
+
+test('abort during revalidation cancels the in-flight conditional request (review)', async (t) => {
+  t.plan(2)
+  let sawRequest = false
+  const server = await startServer((req, res) => {
+    sawRequest = true
+    // Never answer — only an abort can end this request.
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } },
+      {
+        onConnect(abort) {
+          // Abort as soon as the handle exists — during the conditional flight.
+          setTimeout(() => abort(new Error('user-abort')), 20)
+        },
+        onHeaders() {
+          reject(new Error('should not receive headers'))
+          return true
+        },
+        onData() {
+          return true
+        },
+        onComplete() {
+          reject(new Error('should not complete'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+  t.equal(err.message, 'user-abort', "the user's abort reason surfaces via onError")
+  t.ok(sawRequest, 'the conditional request had reached the origin')
+})
+
+test('request no-store: revalidation replacement is delivered but not stored', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('replacement')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  const res = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'no-store' },
+  })
+  t.equal(res.body, 'replacement')
+  await flush()
+
+  // The stale seeded entry is still there (superseded only on store), and the
+  // replacement must not have been written: a plain request revalidates again.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'no-store replacement was not written to the cache')
+})

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -1,0 +1,761 @@
+/* eslint-disable */
+// Storability and freshness-math behavior: Expires fallback, corrected initial
+// age, §3.5 authorization permits, opt-in heuristic freshness / defaultTTL,
+// header stripping, unsafe-method invalidation, query-in-key, and the store's
+// delete()/supersede machinery.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { DatabaseSync } from 'node:sqlite'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import { parseHttpDate } from '../lib/utils.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc, h) {
+        statusCode = sc
+        headers = h
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, headers, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function origin(server) {
+  return `http://0.0.0.0:${server.address().port}`
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// ---------------------------------------------------------------------------
+// parseHttpDate unit coverage (strict RFC 9110 formats only)
+// ---------------------------------------------------------------------------
+
+test('parseHttpDate: accepts the three RFC 9110 formats, rejects everything else', (t) => {
+  const expected = Date.UTC(1994, 10, 6, 8, 49, 37)
+  t.equal(parseHttpDate('Sun, 06 Nov 1994 08:49:37 GMT')?.getTime(), expected, 'IMF-fixdate')
+  t.equal(parseHttpDate('Sunday, 06-Nov-94 08:49:37 GMT')?.getTime(), expected, 'RFC 850')
+  t.equal(parseHttpDate('Sun Nov  6 08:49:37 1994')?.getTime(), expected, 'asctime')
+  t.equal(parseHttpDate('0'), undefined, 'Expires: 0 is invalid')
+  t.equal(parseHttpDate('Mon, 06 Nov 1994 08:49:37 GMT'), undefined, 'wrong weekday')
+  t.equal(parseHttpDate('Wed, 30 Feb 2022 00:00:00 GMT'), undefined, 'nonexistent date')
+  t.equal(parseHttpDate('2026-07-04T00:00:00Z'), undefined, 'ISO 8601 is not an HTTP date')
+  t.equal(parseHttpDate(123), undefined, 'non-string')
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Expires fallback (RFC 9111 §4.2.1 / §5.3)
+// ---------------------------------------------------------------------------
+
+test('storability: Expires-only response is cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      expires: new Date(Date.now() + 60e3).toUTCString(),
+      date: new Date().toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'future Expires provides the freshness lifetime')
+})
+
+test('storability: invalid Expires (0) means already expired — not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { expires: '0' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'Expires: 0 is treated as already expired (RFC 9111 §5.3)')
+})
+
+test('storability: past Expires with etag is stored for revalidation', async (t) => {
+  t.plan(2)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match'] === '"e"') {
+      conditional++
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200, {
+        expires: new Date(Date.now() - 60e3).toUTCString(),
+        etag: '"e"',
+      })
+      res.end('body')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'body', 'validated body served')
+  t.equal(conditional, 1, 'second request revalidated instead of refetching')
+})
+
+// ---------------------------------------------------------------------------
+// Corrected initial age (RFC 9111 §4.2.3)
+// ---------------------------------------------------------------------------
+
+test('storability: apparent age from the Date header counts against freshness', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    // Generated 120s ago per Date, only 60s of freshness, no validator:
+    // stale on arrival, must not be stored.
+    res.writeHead(200, {
+      'cache-control': 'max-age=60',
+      date: new Date(Date.now() - 120e3).toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'response stale on arrival (Date-based apparent age) is not cached')
+})
+
+test('storability: served Age includes the age the response arrived with', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', age: '5' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1)
+  t.ok(Number(second.headers.age) >= 5, 'cachedAt backdating carries the initial age forward')
+})
+
+// ---------------------------------------------------------------------------
+// RFC 9111 §3.5: authorization permits
+// ---------------------------------------------------------------------------
+
+test('authorization: s-maxage permits shared-cache storage and reuse (#4911)', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 's-maxage response cached and served for authorized requests')
+})
+
+test('authorization: must-revalidate permits storage for authorized requests', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60, must-revalidate' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'must-revalidate response cached while fresh for authorized requests')
+})
+
+// ---------------------------------------------------------------------------
+// Opt-in heuristic freshness and defaultTTL
+// ---------------------------------------------------------------------------
+
+test('heuristic: last-modified-only response is cached when opted in', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'last-modified': new Date(Date.now() - 3600e3).toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+
+  // Without the opt-in: not cached.
+  const store1 = new SqliteCacheStore({ location: ':memory:' })
+  const base1 = { origin: origin(server), path: '/', method: 'GET', headers: {} }
+  await rawRequest(dispatch, { ...base1, cache: { store: store1 } })
+  await rawRequest(dispatch, { ...base1, cache: { store: store1 } })
+  t.equal(hits, 2, 'no heuristic caching by default')
+
+  // With the opt-in: 10% of 1h ≈ 6 min of freshness.
+  const store2 = new SqliteCacheStore({ location: ':memory:' })
+  await rawRequest(dispatch, { ...base1, path: '/h', cache: { store: store2, heuristic: true } })
+  await rawRequest(dispatch, { ...base1, path: '/h', cache: { store: store2, heuristic: true } })
+  t.equal(hits, 3, 'heuristic freshness serves the second request from cache')
+})
+
+test('defaultTTL: response without any caching headers is cached when opted in', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store, defaultTTL: 60 },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'defaultTTL supplies the missing freshness lifetime')
+})
+
+// ---------------------------------------------------------------------------
+// Header stripping (RFC 9111 §3.1, §5.2.2.4, §5.2.2.7)
+// ---------------------------------------------------------------------------
+
+test('stripping: hop-by-hop and Connection-listed headers are not stored', async (t) => {
+  t.plan(4)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60',
+      connection: 'x-hop',
+      'x-hop': 'per-connection',
+      'keep-alive': 'timeout=5',
+      'x-keep': 'stored',
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'served from cache')
+  t.equal(second.headers['x-hop'], undefined, 'Connection-listed field stripped')
+  t.equal(second.headers['keep-alive'], undefined, 'hop-by-hop field stripped')
+  t.equal(second.headers['x-keep'], 'stored', 'end-to-end field preserved')
+})
+
+test('stripping: qualified no-cache="field" strips the field but stores the response', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60, no-cache="x-secret"',
+      'x-secret': 'do-not-replay',
+      'x-public': 'fine',
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'qualified no-cache does not prevent storage')
+  t.equal(second.headers['x-secret'], undefined, 'listed field stripped from the stored entry')
+  t.equal(second.headers['x-public'], 'fine', 'other fields preserved')
+})
+
+// ---------------------------------------------------------------------------
+// Unsafe-method invalidation (RFC 9111 §4.4, undici PR #5514)
+// ---------------------------------------------------------------------------
+
+test('invalidation: successful POST invalidates the cached GET for the URI', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'GET cached')
+
+  await rawRequest(dispatch, { ...base, method: 'POST' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 2, 'POST invalidated the entry — GET went back to the origin')
+})
+
+test('invalidation: Location header target is invalidated too', async (t) => {
+  t.plan(2)
+  let bHits = 0
+  const server = await startServer((req, res) => {
+    if (req.url === '/b' && req.method === 'GET') {
+      bHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('b-body')
+    } else {
+      res.writeHead(201, { location: '/b' })
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 1, '/b cached')
+
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 2, 'POST /a with Location: /b invalidated the cached /b')
+})
+
+test('invalidation: cross-origin Location is ignored (no poisoning)', async (t) => {
+  t.plan(1)
+  let bHits = 0
+  const server = await startServer((req, res) => {
+    if (req.url === '/b' && req.method === 'GET') {
+      bHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('b-body')
+    } else {
+      res.writeHead(201, { location: 'http://attacker.example/b' })
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 1, 'cross-origin Location did not invalidate the same-path entry')
+})
+
+test('invalidation: failed (5xx) unsafe request does not invalidate', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      hits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.writeHead(500)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'POST' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'a 500 to the POST left the cached entry alone')
+})
+
+test('invalidation: OPTIONS is safe and does not invalidate', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      hits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.writeHead(204)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'OPTIONS' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'OPTIONS left the cached entry alone')
+})
+
+test('invalidation: array Location header uses the first value (review)', async (t) => {
+  t.plan(2)
+  let bHits = 0
+  let cHits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      if (req.url === '/b') bHits++
+      if (req.url === '/c') cHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.setHeader('location', ['/b', '/c'])
+      res.writeHead(201)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/c', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/c', method: 'GET' })
+  t.equal(bHits, 2, 'first Location value (/b) was invalidated')
+  t.equal(cHits, 1, 'second Location value (/c) untouched (first-value semantics)')
+})
+
+test('invalidation: POST with flat-array headers does not throw (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET', headers: {} })
+  // The legal undici flat name/value array form must not crash key building.
+  const res = await rawRequest(dispatch, {
+    ...base,
+    method: 'POST',
+    headers: ['content-type', 'text/plain'],
+  })
+  t.equal(res.statusCode, 200, 'POST with flat-array headers succeeds')
+
+  await rawRequest(dispatch, { ...base, method: 'GET', headers: {} })
+  t.equal(hits, 2, 'and still invalidated the cached GET')
+})
+
+// ---------------------------------------------------------------------------
+// Parser regressions (review): restrictive forms must win, quoted lists must
+// not leak directives
+// ---------------------------------------------------------------------------
+
+test('parser: qualified private/no-cache never clobbers the unqualified form (review)', async (t) => {
+  const { parseCacheControl } = await import('../lib/utils.js')
+  t.equal(
+    parseCacheControl('private, private="x-a"').private,
+    true,
+    'unqualified private survives a later qualified form',
+  )
+  t.equal(
+    parseCacheControl('no-cache="x-a", no-cache')['no-cache'],
+    true,
+    'a later unqualified no-cache overrides the qualified list',
+  )
+  t.strictSame(
+    parseCacheControl('no-cache="a, max-stale, b"'),
+    { 'no-cache': ['a', 'max-stale', 'b'] },
+    'tokens inside a quoted field list never become live directives',
+  )
+  t.strictSame(
+    parseCacheControl('no-cache="a, b" , max-age=5'),
+    { 'no-cache': ['a', 'b'], 'max-age': 5 },
+    'whitespace after the closing quote does not defeat the scan',
+  )
+  t.equal(
+    parseCacheControl('no-cache="a, max-age=1')['no-cache'],
+    true,
+    'unterminated quoted list fails restrictive (unqualified)',
+  )
+  t.equal(
+    parseCacheControl('no-cache="a, max-age=1')['max-age'],
+    undefined,
+    'fragments of the broken quoted list are not parsed as directives',
+  )
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Query folded into the cache key (undici PR #5081)
+// ---------------------------------------------------------------------------
+
+test('query: opts.query is part of the cache key in standalone compositions', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end(req.url)
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const a = await rawRequest(dispatch, { ...base, query: { i: 0 } })
+  const b = await rawRequest(dispatch, { ...base, query: { i: 1 } })
+  t.not(a.body, b.body, 'different query strings are distinct entries')
+  t.equal(hits, 2)
+
+  await flush()
+  const c = await rawRequest(dispatch, { ...base, query: { i: 0 } })
+  t.equal(hits, 2, 'repeat query served from cache')
+})
+
+// ---------------------------------------------------------------------------
+// Store: delete() and supersede
+// ---------------------------------------------------------------------------
+
+test('store: delete() removes all entries for the URI including pending batch inserts', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const now = Date.now()
+  const value = (body) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    cachedAt: now,
+    staleAt: now + 60e3,
+    deleteAt: now + 120e3,
+  })
+
+  const getKey = { origin: 'https://example.com', method: 'GET', path: '/x' }
+  const headKey = { origin: 'https://example.com', method: 'HEAD', path: '/x' }
+
+  // One flushed entry and one pending batch entry.
+  store.set(getKey, value('flushed'))
+  await flush()
+  store.set(headKey, { ...value(''), body: null, end: 0 })
+
+  t.ok(store.get(getKey), 'GET entry present')
+  t.ok(store.get(headKey), 'HEAD entry present (batch)')
+
+  store.delete(getKey)
+
+  t.equal(store.get(getKey), undefined, 'flushed entry deleted')
+  t.equal(
+    store.get(headKey),
+    undefined,
+    'pending batch entry for the URI dropped (no resurrection)',
+  )
+
+  await flush()
+  t.equal(store.get(getKey), undefined, 'entry stays gone after the batch flushes')
+  t.end()
+})
+
+test('store: re-caching a key supersedes the old row instead of accumulating', async (t) => {
+  const dbPath = path.join(
+    os.tmpdir(),
+    `supersede-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
+  )
+  const store = new SqliteCacheStore({ location: dbPath })
+  t.teardown(() => {
+    store.close()
+    fs.rmSync(dbPath, { force: true })
+    fs.rmSync(`${dbPath}-wal`, { force: true })
+    fs.rmSync(`${dbPath}-shm`, { force: true })
+  })
+
+  const key = { origin: 'https://example.com', method: 'GET', path: '/hot' }
+  const value = (body, cachedAt) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    cachedAt,
+    staleAt: cachedAt + 60e3,
+    deleteAt: cachedAt + 120e3,
+  })
+
+  const now = Date.now()
+  store.set(key, value('one', now - 2))
+  await flush()
+  store.set(key, value('two-longer', now - 1))
+  await flush()
+  store.set(key, value('three', now))
+  await flush()
+
+  t.equal(store.get(key).body.toString(), 'three', 'newest entry served')
+
+  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const { c } = db
+    .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV11 WHERE url = ?`)
+    .get('https://example.com/hot')
+  db.close()
+  t.equal(c, 1, 'older rows for the representation were superseded')
+  t.end()
+})
+
+test('store: distinct vary variants are not superseded by each other', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const now = Date.now()
+  const value = (body, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    vary,
+    cachedAt: now,
+    staleAt: now + 60e3,
+    deleteAt: now + 120e3,
+  })
+
+  store.set(
+    { origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '1' } },
+    value('variant-1', { a: '1' }),
+  )
+  await flush()
+  store.set(
+    { origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '2' } },
+    value('variant-2', { a: '2' }),
+  )
+  await flush()
+
+  t.equal(
+    store
+      .get({ origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '1' } })
+      .body.toString(),
+    'variant-1',
+    'first variant still served',
+  )
+  t.equal(
+    store
+      .get({ origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '2' } })
+      .body.toString(),
+    'variant-2',
+    'second variant served',
+  )
+  t.end()
+})

--- a/test/review-bugfixes-4-cache-header-case.js
+++ b/test/review-bugfixes-4-cache-header-case.js
@@ -58,8 +58,9 @@ test('cache: capitalized Authorization is not served a cached non-public respons
   const server = await startServer((req, res) => {
     hits++
     res.writeHead(200, {
-      // s-maxage but no 'public' — cacheable for anonymous requests only.
-      'cache-control': 's-maxage=60',
+      // max-age but no 'public'/'s-maxage'/'must-revalidate' — cacheable for
+      // anonymous requests only (RFC 9111 §3.5).
+      'cache-control': 'max-age=60',
       'content-type': 'text/plain',
     })
     res.end('non-public body')

--- a/test/review-bugfixes-4-cache-immutable.js
+++ b/test/review-bugfixes-4-cache-immutable.js
@@ -39,14 +39,15 @@ async function startServer(handler) {
   return server
 }
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
 test('cache: immutable does not override explicit max-age (expires on schedule)', async (t) => {
   t.plan(2)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    res.writeHead(200, { 'cache-control': 'max-age=1, immutable', 'content-type': 'text/plain' })
+    // max-age=5 rather than 1: node's Date header is second-truncated, so the
+    // corrected initial age (RFC 9111 §4.2.3) can legitimately read 1s at
+    // receipt — a 1s lifetime would make storability itself racy.
+    res.writeHead(200, { 'cache-control': 'max-age=5, immutable', 'content-type': 'text/plain' })
     res.end('body')
   })
   t.teardown(server.close.bind(server))
@@ -65,12 +66,11 @@ test('cache: immutable does not override explicit max-age (expires on schedule)'
   await rawRequest(dispatch, opts)
   t.equal(hits, 1, 'served from cache within the max-age window')
 
-  // getFastNow (used by the store's expiry check) refreshes on a 1s interval,
-  // so wait comfortably past max-age=1 for at least two ticks to elapse.
-  await sleep(2600)
-
-  await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'goes back to origin after max-age expires despite immutable')
+  // Expiry-on-schedule is asserted from the stored entry instead of sleeping
+  // past the TTL: max-age bounds the freshness lifetime, immutable does not
+  // extend it.
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.staleAt - entry.cachedAt, 5000, 'freshness is max-age, not immutable')
 })
 
 test('cache: immutable alone still caches with a long default TTL', async (t) => {
@@ -127,5 +127,9 @@ test('cache: explicit s-maxage wins over immutable', async (t) => {
   t.equal(hits, 1, 'served from cache within the s-maxage window')
 
   const entry = store.get(undici.util.cache.makeCacheKey(opts))
-  t.equal(entry.deleteAt - entry.cachedAt, 60 * 1000, 's-maxage=60 sets the TTL, not immutable')
+  t.equal(
+    entry.staleAt - entry.cachedAt,
+    60 * 1000,
+    's-maxage=60 sets the freshness, not immutable',
+  )
 })

--- a/test/review-bugfixes-4-sqlite-registry.js
+++ b/test/review-bugfixes-4-sqlite-registry.js
@@ -30,6 +30,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }
@@ -172,6 +173,7 @@ test('unclosed store is not pinned by the registry (GC can collect it)', async (
           statusCode: 200,
           statusMessage: 'OK',
           cachedAt: Date.now(),
+          staleAt: Date.now() + 3600e3,
           deleteAt: Date.now() + 7200e3,
         },
       )

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -24,6 +24,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -91,12 +91,12 @@ test('cache: request max-age=0 bypasses cache lookup', async (t) => {
 })
 
 // ---------------------------------------------------------------------------
-// 'min-fresh' / 'max-stale' are not recognised by cache-control-parser, so the
-// old directive checks were dead code and the cache served entries anyway.
+// 'min-fresh' / 'max-stale' are evaluated locally against the entry's
+// freshness (RFC 9111 §5.2.1.3 / §5.2.1.2) instead of bypassing the cache.
 // ---------------------------------------------------------------------------
 
-test('cache: request min-fresh bypasses cache lookup', async (t) => {
-  t.plan(1)
+test('cache: request min-fresh is evaluated against the entry freshness', async (t) => {
+  t.plan(2)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
@@ -115,11 +115,16 @@ test('cache: request min-fresh bypasses cache lookup', async (t) => {
   }
 
   await rawRequest(dispatch, { ...base, headers: {} })
+  // ~60s of freshness left — comfortably more than 30s.
   await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'min-fresh=30' } })
-  t.equal(hits, 2, 'min-fresh must go to the origin until the directive is supported')
+  t.equal(hits, 1, 'entry fresh for longer than min-fresh is served from cache')
+
+  // Demands more remaining freshness than the entry can have — origin.
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'min-fresh=120' } })
+  t.equal(hits, 2, 'entry with less remaining freshness than min-fresh goes to origin')
 })
 
-test('cache: request max-stale bypasses cache lookup', async (t) => {
+test('cache: request max-stale still serves a fresh entry', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
@@ -140,7 +145,7 @@ test('cache: request max-stale bypasses cache lookup', async (t) => {
 
   await rawRequest(dispatch, { ...base, headers: {} })
   await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-stale=30' } })
-  t.equal(hits, 2, 'max-stale must go to the origin until the directive is supported')
+  t.equal(hits, 1, 'a fresh entry satisfies a max-stale request')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/review-bugfixes-store.js
+++ b/test/review-bugfixes-store.js
@@ -19,6 +19,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }

--- a/test/sqlite-cache-store.js
+++ b/test/sqlite-cache-store.js
@@ -22,6 +22,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }


### PR DESCRIPTION
Reworks the cache interceptor around a `staleAt`/`deleteAt` split (schema v11): entries are retained past freshness and revalidated with conditional requests instead of refetched in full. Adopts the applicable fixes from upstream undici's open PR series (#5510–#5516) and merged work (#4911, #5081, #4913), adapted to our handler protocol and SQLite store.

## Revalidation core
- **`RevalidationHandler`**: dispatches conditional requests for stale entries — `if-none-match` from the stored etag, `if-modified-since` echoing the stored `Last-Modified` **verbatim** (nginx `if_modified_since exact` compat, undici PR #5512), falling back to the response `Date`, then receipt time. A 304 merges headers, restarts the freshness clock (RFC 9110 §6.6.1 receipt-time `Date` when the 304 omits one) and re-stores; any other status replaces the entry. User callbacks defer until the decision, with an eager connect so caller aborts cancel the in-flight conditional request.
- **stale-while-revalidate** (RFC 5861 §3): serve stale immediately, refresh in the background (per-key in-flight guard; opts cloned without `body`/`signal`).
- **stale-if-error** (RFC 5861 §4): serve stale on origin 5xx **and** pre-response connection errors (undici PR #5513); response directive first, request directive fallback; vetoed by `must-revalidate`/`proxy-revalidate` (undici PR #5511).
- **Store-and-revalidate**: `must-revalidate`/`proxy-revalidate`/unqualified `no-cache` responses are now stored and validated before reuse; zero-TTL responses with a validator are kept for revalidation (undici PR #5515).

## Request directives (undici #5504 / PR #5510)
Evaluated locally instead of bypassing: `max-age` (including `=0`, the `fetch cache:'no-cache'` idiom), `min-fresh`, `max-stale` (bare = any staleness), `no-cache`, `only-if-cached`. The caller's age bounds also gate every stale-serving window, and write-back is preserved on all miss paths — one client's freshness override no longer disables caching of the URL for everyone. Request `no-store` never writes, including 304 freshens.

## Invalidation (RFC 9111 §4.4, undici PR #5514)
Unsafe methods with a non-error response invalidate the target URI plus same-origin `Location`/`Content-Location` targets (cross-origin skipped as a poisoning guard). The store's new `delete()` also splices the pending insert batch so an in-flight write cannot resurrect an invalidated entry.

## Freshness math
Corrected initial age (§4.2.3: `cachedAt` backdated, origin `Age` stripped at store time), `Expires` fallback with invalid-`Expires`-is-expired (§5.3), opt-in `heuristic` and `defaultTTL` knobs (200s only), and `s-maxage`/`must-revalidate` accepted as §3.5 authorization permits with the store and serve gates in lockstep (undici PR #4911).

## Store & parser
- Supersede-on-write and read preference keyed by **receipt order** (matches upstream's update-in-place; a backdated `cachedAt` must not decide winners), so hot keys stop accumulating dead rows.
- `opts.query` folded into the cache key (undici PR #5081); flat-array request headers normalized before key building.
- Vendored cache-control parser replaces the `cache-control-parser` dependency: qualified `no-cache=`/`private=` field lists (stripped at store/freshen time per §5.2.2.4/§5.2.2.7), `only-if-cached`/`max-stale`/`min-fresh`, restrictive handling of duplicate and malformed directives; strict RFC 9110 `parseHttpDate`.

## Notes
- Schema bump to v11 invalidates existing on-disk caches on deploy (old-version tables are dropped automatically).
- Request deduplication/collapsing is deliberately out of scope.
- The implementation was adversarially reviewed by a 34-agent workflow (six lenses, per-finding refutation with live repros); all 28 confirmed findings are fixed with regression tests. Suites: 21 test files, 550+ assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)