### PR TITLE
feat(cache): RFC 9111 freshness, §3.5 auth permits, invalidation, store hardening

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -252,7 +252,8 @@ export interface CacheValue {
   etag?: string
   vary?: Record<string, string | string[]>
   cachedAt: number
-  staleAt: number
+  /** Optional on set(): omitting it defaults to deleteAt (staleAt === deleteAt). */
+  staleAt?: number
   deleteAt?: number
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -134,8 +134,15 @@ export interface ProxyOptions {
 export interface CacheOptions {
   store?: CacheStore
   maxEntrySize?: number
-  /** Upper bound on an entry's freshness lifetime, in seconds (default 30 days). */
+  /** Upper bound on an entry's freshness lifetime AND retention, in seconds
+   *  (default 30 days). */
   maxEntryTTL?: number
+  /** Opt-in RFC 9111 §4.2.2 heuristic freshness (10% of time since
+   *  Last-Modified) for 200 responses without explicit expiration. */
+  heuristic?: boolean
+  /** Opt-in fallback freshness lifetime in seconds for 200 responses without
+   *  any expiration information. */
+  defaultTTL?: number
 }
 
 export interface VerifyOptions {
@@ -245,6 +252,7 @@ export interface CacheValue {
   etag?: string
   vary?: Record<string, string | string[]>
   cachedAt: number
+  staleAt: number
   deleteAt?: number
 }
 
@@ -257,6 +265,7 @@ export interface CacheGetResult {
   cacheControlDirectives?: Record<string, unknown>
   vary?: Record<string, string | string[]>
   cachedAt: number
+  staleAt: number
   deleteAt: number
 }
 
@@ -266,6 +275,9 @@ export interface CacheStore {
     key: CacheKey,
     value: CacheValue & { body: null | Buffer | Buffer[]; start: number; end: number },
   ): void
+  /** RFC 9111 §4.4 invalidation — optional; the cache interceptor
+   *  feature-detects it and skips invalidation when absent. */
+  delete?(key: CacheKey): void
   gc(): void
   clear(): void
   close(): void
@@ -338,6 +350,8 @@ export class SqliteCacheStore implements CacheStore {
     key: CacheKey,
     value: CacheValue & { body: null | Buffer | Buffer[]; start: number; end: number },
   ): void
+  /** RFC 9111 §4.4: invalidates every stored response for the key's URI. */
+  delete(key: CacheKey): void
   gc(): void
   clear(): void
   close(): void

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1,17 +1,135 @@
 import undici from '@nxtedition/undici'
+import { stringify } from 'fast-querystring'
 import {
   DecoratorHandler,
-  getFastNow,
   isStream,
   parseCacheControl,
   parseContentRange,
+  parseHeaders,
+  parseHttpDate,
 } from '../utils.js'
+import { isHopByHop } from './proxy.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
 
 let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
-const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600
+const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600 // seconds
+// RFC 8246 'immutable' has no lifetime of its own; this is the customary
+// 1-year default, capped by maxEntryTTL below.
+const IMMUTABLE_LIFETIME = 31556952 // seconds
 const NOOP = () => {}
+
+/**
+ * Explicit (or opt-in heuristic) freshness lifetime in seconds, or null when
+ * the response carries no usable expiration information. RFC 9111 §4.2.1
+ * priority for a shared cache: s-maxage > max-age > Expires. immutable
+ * (RFC 8246) and the opt-in heuristics only apply when no explicit lifetime
+ * is present. `explicit` marks origin-provided expiration — required for the
+ * stale-on-arrival store-and-revalidate path (never keep heuristically-stale
+ * content around for revalidation).
+ *
+ * @returns {{ lifetime: number, explicit: boolean } | null}
+ */
+function determineLifetime(
+  statusCode,
+  headers,
+  cacheControlDirectives,
+  { heuristic, defaultTTL },
+  now,
+) {
+  const explicit = cacheControlDirectives['s-maxage'] ?? cacheControlDirectives['max-age']
+  if (explicit != null) {
+    return { lifetime: explicit, explicit: true }
+  }
+
+  if (headers.expires != null) {
+    // RFC 9111 §5.3: an invalid Expires (notably `Expires: 0`) means already
+    // expired — the parse failure must surface as lifetime 0, not fall through
+    // to heuristics. Arrays (duplicated, potentially conflicting Expires field
+    // lines) are treated the same way.
+    const expires = typeof headers.expires === 'string' ? parseHttpDate(headers.expires) : undefined
+    if (!expires) {
+      return { lifetime: 0, explicit: true }
+    }
+    const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+    return {
+      lifetime: Math.floor((expires.getTime() - (date ? date.getTime() : now)) / 1000),
+      explicit: true,
+    }
+  }
+
+  if (cacheControlDirectives.immutable) {
+    return { lifetime: IMMUTABLE_LIFETIME, explicit: false }
+  }
+
+  // Heuristic freshness and defaultTTL are per-request client opt-ins and
+  // deliberately restricted to plain 200s — heuristically extending 206/307
+  // would cache partials and temporary redirects without origin consent.
+  if (statusCode === 200) {
+    if (heuristic && typeof headers['last-modified'] === 'string') {
+      // RFC 9111 §4.2.2 suggested heuristic: 10% of time since Last-Modified.
+      // §4.2.2 forbids heuristics when an explicit expiration exists; Expires
+      // was handled (including the invalid form) above, so this is reached
+      // only when none does.
+      const lastModified = parseHttpDate(headers['last-modified'])
+      if (lastModified && lastModified.getTime() < now) {
+        return { lifetime: Math.floor((now - lastModified.getTime()) / 10 / 1000), explicit: false }
+      }
+    }
+    if (typeof defaultTTL === 'number' && defaultTTL > 0) {
+      return { lifetime: defaultTTL, explicit: false }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Corrected initial age in whole seconds per RFC 9111 §4.2.3 (simplified):
+ * the larger of the Age header and the apparent age (receipt time minus the
+ * origin Date). A response relayed through intermediaries that don't add Age
+ * would otherwise get an over-extended TTL and be served stale.
+ */
+function determineAge(headers, now) {
+  const rawAge = headers.age
+  // A duplicated Age header arrives as an array; take the first value like
+  // upstream — Number(array) would yield NaN and silently read as age 0.
+  const age = parseInt(Array.isArray(rawAge) ? rawAge[0] : rawAge, 10)
+  const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+  const apparentAge = date ? Math.max(0, Math.floor((now - date.getTime()) / 1000)) : 0
+  return Math.max(Number.isFinite(age) && age > 0 ? age : 0, apparentAge)
+}
+
+/**
+ * Computes the entry's absolute times, or null when it shouldn't be stored.
+ *
+ * cachedAt is backdated by the corrected initial age so all downstream age
+ * math (served Age header, freshness checks) reduces to `now - cachedAt`; the
+ * origin Age header is stripped before storing to match.
+ *
+ * This cache does not retain entries past freshness for revalidation, so
+ * deleteAt == staleAt: an entry is dropped by the store as soon as it goes
+ * stale, and the read path never serves a stale entry. (The staleAt column
+ * exists for forward compatibility with revalidation.) Everything is capped
+ * by maxEntryTTL, measured from the (backdated) cachedAt.
+ */
+function computeEntryTimes(lifetime, age, maxEntryTTL, now) {
+  if (!Number.isFinite(lifetime)) {
+    return null
+  }
+
+  const freshness = Math.min(lifetime, maxEntryTTL) // seconds
+  if (freshness - age <= 0) {
+    // Stale on arrival — not worth storing.
+    return null
+  }
+
+  const cachedAt = now - age * 1000
+  const staleAt = cachedAt + freshness * 1000
+  const deleteAt = staleAt
+
+  return { cachedAt, staleAt, deleteAt }
+}
 
 class CacheHandler extends DecoratorHandler {
   #key
@@ -20,8 +138,10 @@ class CacheHandler extends DecoratorHandler {
   #logger
   #maxEntrySize
   #maxEntryTTL
+  #heuristic
+  #defaultTTL
 
-  constructor(key, { store, logger, handler, maxEntrySize, maxEntryTTL }) {
+  constructor(key, { store, logger, handler, maxEntrySize, maxEntryTTL, heuristic, defaultTTL }) {
     super(handler)
 
     this.#key = key
@@ -30,6 +150,8 @@ class CacheHandler extends DecoratorHandler {
     this.#store = store
     this.#maxEntrySize = maxEntrySize ?? store.maxEntrySize ?? DEFAULT_MAX_ENTRY_SIZE
     this.#maxEntryTTL = maxEntryTTL ?? store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL
+    this.#heuristic = heuristic ?? false
+    this.#defaultTTL = defaultTTL ?? null
   }
 
   onConnect(abort) {
@@ -94,11 +216,30 @@ class CacheHandler extends DecoratorHandler {
 
     const cacheControlDirectives = parseCacheControl(headers['cache-control']) ?? {}
 
-    if (this.#key.headers.authorization && !cacheControlDirectives.public) {
-      return super.onHeaders(statusCode, headers, resume)
+    // RFC 9111 §3.5: a shared cache may store a response to a request with
+    // Authorization only when the response explicitly allows it: public,
+    // s-maxage, or must-revalidate (safe because such entries are never
+    // served stale without successful revalidation). Must stay in lockstep
+    // with the serve-side gate in the interceptor below. A duplicated
+    // (array) authorization header is refused outright.
+    const authorization = this.#key.headers.authorization
+    if (authorization != null) {
+      if (
+        typeof authorization !== 'string' ||
+        !(
+          cacheControlDirectives.public === true ||
+          cacheControlDirectives['s-maxage'] != null ||
+          cacheControlDirectives['must-revalidate'] === true
+        )
+      ) {
+        return super.onHeaders(statusCode, headers, resume)
+      }
     }
 
-    if (cacheControlDirectives.private || cacheControlDirectives['no-store']) {
+    // Unqualified private forbids shared-cache storage entirely; the
+    // qualified form (private="field") only forbids storing the listed
+    // fields, which are stripped below (RFC 9111 §5.2.2.7).
+    if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -113,11 +254,14 @@ class CacheHandler extends DecoratorHandler {
     if (
       cacheControlDirectives['must-revalidate'] ||
       cacheControlDirectives['proxy-revalidate'] ||
-      cacheControlDirectives['stale-while-revalidate'] ||
-      cacheControlDirectives['stale-if-error'] ||
-      cacheControlDirectives['no-cache']
+      cacheControlDirectives['stale-while-revalidate'] != null ||
+      cacheControlDirectives['stale-if-error'] != null ||
+      cacheControlDirectives['no-cache'] === true
     ) {
-      // TODO (fix): Support all cache control directives...
+      // These directives require origin revalidation, which this cache does
+      // not yet perform — so the responses are not stored (a follow-up adds
+      // conditional revalidation and turns these into stored-and-validated
+      // entries).
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -144,26 +288,23 @@ class CacheHandler extends DecoratorHandler {
       }
     }
 
-    // RFC 8246: 'immutable' means the body won't change during the freshness
-    // lifetime — it does not define or extend that lifetime. An explicit
-    // s-maxage/max-age always wins; immutable only supplies a (long) default
-    // when no explicit lifetime is present. Capped by maxEntryTTL below.
-    const ttl = Number(
-      cacheControlDirectives['s-maxage'] ??
-        cacheControlDirectives['max-age'] ??
-        (cacheControlDirectives.immutable ? 31556952 : NaN),
+    const now = Date.now()
+
+    const lifetimeInfo = determineLifetime(
+      statusCode,
+      headers,
+      cacheControlDirectives,
+      { heuristic: this.#heuristic, defaultTTL: this.#defaultTTL },
+      now,
     )
-    if (!ttl || !Number.isFinite(ttl) || ttl <= 0) {
+    if (lifetimeInfo == null) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    // RFC 9111 §4.2.3: a response relayed by an upstream/shared cache may
-    // already be partway through its freshness lifetime. Subtract the
-    // advertised Age so we don't over-extend the TTL and serve stale content.
-    const age = Number(headers.age)
-    const lifetime = Math.min(ttl, this.#maxEntryTTL) - (Number.isFinite(age) && age > 0 ? age : 0)
-    if (lifetime <= 0) {
-      // Already stale on arrival — not worth caching.
+    const etag = typeof headers.etag === 'string' && isEtagUsable(headers.etag) ? headers.etag : ''
+    const age = determineAge(headers, now)
+    const times = computeEntryTimes(lifetimeInfo.lifetime, age, this.#maxEntryTTL, now)
+    if (times == null) {
       return super.onHeaders(statusCode, headers, resume)
     }
 
@@ -175,7 +316,6 @@ class CacheHandler extends DecoratorHandler {
     const end = contentRange ? contentRange.end : this.#key.method === 'HEAD' ? 0 : contentLength
 
     if (end == null || end - start <= this.#maxEntrySize) {
-      const cachedAt = Date.now()
       // Snapshot the headers: the same object is delivered downstream to the
       // caller (request() resolves with it before the body finishes), and the
       // entry isn't serialized to the store until onComplete. Without a copy,
@@ -188,23 +328,58 @@ class CacheHandler extends DecoratorHandler {
       // plain `{}` a header literally named `__proto__` would hit the
       // Object.prototype setter instead of becoming a data property (silent
       // drop / prototype-pollution vector).
+      //
+      // Stripped while copying (RFC 9111 §3.1): hop-by-hop fields, fields
+      // listed in the Connection header, fields named by qualified
+      // no-cache=/private= directives (§5.2.2.4/§5.2.2.7), and Age — cachedAt
+      // is backdated by the corrected initial age, so the served Age is fully
+      // recomputed and a stored Age would double-count.
+      const excludedHeaders = new Set(['age'])
+      const connection = headers.connection
+      if (typeof connection === 'string') {
+        for (const name of connection.split(',')) {
+          excludedHeaders.add(name.trim().toLowerCase())
+        }
+      } else if (Array.isArray(connection)) {
+        for (const line of connection) {
+          for (const name of `${line}`.split(',')) {
+            excludedHeaders.add(name.trim().toLowerCase())
+          }
+        }
+      }
+      if (Array.isArray(cacheControlDirectives['no-cache'])) {
+        for (const name of cacheControlDirectives['no-cache']) {
+          excludedHeaders.add(name)
+        }
+      }
+      if (Array.isArray(cacheControlDirectives.private)) {
+        for (const name of cacheControlDirectives.private) {
+          excludedHeaders.add(name)
+        }
+      }
+
       const storedHeaders = Object.create(null)
       for (const name of Object.keys(headers)) {
+        if (isHopByHop(name) || excludedHeaders.has(name.toLowerCase())) {
+          continue
+        }
         const val = headers[name]
         storedHeaders[name] = Array.isArray(val) ? val.slice() : val
       }
+
       this.#value = {
         body: [],
         start,
         end,
-        deleteAt: cachedAt + lifetime * 1e3,
+        cachedAt: times.cachedAt,
+        staleAt: times.staleAt,
+        deleteAt: times.deleteAt,
         statusCode,
         statusMessage: '',
         headers: storedHeaders,
         cacheControlDirectives,
-        etag: isEtagUsable(headers.etag) ? headers.etag : '',
+        etag,
         vary,
-        cachedAt,
         // Handler state.
         size: 0,
       }
@@ -246,24 +421,109 @@ class CacheHandler extends DecoratorHandler {
   }
 }
 
-export default () => (dispatch) => (opts, handler) => {
-  if (!opts.cache || opts.upgrade) {
-    return dispatch(opts, handler)
+/**
+ * RFC 9111 §4.4: a non-error response to an unsafe method invalidates the
+ * stored entries for the target URI and any same-origin Location /
+ * Content-Location URIs (undici PR #5514). Cross-origin targets are skipped —
+ * honoring an attacker-influenced Location against another origin's entries
+ * would be a cache-poisoning vector.
+ */
+class InvalidationHandler extends DecoratorHandler {
+  #key
+  #store
+  #logger
+
+  constructor(key, { store, logger, handler }) {
+    super(handler)
+    this.#key = key
+    this.#store = store
+    this.#logger = logger
   }
 
-  if (opts.method !== 'GET' && opts.method !== 'HEAD') {
-    return dispatch(opts, handler)
+  onHeaders(statusCode, headers, resume) {
+    if (statusCode >= 200 && statusCode <= 399) {
+      // Invalidation failures must never break the actual response. Deletes
+      // are idempotent, so a retry re-driving onHeaders is harmless.
+      try {
+        this.#invalidate(headers)
+      } catch (err) {
+        if (err.message === 'database is locked') {
+          this.#logger?.debug({ err }, 'failed to invalidate cache entry')
+        } else {
+          this.#logger?.error({ err }, 'failed to invalidate cache entry')
+        }
+      }
+    }
+    return super.onHeaders(statusCode, headers, resume)
   }
 
-  // TODO (fix): enable range requests
+  #invalidate(headers) {
+    this.#store.delete(this.#key)
 
+    const invalidated = new Set([this.#key.path])
+    let base
+    for (const name of ['location', 'content-location']) {
+      let value = headers[name]
+      if (Array.isArray(value)) {
+        value = value[0]
+      }
+      if (typeof value !== 'string' || value === '') {
+        continue
+      }
+
+      base ??= new URL(this.#key.path, this.#key.origin)
+      let target
+      try {
+        target = new URL(value, base)
+      } catch {
+        continue
+      }
+      if (target.origin !== base.origin) {
+        continue
+      }
+
+      const path = target.pathname + target.search
+      if (!invalidated.has(path)) {
+        invalidated.add(path)
+        this.#store.delete({ ...this.#key, path })
+      }
+    }
+  }
+}
+
+function getStore(opts) {
+  return opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
+}
+
+function tryGetEntry(store, key, logger) {
+  try {
+    return store.get(key)
+  } catch (err) {
+    if (err.message === 'database is locked') {
+      // Database is busy. We don't bother trying again...
+      logger?.debug({ err }, 'failed to get cache entry')
+    } else {
+      logger?.error({ err }, 'failed to get cache entry')
+    }
+  }
+}
+
+/**
+ * Builds the cache key shared by the get and set paths.
+ */
+function makeKey(opts) {
   // Build the key the same way for lookups and stores: makeCacheKey
   // stringifies the origin (e.g. URL objects), so using raw opts on the get
   // path while the set path normalizes would make the cache permanently miss.
-  const key = undici.util.cache.makeCacheKey(opts)
+  // The flat name/value array form of opts.headers (legal at the undici
+  // client level) makes makeCacheKey throw — normalize it through
+  // parseHeaders first (which also lowercases the names).
+  const key = undici.util.cache.makeCacheKey(
+    Array.isArray(opts.headers) ? { ...opts, headers: parseHeaders(opts.headers) } : opts,
+  )
 
   // makeCacheKey preserves request header names verbatim. Vary selector names
-  // are lowercased (in onHeaders and matchesValue), so lowercase the key's
+  // are lowercased (in CacheHandler and matchesValue), so lowercase the key's
   // header names once here — the same key feeds both the get and set paths, so
   // this keeps Vary matching symmetric even when a caller supplies non-lowercase
   // header names (the standalone interceptors.cache() composition; the wrapped
@@ -279,6 +539,64 @@ export default () => (dispatch) => (opts, handler) => {
     key.headers = lower
   }
 
+  // The vendored makeCacheKey ignores opts.query. The wrapped pipeline is
+  // immune (the query interceptor rewrites path before the cache sees it),
+  // but a standalone interceptors.cache() composition would silently collide
+  // distinct query strings onto one entry and serve the wrong response
+  // (undici issue #4209 / PR #5081) — fold the query into the key path.
+  if (
+    opts.query &&
+    typeof key.path === 'string' &&
+    !key.path.includes('?') &&
+    !key.path.includes('#')
+  ) {
+    const qs = stringify(opts.query)
+    if (qs) {
+      key.path = `${key.path || '/'}?${qs}`
+    }
+  }
+
+  return key
+}
+
+function cacheOptsOf(opts) {
+  return {
+    maxEntrySize: opts.cache.maxEntrySize,
+    maxEntryTTL: opts.cache.maxEntryTTL,
+    heuristic: opts.cache.heuristic,
+    defaultTTL: opts.cache.defaultTTL,
+  }
+}
+
+export default () => (dispatch) => (opts, handler) => {
+  if (!opts.cache || opts.upgrade) {
+    return dispatch(opts, handler)
+  }
+
+  if (opts.method !== 'GET' && opts.method !== 'HEAD') {
+    // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
+    // must not invalidate either. Every other method (POST/PUT/DELETE/...)
+    // invalidates the target URI on a non-error response (RFC 9111 §4.4).
+    if (opts.method === 'OPTIONS' || opts.method === 'TRACE') {
+      return dispatch(opts, handler)
+    }
+
+    const store = getStore(opts)
+    if (typeof store.delete !== 'function') {
+      // User-supplied store without invalidation support.
+      return dispatch(opts, handler)
+    }
+
+    return dispatch(
+      opts,
+      new InvalidationHandler(makeKey(opts), { store, logger: opts.logger, handler }),
+    )
+  }
+
+  // TODO (fix): enable range requests
+
+  const key = makeKey(opts)
+
   // All request-directive and conditional-header guards below MUST read from
   // the lowercased key.headers, not raw opts.headers — otherwise a caller
   // supplying capitalized names (e.g. `Authorization`, `Cache-Control` via the
@@ -287,64 +605,72 @@ export default () => (dispatch) => (opts, handler) => {
   // cached response to an authorized request (RFC 9111 §3.5).
   const headers = key.headers ?? {}
 
-  // Cache-Control is a list-typed field: duplicated field lines arrive as an
-  // array and combine into a single comma-separated value per RFC 9110 §5.2,
-  // keeping the raw-string directive checks below working.
-  let rawCacheControl = headers['cache-control']
-  if (Array.isArray(rawCacheControl)) {
-    rawCacheControl = rawCacheControl.join(', ')
-  }
-  const cacheControlDirectives = parseCacheControl(rawCacheControl) ?? {}
-  // cache-control-parser does not recognise 'only-if-cached', so check the raw string.
-  const onlyIfCached =
-    typeof rawCacheControl === 'string' && rawCacheControl.includes('only-if-cached')
+  const rawCacheControl = headers['cache-control']
+  const requestCacheControl = parseCacheControl(rawCacheControl) ?? {}
 
   // RFC 9111 Section 5.4: Pragma: no-cache should be treated as
   // Cache-Control: no-cache when Cache-Control is absent.
   if (rawCacheControl == null && headers.pragma === 'no-cache') {
-    cacheControlDirectives['no-cache'] = true
+    requestCacheControl['no-cache'] = true
   }
 
-  if (cacheControlDirectives['no-transform']) {
+  if (requestCacheControl['no-transform']) {
     // Do nothing. We don't transform requests...
   }
 
-  if (
-    // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
-    cacheControlDirectives['max-age'] != null ||
-    cacheControlDirectives['no-cache'] ||
-    cacheControlDirectives['stale-if-error'] != null ||
-    // cache-control-parser does not recognise 'max-stale'/'min-fresh', so
-    // check the raw string like we do for 'only-if-cached'.
-    (typeof rawCacheControl === 'string' &&
-      (rawCacheControl.includes('max-stale') || rawCacheControl.includes('min-fresh')))
-  ) {
-    // TODO (fix): Support all cache control directives...
-    return dispatch(opts, handler)
-  }
+  const onlyIfCached = requestCacheControl['only-if-cached'] === true
+  const store = getStore(opts)
 
-  const store =
-    opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
+  let entry = tryGetEntry(store, key, opts.logger)
 
-  let entry
-  try {
-    entry = store.get(key)
-  } catch (err) {
-    if (err.message === 'database is locked') {
-      // Database is busy. We don't bother trying again...
-      opts.logger?.debug({ err }, 'failed to get cache entry')
-    } else {
-      opts.logger?.error({ err }, 'failed to get cache entry')
+  // RFC 9111 §3.5 serve-side authorization gate: a shared cache must not
+  // reuse a stored response for a request with Authorization unless the
+  // response allowed it (public, s-maxage or must-revalidate — the mirror of
+  // the store-side gate in CacheHandler; both sites must stay in lockstep).
+  if (entry && headers.authorization != null) {
+    const directives = entry.cacheControlDirectives
+    if (
+      typeof headers.authorization !== 'string' ||
+      !(
+        directives?.public === true ||
+        directives?.['s-maxage'] != null ||
+        directives?.['must-revalidate'] === true
+      )
+    ) {
+      entry = undefined
     }
   }
 
-  // RFC 9111 Section 3.5: A shared cache must not use a cached response to a
-  // request with Authorization unless the response includes a public directive.
-  if (entry && headers.authorization && !entry.cacheControlDirectives?.public) {
-    entry = undefined
+  const cacheHandler = () =>
+    new CacheHandler(key, {
+      ...cacheOptsOf(opts),
+      store,
+      logger: opts.logger,
+      handler,
+    })
+
+  // Request Cache-Control directives that this cache does not evaluate locally
+  // (a follow-up adds conditional revalidation and local evaluation) cause a
+  // bypass to the origin. These constrain REUSE of a stored response, not the
+  // stored entry itself, so an existing entry is left intact for other
+  // callers. only-if-cached is the exception: it forbids contacting the
+  // origin, so it is handled from the cache below instead of bypassing.
+  const bypass =
+    !onlyIfCached &&
+    // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
+    (requestCacheControl['max-age'] != null ||
+      requestCacheControl['no-cache'] === true ||
+      requestCacheControl['stale-if-error'] != null ||
+      requestCacheControl['max-stale'] != null ||
+      requestCacheControl['min-fresh'] != null)
+
+  if (bypass) {
+    return dispatch(opts, handler)
   }
 
-  // RFC 9110 Section 13: Evaluate conditional request headers against cached entry.
+  // RFC 9110 Section 13: evaluate conditional request headers against the
+  // cached entry. The store only returns entries that are still fresh
+  // (deleteAt === staleAt), so a returned entry is always servable.
   // typeof guards: duplicated conditional headers arrive as arrays — treat
   // them as non-matching and bypass to origin rather than crashing.
   if (entry && headers['if-none-match']) {
@@ -384,20 +710,13 @@ export default () => (dispatch) => (opts, handler) => {
   }
 
   if (!entry && !onlyIfCached) {
-    return dispatch(
-      opts,
-      cacheControlDirectives['no-store']
-        ? handler
-        : new CacheHandler(key, {
-            maxEntrySize: opts.cache.maxEntrySize,
-            maxEntryTTL: opts.cache.maxEntryTTL,
-            store,
-            logger: opts.logger,
-            handler,
-          }),
-    )
+    // A miss keeps the CacheHandler write-back unless the request's no-store
+    // forbids storing.
+    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
   }
 
+  // A hit (fresh, per the store) is served; only-if-cached with no usable
+  // entry yields 504 (RFC 9111 §5.2.1.7).
   return serveFromCache(entry ?? { statusCode: 504 }, opts, handler)
 }
 
@@ -406,13 +725,13 @@ function serveFromCache(entry, opts, handler) {
 
   let headers = entry.headers
   if (entry.cachedAt != null) {
-    // RFC 9111 §5.1: every response served from cache must carry an Age header
-    // reflecting time spent in this cache plus any age it arrived with —
-    // otherwise downstream caches treat it as fresh-from-origin.
-    // getFastNow has 1s resolution — Age is whole seconds, so that's enough.
-    const residentAge = Math.max(0, Math.floor((getFastNow() - entry.cachedAt) / 1000))
-    const originAge = Number(headers?.age)
-    const age = Number.isFinite(originAge) && originAge > 0 ? originAge + residentAge : residentAge
+    // RFC 9111 §5.1: every response served from cache must carry an Age
+    // header. cachedAt is backdated by the corrected initial age at store
+    // time (§4.2.3) and the origin's Age header is stripped, so resident time
+    // IS the response's age — no origin-Age addition. Date.now(), not
+    // getFastNow(): the lagging clock would understate a relayed response's
+    // initial age by up to a second.
+    const age = Math.max(0, Math.floor((Date.now() - entry.cachedAt) / 1000))
     headers = { ...headers, age: `${age}` }
   }
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -92,12 +92,18 @@ function determineLifetime(
  */
 function determineAge(headers, now) {
   const rawAge = headers.age
-  // A duplicated Age header arrives as an array; take the first value like
-  // upstream — Number(array) would yield NaN and silently read as age 0.
-  const age = parseInt(Array.isArray(rawAge) ? rawAge[0] : rawAge, 10)
+  // A duplicated Age header arrives as an array; take the first value.
+  const rawAgeValue = Array.isArray(rawAge) ? rawAge[0] : rawAge
+  // RFC 9111 §5.1 Age is delta-seconds (1*DIGIT): require a pure integer so a
+  // malformed value like "5junk" isn't parseInt-coerced to 5 and used to
+  // backdate cachedAt / extend staleness.
+  const age =
+    typeof rawAgeValue === 'string' && /^\d+$/.test(rawAgeValue.trim())
+      ? parseInt(rawAgeValue, 10)
+      : 0
   const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
   const apparentAge = date ? Math.max(0, Math.floor((now - date.getTime()) / 1000)) : 0
-  return Math.max(Number.isFinite(age) && age > 0 ? age : 0, apparentAge)
+  return Math.max(age, apparentAge)
 }
 
 /**

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -663,9 +663,11 @@ export default () => (dispatch) => (opts, handler) => {
   // Request Cache-Control directives that this cache does not evaluate locally
   // (a follow-up adds conditional revalidation and local evaluation) cause a
   // bypass to the origin. These constrain REUSE of a stored response, not the
-  // stored entry itself, so an existing entry is left intact for other
-  // callers. only-if-cached is the exception: it forbids contacting the
-  // origin, so it is handled from the cache below instead of bypassing.
+  // storage of a fresh one — so the bypass still writes the origin response
+  // back through CacheHandler for later callers (undici PR #5510), unless the
+  // request's own no-store forbids storing. only-if-cached is the exception:
+  // it forbids contacting the origin, so it is handled from the cache below
+  // instead of bypassing.
   const bypass =
     !onlyIfCached &&
     // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
@@ -676,7 +678,7 @@ export default () => (dispatch) => (opts, handler) => {
       requestCacheControl['min-fresh'] != null)
 
   if (bypass) {
-    return dispatch(opts, handler)
+    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
   }
 
   // RFC 9110 Section 13: evaluate conditional request headers against the

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -523,9 +523,14 @@ function makeKey(opts) {
   // path while the set path normalizes would make the cache permanently miss.
   // The flat name/value array form of opts.headers (legal at the undici
   // client level) makes makeCacheKey throw — normalize it through
-  // parseHeaders first (which also lowercases the names).
+  // parseHeaders first (which also lowercases the names). Header names are
+  // caller-controlled, so parse into a null-prototype target: a `__proto__`
+  // name on a plain `{}` would hit the Object.prototype setter instead of
+  // becoming a data property.
   const key = undici.util.cache.makeCacheKey(
-    Array.isArray(opts.headers) ? { ...opts, headers: parseHeaders(opts.headers) } : opts,
+    Array.isArray(opts.headers)
+      ? { ...opts, headers: parseHeaders(opts.headers, Object.create(null)) }
+      : opts,
   )
 
   // makeCacheKey preserves request header names verbatim. Vary selector names

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -108,10 +108,13 @@ function eqiLower(a, b) {
 // allocation-free and letting the common (non-hop) header bail out in a single
 // comparison.
 /**
+ * Exported for reuse by the cache interceptor: RFC 9111 §3.1 forbids storing
+ * hop-by-hop fields, which is the same set a proxy must not retransmit.
+ *
  * @param {string} key
  * @returns {boolean}
  */
-function isHopByHop(key) {
+export function isHopByHop(key) {
   switch (key.length) {
     case 2:
       return eqiLower(key, 'te')

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
-const VERSION = 10
+const VERSION = 11
 
 // Registry of live stores so process-level broadcasts (nxt:offPeak,
 // nxt:clearCache) can reach them. Stores are held via WeakRef so that a store
@@ -51,8 +51,9 @@ function forEachStore(fn) {
 }
 
 /**
- * @typedef {import('undici-types/cache-interceptor.d.ts').default.CacheStore} CacheStore
- * @implements {CacheStore}
+ * Synchronous get/set/delete cache store backed by node:sqlite. Note: this is
+ * NOT undici's stream-based CacheStore interface (createWriteStream); the
+ * cache interceptor in this package drives it directly.
  *
  * @typedef {{
  *  id: Readonly<number>,
@@ -66,6 +67,7 @@ function forEachStore(fn) {
  *  etag?: string
  *  cacheControlDirectives?: string
  *  cachedAt: number
+ *  staleAt: number
  *  deleteAt: number
  * }} SqliteStoreValue
  */
@@ -99,6 +101,21 @@ export class SqliteCacheStore {
    * @type {import('node:sqlite').StatementSync}
    */
   #evictQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #deleteByUrlQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #supersedeFullQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #supersede206Query
 
   #insertBatch = []
   #insertSeq = 0
@@ -136,6 +153,7 @@ export class SqliteCacheStore {
         body BLOB NULL,
         start INTEGER NOT NULL,
         end INTEGER NOT NULL,
+        staleAt INTEGER NOT NULL,
         deleteAt INTEGER NOT NULL,
         statusCode INTEGER NOT NULL,
         statusMessage TEXT NOT NULL,
@@ -200,6 +218,7 @@ export class SqliteCacheStore {
         body,
         start,
         end,
+        staleAt,
         deleteAt,
         statusCode,
         statusMessage,
@@ -215,7 +234,7 @@ export class SqliteCacheStore {
         AND start <= ?
         AND deleteAt > ?
       ORDER BY
-        cachedAt DESC, id DESC
+        id DESC
     `)
 
     this.#insertValueQuery = this.#db.prepare(`
@@ -225,6 +244,7 @@ export class SqliteCacheStore {
         body,
         start,
         end,
+        staleAt,
         deleteAt,
         statusCode,
         statusMessage,
@@ -233,7 +253,7 @@ export class SqliteCacheStore {
         cacheControlDirectives,
         vary,
         cachedAt
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     this.#deleteExpiredValuesQuery = this.#db.prepare(
@@ -244,6 +264,35 @@ export class SqliteCacheStore {
     // without requiring expired entries to already exist.
     this.#evictQuery = this.#db.prepare(
       `DELETE FROM cacheInterceptorV${VERSION} WHERE id IN (SELECT id FROM cacheInterceptorV${VERSION} ORDER BY deleteAt ASC LIMIT ?)`,
+    )
+
+    // RFC 9111 §4.4 invalidation: a successful unsafe request invalidates every
+    // stored response for the URI, across methods and vary variants.
+    this.#deleteByUrlQuery = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ?`,
+    )
+
+    // Supersede queries: a newly flushed row replaces prior rows for the same
+    // representation so hot keys don't accumulate dead duplicates until gc.
+    // Receipt order (insertion order), NOT cachedAt, decides who wins — the
+    // same semantics as upstream undici's update-in-place set(). cachedAt is
+    // backdated by the corrected initial age (RFC 9111 §4.2.3), so a
+    // replacement fetched through a relay advertising a large Age (or a 304
+    // freshening with a skewed origin Date) can carry an OLDER cachedAt than
+    // the stale row it replaces; keying supersede or the read sort on
+    // cachedAt would let the stale row win every read, forever. `vary IS ?`
+    // is NULL-safe and compares the serialized-JSON text, deterministic
+    // because both sides are produced by the same CacheHandler code path
+    // (key order = Vary header order). A new full (non-206) representation
+    // supersedes all prior full ones regardless of byte window; a 206 only
+    // supersedes the exact same window so distinct partials coexist, and
+    // never a 200 row (matchesValue routes range and non-range requests to
+    // different rows).
+    this.#supersedeFullQuery = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ? AND method = ? AND vary IS ? AND statusCode != 206`,
+    )
+    this.#supersede206Query = this.#db.prepare(
+      `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ? AND method = ? AND vary IS ? AND statusCode = 206 AND start = ? AND end = ?`,
     )
 
     this.#ref = new WeakRef(this)
@@ -371,7 +420,7 @@ export class SqliteCacheStore {
       setImmediate(this.#flush)
     }
 
-    this.#insertBatch.push({
+    const entry = {
       // Monotonic per-store sequence used only to break cachedAt ties in
       // #findValue (newest write wins). Not persisted — #flush ignores it.
       seq: this.#insertSeq++,
@@ -380,6 +429,7 @@ export class SqliteCacheStore {
       body,
       start: value.start,
       end: value.end,
+      staleAt: value.staleAt,
       deleteAt: value.deleteAt,
       statusCode: value.statusCode,
       statusMessage: value.statusMessage,
@@ -390,7 +440,56 @@ export class SqliteCacheStore {
         : null,
       vary: value.vary ? JSON.stringify(value.vary) : null,
       cachedAt: value.cachedAt,
-    })
+    }
+
+    // Coalesce within the pending batch: a stampede of identical misses would
+    // otherwise commit N identical rows. Receipt order wins (see the
+    // #supersede* query comments): the entry being added supersedes every
+    // pending entry for the same representation.
+    for (let i = this.#insertBatch.length - 1; i >= 0; i--) {
+      const other = this.#insertBatch[i]
+      if (
+        other.url === entry.url &&
+        other.method === entry.method &&
+        other.vary === entry.vary &&
+        (entry.statusCode !== 206
+          ? other.statusCode !== 206
+          : other.statusCode === 206 && other.start === entry.start && other.end === entry.end)
+      ) {
+        this.#insertBatch.splice(i, 1)
+      }
+    }
+
+    this.#insertBatch.push(entry)
+  }
+
+  /**
+   * Invalidates every stored response for the key's URI (RFC 9111 §4.4) —
+   * across methods and vary variants. Pending batched inserts for the URI are
+   * dropped as well: a batch entry flushed after the DELETE would otherwise
+   * resurrect the invalidated response. Note this only covers THIS process's
+   * batch — with a shared on-disk store, another process's in-flight batch
+   * can still transiently resurrect an entry (bounded by its ~10ms flush
+   * slice); cross-process invalidation is inherently best-effort.
+   *
+   * @param {import('undici-types/cache-interceptor.d.ts').default.CacheKey} key
+   */
+  delete(key) {
+    assertCacheKey(key)
+
+    if (this.#closed) {
+      return
+    }
+
+    const url = makeValueUrl(key)
+
+    for (let i = this.#insertBatch.length - 1; i >= 0; i--) {
+      if (this.#insertBatch[i].url === url) {
+        this.#insertBatch.splice(i, 1)
+      }
+    }
+
+    this.#deleteByUrlQuery.run(url)
   }
 
   #flush = (final = false) => {
@@ -412,6 +511,7 @@ export class SqliteCacheStore {
               body,
               start,
               end,
+              staleAt,
               deleteAt,
               statusCode,
               statusMessage,
@@ -421,12 +521,21 @@ export class SqliteCacheStore {
               vary,
               cachedAt,
             } = this.#insertBatch[n++]
+            // Supersede prior rows for the same representation (see the
+            // #supersede* query comments) inside the same transaction, so a
+            // re-cache replaces instead of accumulating.
+            if (statusCode === 206) {
+              this.#supersede206Query.run(url, method, vary, start, end)
+            } else {
+              this.#supersedeFullQuery.run(url, method, vary)
+            }
             this.#insertValueQuery.run(
               url,
               method,
               body,
               start,
               end,
+              staleAt,
               deleteAt,
               statusCode,
               statusMessage,
@@ -534,16 +643,14 @@ export class SqliteCacheStore {
       return undefined
     }
 
-    // Newest representation wins. cachedAt is millisecond-resolution, so a
-    // re-cache within the same millisecond produces a tie; break it
-    // deterministically toward the freshest write: pending batch entries
-    // (tagged with a monotonic seq) are always newer than any flushed DB row,
-    // and within each source a higher seq/id wins.
+    // Most recently WRITTEN representation wins — receipt order, not
+    // cachedAt (see the #supersede* query comments: cachedAt is backdated by
+    // the corrected initial age, so a fresher write can carry an older
+    // cachedAt). Pending batch entries (tagged with a monotonic seq) are
+    // always newer than any flushed DB row, and within each source a higher
+    // seq/id wins.
     if (values.length > 1) {
       values.sort((a, b) => {
-        if (a.cachedAt !== b.cachedAt) {
-          return b.cachedAt - a.cachedAt
-        }
         const aBatch = a.seq != null
         const bBatch = b.seq != null
         if (aBatch !== bBatch) {
@@ -657,6 +764,7 @@ function makeResult(value) {
       ? JSON.parse(value.cacheControlDirectives)
       : undefined,
     cachedAt: value.cachedAt,
+    staleAt: value.staleAt,
     deleteAt: value.deleteAt,
   }
 }
@@ -696,7 +804,7 @@ function assertCacheValue(value) {
     throw new TypeError(`expected value to be object, got ${printType(value)}`)
   }
 
-  for (const property of ['statusCode', 'cachedAt', 'deleteAt']) {
+  for (const property of ['statusCode', 'cachedAt', 'staleAt', 'deleteAt']) {
     if (typeof value[property] !== 'number') {
       throw new TypeError(
         `expected value.${property} to be number, got ${printType(value[property])} [${value[property]}]`,

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -435,7 +435,9 @@ export class SqliteCacheStore {
       body,
       start: value.start,
       end: value.end,
-      staleAt: value.staleAt,
+      // staleAt column is NOT NULL; default to deleteAt when the caller omits
+      // it (pre-v11 value shape) — matches this package's staleAt === deleteAt.
+      staleAt: value.staleAt ?? value.deleteAt,
       deleteAt: value.deleteAt,
       statusCode: value.statusCode,
       statusMessage: value.statusMessage,
@@ -810,12 +812,22 @@ function assertCacheValue(value) {
     throw new TypeError(`expected value to be object, got ${printType(value)}`)
   }
 
-  for (const property of ['statusCode', 'cachedAt', 'staleAt', 'deleteAt']) {
+  for (const property of ['statusCode', 'cachedAt', 'deleteAt']) {
     if (typeof value[property] !== 'number') {
       throw new TypeError(
         `expected value.${property} to be number, got ${printType(value[property])} [${value[property]}]`,
       )
     }
+  }
+
+  // staleAt is optional for backward compatibility: pre-v11 callers of the
+  // public SqliteCacheStore.set() omit it, and set() defaults it to deleteAt
+  // (this package's staleAt === deleteAt semantics). Validate the type only
+  // when supplied.
+  if (value.staleAt !== undefined && typeof value.staleAt !== 'number') {
+    throw new TypeError(
+      `expected value.staleAt to be number, got ${printType(value.staleAt)} [${value.staleAt}]`,
+    )
   }
 
   if (typeof value.statusMessage !== 'string') {

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -166,6 +166,12 @@ export class SqliteCacheStore {
 
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method, start, deleteAt);
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
+      -- Covers the supersede-on-flush DELETEs (#supersedeFullQuery /
+      -- #supersede206Query), whose predicate is url+method+vary (+statusCode,
+      -- and start/end for 206) — so a re-cache supersedes via an index seek
+      -- instead of scanning every row for a hot url+method with many Vary
+      -- variants or partial windows.
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_supersedeQuery ON cacheInterceptorV${VERSION}(url, method, vary, statusCode, start, end);
     `)
 
     // Drop tables left behind by previous schema versions. gc(), clear() and

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-import cacheControlParser from 'cache-control-parser'
 import stream from 'node:stream'
 import assert from 'node:assert'
 import { util } from '@nxtedition/undici'
@@ -14,14 +13,288 @@ export function getFastNow() {
   return fastNow
 }
 
-export function parseCacheControl(str) {
-  if (Array.isArray(str)) {
-    // Cache-Control is a list-typed field, so duplicated field lines are legal
-    // (e.g. CDN + origin each adding one) and combine into a single
-    // comma-separated value per RFC 9110 §5.2.
-    str = str.join(', ')
+/**
+ * Vendored from undici's parseCacheControlHeader (lib/util/cache.js) with two
+ * deliberate deviations, both toward the conservative reading of RFC 9111:
+ * - duplicated max-age keeps the SMALLER value (§4.2.1 says a cache is free to
+ *   pick, so pick the one that revalidates sooner), upstream keeps the larger;
+ * - a bare (valueless) max-stale is represented as Infinity per §5.2.1.2
+ *   ("willing to accept a stale response of any age"), upstream drops it.
+ *
+ * Qualified no-cache/private (e.g. `no-cache="set-cookie"`) parse to an array
+ * of the listed field names; the unqualified forms parse to `true`. Callers
+ * that mean "unqualified" must check `=== true`, not truthiness.
+ *
+ * Keeps the historical wrapper contract: '', [], and non-strings return null
+ * (call sites rely on `?? {}`); an array of field lines is accepted directly
+ * (Cache-Control is list-typed, duplicated lines are legal per RFC 9110 §5.2).
+ *
+ * @param {string | string[] | null | undefined} header
+ * @returns {Record<string, boolean | number | string[]> | null}
+ */
+export function parseCacheControl(header) {
+  let directives
+  if (Array.isArray(header)) {
+    directives = []
+    for (const line of header) {
+      if (typeof line !== 'string') {
+        return null
+      }
+      directives.push(...line.split(','))
+    }
+    if (directives.length === 0) {
+      return null
+    }
+  } else if (header && typeof header === 'string') {
+    directives = header.split(',')
+  } else {
+    return null
   }
-  return str && typeof str === 'string' ? cacheControlParser.parse(str) : null
+
+  const output = {}
+
+  for (let i = 0; i < directives.length; i++) {
+    const directive = directives[i].toLowerCase()
+    const keyValueDelimiter = directive.indexOf('=')
+
+    let key
+    let value
+    if (keyValueDelimiter !== -1) {
+      key = directive.substring(0, keyValueDelimiter).trim()
+      value = directive.substring(keyValueDelimiter + 1)
+    } else {
+      key = directive.trim()
+    }
+
+    switch (key) {
+      case 'min-fresh':
+      case 'max-stale':
+      case 'max-age':
+      case 's-maxage':
+      case 'stale-while-revalidate':
+      case 'stale-if-error': {
+        if (value === undefined) {
+          if (key === 'max-stale') {
+            // Bare max-stale: any staleness is acceptable (RFC 9111
+            // §5.2.1.2). Number semantics keep call-site math
+            // (`staleAt + max-stale * 1000`) working unchanged.
+            output[key] = Infinity
+          }
+          continue
+        }
+        if (value[0] === ' ') {
+          continue
+        }
+
+        if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
+          value = value.substring(1, value.length - 1)
+        }
+
+        const parsedValue = parseInt(value, 10)
+        // RFC 9111 delta-seconds are non-negative; reject NaN and negatives
+        // (e.g. `max-age=-1`) rather than letting them into freshness math.
+        if (Number.isNaN(parsedValue) || parsedValue < 0) {
+          continue
+        }
+
+        if (key === 'max-age' && key in output && output[key] <= parsedValue) {
+          // Duplicate max-age: keep the smaller (sooner-stale) value.
+          continue
+        }
+
+        output[key] = parsedValue
+
+        break
+      }
+      case 'private':
+      case 'no-cache': {
+        if (value) {
+          // Qualified form: a quoted, possibly comma-separated list of field
+          // names (`no-cache="set-cookie, warning"`). The split-by-comma above
+          // may have cut the quoted list apart, so scan forward until the part
+          // that carries the closing quote. https://www.rfc-editor.org/rfc/rfc9111.html#name-no-cache-2
+          //
+          // The unqualified form is strictly more restrictive (forbids
+          // storing / demands validation for the WHOLE response), so when
+          // both forms appear (`private, private="x"` — invalid but seen in
+          // the wild), the qualified form must never clobber the `true`.
+          value = value.trim()
+          if (value[0] === '"') {
+            const headerNames = [value.substring(1)]
+
+            // length > 1: a lone `"` is an opening quote, not a closed list.
+            let foundEndingQuote = value.length > 1 && value[value.length - 1] === '"'
+            if (!foundEndingQuote) {
+              for (let j = i + 1; j < directives.length; j++) {
+                // Trim before the closing-quote check: optional whitespace
+                // between the quote and the next comma (`no-cache="a, b" ,x`)
+                // must not defeat the scan.
+                const nextPart = directives[j].trim()
+                headerNames.push(nextPart)
+                if (nextPart.length !== 0 && nextPart[nextPart.length - 1] === '"') {
+                  foundEndingQuote = true
+                  // Consume the scanned parts so a quoted fragment (e.g. a
+                  // literal `max-age=1` inside the field list) is not
+                  // re-parsed as a real directive.
+                  i = j
+                  break
+                }
+              }
+            }
+
+            if (foundEndingQuote) {
+              const lastHeader = headerNames[headerNames.length - 1]
+              if (lastHeader[lastHeader.length - 1] === '"') {
+                headerNames[headerNames.length - 1] = lastHeader.substring(0, lastHeader.length - 1)
+              }
+              if (output[key] !== true) {
+                const fields = headerNames.map((name) => name.trim().toLowerCase())
+                output[key] = Array.isArray(output[key]) ? output[key].concat(fields) : fields
+              }
+            } else {
+              // Unterminated quoted list (invalid header). Fail restrictive:
+              // treat as the unqualified form, and consume the remaining
+              // parts — they are fragments of the broken quoted string, not
+              // real directives.
+              output[key] = true
+              i = directives.length
+            }
+          } else if (output[key] !== true) {
+            const fieldName = value.toLowerCase()
+            output[key] = Array.isArray(output[key]) ? output[key].concat(fieldName) : [fieldName]
+          }
+
+          break
+        }
+      }
+      // eslint-disable-next-line no-fallthrough
+      case 'public':
+      case 'no-store':
+      case 'must-revalidate':
+      case 'proxy-revalidate':
+      case 'immutable':
+      case 'no-transform':
+      case 'must-understand':
+      case 'only-if-cached':
+        // These directives take no value. An explicit `=` (even empty, e.g.
+        // `public=`) is an invalid qualified form and is ignored — not
+        // treated as the bare directive. `value === undefined` is the genuine
+        // valueless form (including the private/no-cache fallthrough above).
+        if (value !== undefined) {
+          continue
+        }
+
+        output[key] = true
+        break
+      default:
+        // Unknown directives are ignored per RFC 9111 §5.2.3.
+        continue
+    }
+  }
+
+  return output
+}
+
+const HTTP_DATE_MONTHS = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+}
+
+const HTTP_DATE_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const HTTP_DATE_FULL_DAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+]
+
+// IMF-fixdate:  Sun, 06 Nov 1994 08:49:37 GMT
+const IMF_DATE_RE =
+  /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+// obsolete RFC 850: Sunday, 06-Nov-94 08:49:37 GMT
+const RFC850_DATE_RE =
+  /^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+// ANSI C asctime(): Sun Nov  6 08:49:37 1994 (day space-padded)
+const ASCTIME_DATE_RE =
+  /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([ \d]\d) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/
+
+/**
+ * Strict HTTP-date parser per RFC 9110 §5.6.7 (the three accepted formats
+ * only). Deliberately NOT `new Date(str)`: V8 accepts many non-HTTP formats,
+ * and RFC 9111 §5.3 requires an invalid Expires (notably `Expires: 0`) to be
+ * treated as already expired rather than silently ignored — which needs the
+ * parse failure to be observable.
+ *
+ * @param {string} date
+ * @returns {Date | undefined} undefined when not a valid HTTP-date
+ */
+export function parseHttpDate(date) {
+  if (typeof date !== 'string') {
+    return undefined
+  }
+
+  let weekday
+  let day
+  let month
+  let year
+  let hour
+  let minute
+  let second
+
+  let m = IMF_DATE_RE.exec(date)
+  if (m) {
+    weekday = HTTP_DATE_DAYS.indexOf(m[1])
+    day = Number(m[2])
+    month = HTTP_DATE_MONTHS[m[3]]
+    year = Number(m[4])
+    hour = Number(m[5])
+    minute = Number(m[6])
+    second = Number(m[7])
+  } else if ((m = RFC850_DATE_RE.exec(date))) {
+    weekday = HTTP_DATE_FULL_DAYS.indexOf(m[1])
+    day = Number(m[2])
+    month = HTTP_DATE_MONTHS[m[3]]
+    // RFC 6265 §5.1.1 two-digit year windowing: 70-99 → 19xx, 00-69 → 20xx.
+    year = Number(m[4])
+    year += year < 70 ? 2000 : 1900
+    hour = Number(m[5])
+    minute = Number(m[6])
+    second = Number(m[7])
+  } else if ((m = ASCTIME_DATE_RE.exec(date))) {
+    weekday = HTTP_DATE_DAYS.indexOf(m[1])
+    month = HTTP_DATE_MONTHS[m[2]]
+    day = Number(m[3].trim())
+    hour = Number(m[4])
+    minute = Number(m[5])
+    second = Number(m[6])
+    year = Number(m[7])
+  } else {
+    return undefined
+  }
+
+  if (day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
+    return undefined
+  }
+
+  const result = new Date(Date.UTC(year, month, day, hour, minute, second))
+  // Date.UTC normalizes out-of-range components (Feb 30 → Mar 2) and the named
+  // weekday must match the actual date — both are rejected by the same check
+  // upstream uses (getUTCDay comparison catches normalization only by luck;
+  // check the day-of-month explicitly as well).
+  return result.getUTCDate() === day && result.getUTCDay() === weekday ? result : undefined
 }
 
 export function isDisturbed(body) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,9 +82,11 @@ export function parseCacheControl(header) {
           }
           continue
         }
-        if (value[0] === ' ') {
-          continue
-        }
+
+        // RFC 9110 §5.6.3: a recipient may remove BWS/OWS around the value, so
+        // tolerate whitespace (`max-age= 60`, `max-age=60 `) rather than
+        // dropping the directive.
+        value = value.trim()
 
         if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
           value = value.substring(1, value.length - 1)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,9 +160,13 @@ export function parseCacheControl(header) {
               output[key] = true
               i = directives.length
             }
-          } else if (output[key] !== true) {
-            const fieldName = value.toLowerCase()
-            output[key] = Array.isArray(output[key]) ? output[key].concat(fieldName) : [fieldName]
+          } else {
+            // Unquoted value (e.g. `private=set-cookie`): the qualified form
+            // MUST be a quoted field-list (RFC 9111 §5.2.2.7). A bare token is
+            // malformed — fail restrictive and treat it as the unqualified
+            // directive (forbid storing / demand revalidation for the whole
+            // response) rather than a more permissive field list.
+            output[key] = true
           }
 
           break

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,12 +90,13 @@ export function parseCacheControl(header) {
           value = value.substring(1, value.length - 1)
         }
 
-        const parsedValue = parseInt(value, 10)
-        // RFC 9111 delta-seconds are non-negative; reject NaN and negatives
-        // (e.g. `max-age=-1`) rather than letting them into freshness math.
-        if (Number.isNaN(parsedValue) || parsedValue < 0) {
+        // RFC 9111 delta-seconds are 1*DIGIT: require the whole value to be
+        // digits so malformed inputs (`max-age=60junk`, `-1`, `1.5`) are
+        // dropped rather than parseInt-coerced into freshness math.
+        if (!/^\d+$/.test(value)) {
           continue
         }
+        const parsedValue = parseInt(value, 10)
 
         if (key === 'max-age' && key in output && output[key] <= parsedValue) {
           // Duplicate max-age: keep the smaller (sooner-stale) value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtedition/nxt-undici",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "license": "MIT",
   "author": "Robert Nagy <robert.nagy@boffins.se>",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@nxtedition/scheduler": "^4.1.1",
     "@nxtedition/undici": "^11.1.4",
-    "cache-control-parser": "^2.2.0",
     "fast-querystring": "^1.1.2",
     "http-errors": "^2.0.1",
     "xxhash-wasm": "^1.1.0"

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -439,13 +439,14 @@ test('cache: only-if-cached returns cached entry when one exists', async (t) => 
 // Authorization header
 // ---------------------------------------------------------------------------
 
-test('cache: authorization header prevents caching unless response has public directive', async (t) => {
+test('cache: authorization header prevents caching unless response permits it (public/s-maxage/must-revalidate)', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    // s-maxage but no 'public' — should not be cached when request has authorization
-    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    // max-age only — RFC 9111 §3.5 requires public, s-maxage or
+    // must-revalidate for a shared cache to store an authorized response.
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
     res.end('private')
   })
   t.teardown(server.close.bind(server))
@@ -500,6 +501,8 @@ test('cache: must-revalidate response directive prevents caching', async (t) => 
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
+    // This cache does not yet revalidate, so responses that require it are
+    // not stored (a follow-up adds revalidation and stores these).
     res.writeHead(200, { 'cache-control': 's-maxage=60, must-revalidate' })
     res.end('body')
   })
@@ -1802,8 +1805,10 @@ test('cache: authorized request not cached without public directive', async (t) 
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
+    // max-age only — does not permit shared-cache storage of an authorized
+    // response (s-maxage/public/must-revalidate would, RFC 9111 §3.5).
     res.writeHead(200, {
-      'cache-control': 's-maxage=60',
+      'cache-control': 'max-age=60',
       'content-type': 'text/plain',
     })
     res.end('secret')
@@ -1963,9 +1968,10 @@ test('cache: cached non-public response is not served to request with Authorizat
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    // First request has no Authorization, so response gets cached.
-    // Response has no 'public' directive.
-    res.writeHead(200, { 'cache-control': 's-maxage=60', 'content-type': 'text/plain' })
+    // First request has no Authorization, so response gets cached. Response
+    // has no directive permitting authorized reuse (max-age doesn't count;
+    // public/s-maxage/must-revalidate would).
+    res.writeHead(200, { 'cache-control': 'max-age=60', 'content-type': 'text/plain' })
     res.end('data')
   })
   t.teardown(server.close.bind(server))

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -192,6 +192,60 @@ test('storability: malformed Age header is ignored, not coerced', async (t) => {
 })
 
 // ---------------------------------------------------------------------------
+// Write-back on request-directive bypass (undici PR #5510): a request
+// directive constrains reuse for THIS request, not storage of the fresh
+// origin response for later callers.
+// ---------------------------------------------------------------------------
+
+test('write-back: a no-cache request on a cold cache still stores for later callers', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  // First request carries a bypass directive on an empty cache.
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'no-cache' } })
+  t.equal(hits, 1, 'no-cache request went to the origin')
+  await flush()
+
+  // A subsequent plain request is served from the entry the bypass stored.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 1, 'fresh response was written back despite the request no-cache')
+})
+
+test('write-back: request no-store on a bypass does not store', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  // no-store forbids storing this request's response...
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'no-store' } })
+  t.equal(hits, 1)
+  await flush()
+
+  // ...so a plain follow-up must hit the origin again.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'no-store bypass did not write back')
+})
+
+// ---------------------------------------------------------------------------
 // RFC 9111 §3.5: authorization permits
 // ---------------------------------------------------------------------------
 

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -1,0 +1,705 @@
+/* eslint-disable */
+// Storability and freshness-math behavior: Expires fallback, corrected initial
+// age, §3.5 authorization permits, opt-in heuristic freshness / defaultTTL,
+// header stripping, unsafe-method invalidation, query-in-key, and the store's
+// delete()/supersede machinery.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { DatabaseSync } from 'node:sqlite'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import { parseHttpDate } from '../lib/utils.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc, h) {
+        statusCode = sc
+        headers = h
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, headers, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function origin(server) {
+  return `http://0.0.0.0:${server.address().port}`
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// ---------------------------------------------------------------------------
+// parseHttpDate unit coverage (strict RFC 9110 formats only)
+// ---------------------------------------------------------------------------
+
+test('parseHttpDate: accepts the three RFC 9110 formats, rejects everything else', (t) => {
+  const expected = Date.UTC(1994, 10, 6, 8, 49, 37)
+  t.equal(parseHttpDate('Sun, 06 Nov 1994 08:49:37 GMT')?.getTime(), expected, 'IMF-fixdate')
+  t.equal(parseHttpDate('Sunday, 06-Nov-94 08:49:37 GMT')?.getTime(), expected, 'RFC 850')
+  t.equal(parseHttpDate('Sun Nov  6 08:49:37 1994')?.getTime(), expected, 'asctime')
+  t.equal(parseHttpDate('0'), undefined, 'Expires: 0 is invalid')
+  t.equal(parseHttpDate('Mon, 06 Nov 1994 08:49:37 GMT'), undefined, 'wrong weekday')
+  t.equal(parseHttpDate('Wed, 30 Feb 2022 00:00:00 GMT'), undefined, 'nonexistent date')
+  t.equal(parseHttpDate('2026-07-04T00:00:00Z'), undefined, 'ISO 8601 is not an HTTP date')
+  t.equal(parseHttpDate(123), undefined, 'non-string')
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Expires fallback (RFC 9111 §4.2.1 / §5.3)
+// ---------------------------------------------------------------------------
+
+test('storability: Expires-only response is cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      expires: new Date(Date.now() + 60e3).toUTCString(),
+      date: new Date().toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'future Expires provides the freshness lifetime')
+})
+
+test('storability: invalid Expires (0) means already expired — not cached', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { expires: '0' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'Expires: 0 is treated as already expired (RFC 9111 §5.3)')
+})
+
+// ---------------------------------------------------------------------------
+// Corrected initial age (RFC 9111 §4.2.3)
+// ---------------------------------------------------------------------------
+
+test('storability: apparent age from the Date header counts against freshness', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    // Generated 120s ago per Date, only 60s of freshness, no validator:
+    // stale on arrival, must not be stored.
+    res.writeHead(200, {
+      'cache-control': 'max-age=60',
+      date: new Date(Date.now() - 120e3).toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'response stale on arrival (Date-based apparent age) is not cached')
+})
+
+test('storability: served Age includes the age the response arrived with', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60', age: '5' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1)
+  t.ok(Number(second.headers.age) >= 5, 'cachedAt backdating carries the initial age forward')
+})
+
+// ---------------------------------------------------------------------------
+// RFC 9111 §3.5: authorization permits
+// ---------------------------------------------------------------------------
+
+test('authorization: s-maxage permits shared-cache storage and reuse (#4911)', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 's-maxage response cached and served for authorized requests')
+})
+
+// ---------------------------------------------------------------------------
+// Opt-in heuristic freshness and defaultTTL
+// ---------------------------------------------------------------------------
+
+test('heuristic: last-modified-only response is cached when opted in', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'last-modified': new Date(Date.now() - 3600e3).toUTCString(),
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const dispatch = makeDispatch()
+
+  // Without the opt-in: not cached.
+  const store1 = new SqliteCacheStore({ location: ':memory:' })
+  const base1 = { origin: origin(server), path: '/', method: 'GET', headers: {} }
+  await rawRequest(dispatch, { ...base1, cache: { store: store1 } })
+  await rawRequest(dispatch, { ...base1, cache: { store: store1 } })
+  t.equal(hits, 2, 'no heuristic caching by default')
+
+  // With the opt-in: 10% of 1h ≈ 6 min of freshness.
+  const store2 = new SqliteCacheStore({ location: ':memory:' })
+  await rawRequest(dispatch, { ...base1, path: '/h', cache: { store: store2, heuristic: true } })
+  await rawRequest(dispatch, { ...base1, path: '/h', cache: { store: store2, heuristic: true } })
+  t.equal(hits, 3, 'heuristic freshness serves the second request from cache')
+})
+
+test('defaultTTL: response without any caching headers is cached when opted in', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store, defaultTTL: 60 },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'defaultTTL supplies the missing freshness lifetime')
+})
+
+// ---------------------------------------------------------------------------
+// Header stripping (RFC 9111 §3.1, §5.2.2.4, §5.2.2.7)
+// ---------------------------------------------------------------------------
+
+test('stripping: hop-by-hop and Connection-listed headers are not stored', async (t) => {
+  t.plan(4)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60',
+      connection: 'x-hop',
+      'x-hop': 'per-connection',
+      'keep-alive': 'timeout=5',
+      'x-keep': 'stored',
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'served from cache')
+  t.equal(second.headers['x-hop'], undefined, 'Connection-listed field stripped')
+  t.equal(second.headers['keep-alive'], undefined, 'hop-by-hop field stripped')
+  t.equal(second.headers['x-keep'], 'stored', 'end-to-end field preserved')
+})
+
+test('stripping: qualified no-cache="field" strips the field but stores the response', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60, no-cache="x-secret"',
+      'x-secret': 'do-not-replay',
+      'x-public': 'fine',
+    })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'qualified no-cache does not prevent storage')
+  t.equal(second.headers['x-secret'], undefined, 'listed field stripped from the stored entry')
+  t.equal(second.headers['x-public'], 'fine', 'other fields preserved')
+})
+
+// ---------------------------------------------------------------------------
+// Unsafe-method invalidation (RFC 9111 §4.4, undici PR #5514)
+// ---------------------------------------------------------------------------
+
+test('invalidation: successful POST invalidates the cached GET for the URI', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'GET cached')
+
+  await rawRequest(dispatch, { ...base, method: 'POST' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 2, 'POST invalidated the entry — GET went back to the origin')
+})
+
+test('invalidation: Location header target is invalidated too', async (t) => {
+  t.plan(2)
+  let bHits = 0
+  const server = await startServer((req, res) => {
+    if (req.url === '/b' && req.method === 'GET') {
+      bHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('b-body')
+    } else {
+      res.writeHead(201, { location: '/b' })
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 1, '/b cached')
+
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 2, 'POST /a with Location: /b invalidated the cached /b')
+})
+
+test('invalidation: cross-origin Location is ignored (no poisoning)', async (t) => {
+  t.plan(1)
+  let bHits = 0
+  const server = await startServer((req, res) => {
+    if (req.url === '/b' && req.method === 'GET') {
+      bHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('b-body')
+    } else {
+      res.writeHead(201, { location: 'http://attacker.example/b' })
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  t.equal(bHits, 1, 'cross-origin Location did not invalidate the same-path entry')
+})
+
+test('invalidation: failed (5xx) unsafe request does not invalidate', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      hits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.writeHead(500)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'POST' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'a 500 to the POST left the cached entry alone')
+})
+
+test('invalidation: OPTIONS is safe and does not invalidate', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      hits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.writeHead(204)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  await rawRequest(dispatch, { ...base, method: 'OPTIONS' })
+  await rawRequest(dispatch, { ...base, method: 'GET' })
+  t.equal(hits, 1, 'OPTIONS left the cached entry alone')
+})
+
+test('invalidation: array Location header uses the first value (review)', async (t) => {
+  t.plan(2)
+  let bHits = 0
+  let cHits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') {
+      if (req.url === '/b') bHits++
+      if (req.url === '/c') cHits++
+      res.writeHead(200, { 'cache-control': 's-maxage=60' })
+      res.end('body')
+    } else {
+      res.setHeader('location', ['/b', '/c'])
+      res.writeHead(201)
+      res.end()
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/c', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/a', method: 'POST' })
+
+  await rawRequest(dispatch, { ...base, path: '/b', method: 'GET' })
+  await rawRequest(dispatch, { ...base, path: '/c', method: 'GET' })
+  t.equal(bHits, 2, 'first Location value (/b) was invalidated')
+  t.equal(cHits, 1, 'second Location value (/c) untouched (first-value semantics)')
+})
+
+test('invalidation: POST with flat-array headers does not throw (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    if (req.method === 'GET') hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', cache: { store } }
+
+  await rawRequest(dispatch, { ...base, method: 'GET', headers: {} })
+  // The legal undici flat name/value array form must not crash key building.
+  const res = await rawRequest(dispatch, {
+    ...base,
+    method: 'POST',
+    headers: ['content-type', 'text/plain'],
+  })
+  t.equal(res.statusCode, 200, 'POST with flat-array headers succeeds')
+
+  await rawRequest(dispatch, { ...base, method: 'GET', headers: {} })
+  t.equal(hits, 2, 'and still invalidated the cached GET')
+})
+
+// ---------------------------------------------------------------------------
+// Parser regressions (review): restrictive forms must win, quoted lists must
+// not leak directives
+// ---------------------------------------------------------------------------
+
+test('parser: qualified private/no-cache never clobbers the unqualified form (review)', async (t) => {
+  const { parseCacheControl } = await import('../lib/utils.js')
+  t.equal(
+    parseCacheControl('private, private="x-a"').private,
+    true,
+    'unqualified private survives a later qualified form',
+  )
+  t.equal(
+    parseCacheControl('no-cache="x-a", no-cache')['no-cache'],
+    true,
+    'a later unqualified no-cache overrides the qualified list',
+  )
+  t.strictSame(
+    parseCacheControl('no-cache="a, max-stale, b"'),
+    { 'no-cache': ['a', 'max-stale', 'b'] },
+    'tokens inside a quoted field list never become live directives',
+  )
+  t.strictSame(
+    parseCacheControl('no-cache="a, b" , max-age=5'),
+    { 'no-cache': ['a', 'b'], 'max-age': 5 },
+    'whitespace after the closing quote does not defeat the scan',
+  )
+  t.equal(
+    parseCacheControl('no-cache="a, max-age=1')['no-cache'],
+    true,
+    'unterminated quoted list fails restrictive (unqualified)',
+  )
+  t.equal(
+    parseCacheControl('no-cache="a, max-age=1')['max-age'],
+    undefined,
+    'fragments of the broken quoted list are not parsed as directives',
+  )
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// Query folded into the cache key (undici PR #5081)
+// ---------------------------------------------------------------------------
+
+test('query: opts.query is part of the cache key in standalone compositions', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end(req.url)
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const a = await rawRequest(dispatch, { ...base, query: { i: 0 } })
+  const b = await rawRequest(dispatch, { ...base, query: { i: 1 } })
+  t.not(a.body, b.body, 'different query strings are distinct entries')
+  t.equal(hits, 2)
+
+  await flush()
+  const c = await rawRequest(dispatch, { ...base, query: { i: 0 } })
+  t.equal(hits, 2, 'repeat query served from cache')
+})
+
+// ---------------------------------------------------------------------------
+// Store: delete() and supersede
+// ---------------------------------------------------------------------------
+
+test('store: delete() removes all entries for the URI including pending batch inserts', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const now = Date.now()
+  const value = (body) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    cachedAt: now,
+    staleAt: now + 60e3,
+    deleteAt: now + 120e3,
+  })
+
+  const getKey = { origin: 'https://example.com', method: 'GET', path: '/x' }
+  const headKey = { origin: 'https://example.com', method: 'HEAD', path: '/x' }
+
+  // One flushed entry and one pending batch entry.
+  store.set(getKey, value('flushed'))
+  await flush()
+  store.set(headKey, { ...value(''), body: null, end: 0 })
+
+  t.ok(store.get(getKey), 'GET entry present')
+  t.ok(store.get(headKey), 'HEAD entry present (batch)')
+
+  store.delete(getKey)
+
+  t.equal(store.get(getKey), undefined, 'flushed entry deleted')
+  t.equal(
+    store.get(headKey),
+    undefined,
+    'pending batch entry for the URI dropped (no resurrection)',
+  )
+
+  await flush()
+  t.equal(store.get(getKey), undefined, 'entry stays gone after the batch flushes')
+  t.end()
+})
+
+test('store: re-caching a key supersedes the old row instead of accumulating', async (t) => {
+  const dbPath = path.join(
+    os.tmpdir(),
+    `supersede-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
+  )
+  const store = new SqliteCacheStore({ location: dbPath })
+  t.teardown(() => {
+    store.close()
+    fs.rmSync(dbPath, { force: true })
+    fs.rmSync(`${dbPath}-wal`, { force: true })
+    fs.rmSync(`${dbPath}-shm`, { force: true })
+  })
+
+  const key = { origin: 'https://example.com', method: 'GET', path: '/hot' }
+  const value = (body, cachedAt) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    cachedAt,
+    staleAt: cachedAt + 60e3,
+    deleteAt: cachedAt + 120e3,
+  })
+
+  const now = Date.now()
+  store.set(key, value('one', now - 2))
+  await flush()
+  store.set(key, value('two-longer', now - 1))
+  await flush()
+  store.set(key, value('three', now))
+  await flush()
+
+  t.equal(store.get(key).body.toString(), 'three', 'newest entry served')
+
+  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const { c } = db
+    .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV11 WHERE url = ?`)
+    .get('https://example.com/hot')
+  db.close()
+  t.equal(c, 1, 'older rows for the representation were superseded')
+  t.end()
+})
+
+test('store: distinct vary variants are not superseded by each other', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const now = Date.now()
+  const value = (body, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: '',
+    vary,
+    cachedAt: now,
+    staleAt: now + 60e3,
+    deleteAt: now + 120e3,
+  })
+
+  store.set(
+    { origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '1' } },
+    value('variant-1', { a: '1' }),
+  )
+  await flush()
+  store.set(
+    { origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '2' } },
+    value('variant-2', { a: '2' }),
+  )
+  await flush()
+
+  t.equal(
+    store
+      .get({ origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '1' } })
+      .body.toString(),
+    'variant-1',
+    'first variant still served',
+  )
+  t.equal(
+    store
+      .get({ origin: 'https://example.com', method: 'GET', path: '/v', headers: { a: '2' } })
+      .body.toString(),
+    'variant-2',
+    'second variant served',
+  )
+  t.end()
+})

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -170,6 +170,27 @@ test('storability: served Age includes the age the response arrived with', async
   t.ok(Number(second.headers.age) >= 5, 'cachedAt backdating carries the initial age forward')
 })
 
+test('storability: malformed Age header is ignored, not coerced', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    // "5junk" must not be read as 5s of age (which would backdate cachedAt).
+    res.writeHead(200, { 'cache-control': 's-maxage=60', age: '5junk' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'still cached (malformed Age treated as absent)')
+  t.equal(Number(second.headers.age), 0, 'malformed Age not coerced into initial age')
+})
+
 // ---------------------------------------------------------------------------
 // RFC 9111 §3.5: authorization permits
 // ---------------------------------------------------------------------------

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -91,6 +91,25 @@ test('parseCacheControl - valueless directive with explicit = is an invalid qual
   t.end()
 })
 
+test('parseCacheControl - unquoted private/no-cache value fails restrictive (unqualified)', (t) => {
+  t.strictSame(
+    parseCacheControl('private=set-cookie'),
+    { private: true },
+    'unquoted private value treated as unqualified private, not a field list',
+  )
+  t.strictSame(
+    parseCacheControl('no-cache=set-cookie'),
+    { 'no-cache': true },
+    'unquoted no-cache value treated as unqualified no-cache',
+  )
+  t.strictSame(
+    parseCacheControl('private="set-cookie"'),
+    { private: ['set-cookie'] },
+    'the quoted field-list form is still honored',
+  )
+  t.end()
+})
+
 test('parseCacheControl - delta-seconds must be all digits (1*DIGIT)', (t) => {
   t.strictSame(
     parseCacheControl('max-age=60junk'),

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -110,6 +110,18 @@ test('parseCacheControl - unquoted private/no-cache value fails restrictive (unq
   t.end()
 })
 
+test('parseCacheControl - whitespace around a delta-seconds value is tolerated (BWS/OWS)', (t) => {
+  t.strictSame(parseCacheControl('max-age= 60'), { 'max-age': 60 }, 'space after = tolerated')
+  t.strictSame(parseCacheControl('max-age=60 '), { 'max-age': 60 }, 'trailing space tolerated')
+  t.strictSame(
+    parseCacheControl('s-maxage= "60"'),
+    { 's-maxage': 60 },
+    'space before a quoted value tolerated',
+  )
+  t.strictSame(parseCacheControl('max-age= 60junk'), {}, 'garbage after trim still dropped')
+  t.end()
+})
+
 test('parseCacheControl - delta-seconds must be all digits (1*DIGIT)', (t) => {
   t.strictSame(
     parseCacheControl('max-age=60junk'),

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -72,6 +72,25 @@ test('parseCacheControl - non-string values return null', (t) => {
   t.end()
 })
 
+test('parseCacheControl - negative delta-seconds are rejected (RFC 9111 non-negative)', (t) => {
+  t.strictSame(parseCacheControl('max-age=-1'), {}, 'negative max-age dropped')
+  t.strictSame(
+    parseCacheControl('s-maxage=-5, max-age=10'),
+    { 'max-age': 10 },
+    'negative dropped, valid kept',
+  )
+  t.strictSame(parseCacheControl('stale-if-error=-3'), {}, 'negative stale-if-error dropped')
+  t.end()
+})
+
+test('parseCacheControl - valueless directive with explicit = is an invalid qualified form', (t) => {
+  t.strictSame(parseCacheControl('public='), {}, 'public= is not treated as public')
+  t.strictSame(parseCacheControl('no-store='), {}, 'no-store= ignored')
+  t.strictSame(parseCacheControl('public'), { public: true }, 'bare public still works')
+  t.strictSame(parseCacheControl('immutable=x'), {}, 'qualified immutable ignored')
+  t.end()
+})
+
 // ---------------------------------------------------------------------------
 // Response side: duplicated Cache-Control field lines must not abort the
 // request. Previously the TypeError escaped CacheHandler.onHeaders and

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -91,6 +91,22 @@ test('parseCacheControl - valueless directive with explicit = is an invalid qual
   t.end()
 })
 
+test('parseCacheControl - delta-seconds must be all digits (1*DIGIT)', (t) => {
+  t.strictSame(
+    parseCacheControl('max-age=60junk'),
+    {},
+    'trailing garbage dropped, not coerced to 60',
+  )
+  t.strictSame(parseCacheControl('max-age=1.5'), {}, 'decimal dropped')
+  t.strictSame(parseCacheControl('max-age="60"'), { 'max-age': 60 }, 'quoted integer still parses')
+  t.strictSame(
+    parseCacheControl('s-maxage=60x, max-age=10'),
+    { 'max-age': 10 },
+    'malformed s-maxage dropped, valid directive kept',
+  )
+  t.end()
+})
+
 // ---------------------------------------------------------------------------
 // Response side: duplicated Cache-Control field lines must not abort the
 // request. Previously the TypeError escaped CacheHandler.onHeaders and

--- a/test/review-bugfixes-4-cache-header-case.js
+++ b/test/review-bugfixes-4-cache-header-case.js
@@ -58,8 +58,9 @@ test('cache: capitalized Authorization is not served a cached non-public respons
   const server = await startServer((req, res) => {
     hits++
     res.writeHead(200, {
-      // s-maxage but no 'public' — cacheable for anonymous requests only.
-      'cache-control': 's-maxage=60',
+      // max-age but no 'public'/'s-maxage'/'must-revalidate' — cacheable for
+      // anonymous requests only (RFC 9111 §3.5).
+      'cache-control': 'max-age=60',
       'content-type': 'text/plain',
     })
     res.end('non-public body')

--- a/test/review-bugfixes-4-cache-immutable.js
+++ b/test/review-bugfixes-4-cache-immutable.js
@@ -39,14 +39,15 @@ async function startServer(handler) {
   return server
 }
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
 test('cache: immutable does not override explicit max-age (expires on schedule)', async (t) => {
   t.plan(2)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    res.writeHead(200, { 'cache-control': 'max-age=1, immutable', 'content-type': 'text/plain' })
+    // max-age=5 rather than 1: node's Date header is second-truncated, so the
+    // corrected initial age (RFC 9111 §4.2.3) can legitimately read 1s at
+    // receipt — a 1s lifetime would make storability itself racy.
+    res.writeHead(200, { 'cache-control': 'max-age=5, immutable', 'content-type': 'text/plain' })
     res.end('body')
   })
   t.teardown(server.close.bind(server))
@@ -65,12 +66,11 @@ test('cache: immutable does not override explicit max-age (expires on schedule)'
   await rawRequest(dispatch, opts)
   t.equal(hits, 1, 'served from cache within the max-age window')
 
-  // getFastNow (used by the store's expiry check) refreshes on a 1s interval,
-  // so wait comfortably past max-age=1 for at least two ticks to elapse.
-  await sleep(2600)
-
-  await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'goes back to origin after max-age expires despite immutable')
+  // Expiry-on-schedule is asserted from the stored entry instead of sleeping
+  // past the TTL: max-age bounds the freshness lifetime, immutable does not
+  // extend it.
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.staleAt - entry.cachedAt, 5000, 'freshness is max-age, not immutable')
 })
 
 test('cache: immutable alone still caches with a long default TTL', async (t) => {
@@ -127,5 +127,9 @@ test('cache: explicit s-maxage wins over immutable', async (t) => {
   t.equal(hits, 1, 'served from cache within the s-maxage window')
 
   const entry = store.get(undici.util.cache.makeCacheKey(opts))
-  t.equal(entry.deleteAt - entry.cachedAt, 60 * 1000, 's-maxage=60 sets the TTL, not immutable')
+  t.equal(
+    entry.staleAt - entry.cachedAt,
+    60 * 1000,
+    's-maxage=60 sets the freshness, not immutable',
+  )
 })

--- a/test/review-bugfixes-4-sqlite-registry.js
+++ b/test/review-bugfixes-4-sqlite-registry.js
@@ -30,6 +30,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }
@@ -172,6 +173,7 @@ test('unclosed store is not pinned by the registry (GC can collect it)', async (
           statusCode: 200,
           statusMessage: 'OK',
           cachedAt: Date.now(),
+          staleAt: Date.now() + 3600e3,
           deleteAt: Date.now() + 7200e3,
         },
       )

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -24,6 +24,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }

--- a/test/review-bugfixes-store.js
+++ b/test/review-bugfixes-store.js
@@ -19,6 +19,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }

--- a/test/sqlite-cache-store.js
+++ b/test/sqlite-cache-store.js
@@ -134,6 +134,23 @@ test('basic get/set round-trip', async (t) => {
   t.end()
 })
 
+test('set() without staleAt defaults it to deleteAt (pre-v11 value shape)', async (t) => {
+  const store = new SqliteCacheStore()
+  t.teardown(() => store.close())
+
+  const key = makeKey({ path: '/no-staleat' })
+  const now = Date.now()
+  const value = makeValue({ path: '/no-staleat', cachedAt: now, deleteAt: now + 3600e3 })
+  delete value.staleAt
+
+  t.doesNotThrow(() => store.set(key, value), 'omitting staleAt is accepted')
+  await flush()
+  const result = store.get(key)
+  t.ok(result, 'entry stored and retrievable')
+  t.equal(result.staleAt, now + 3600e3, 'staleAt defaulted to deleteAt')
+  t.end()
+})
+
 test('get returns undefined for missing key', (t) => {
   const store = new SqliteCacheStore()
   t.teardown(() => store.close())

--- a/test/sqlite-cache-store.js
+++ b/test/sqlite-cache-store.js
@@ -22,6 +22,7 @@ function makeValue(overrides = {}) {
     statusCode: 200,
     statusMessage: 'OK',
     cachedAt: now,
+    staleAt: now + 3600e3,
     deleteAt: now + 7200e3,
     ...overrides,
   }


### PR DESCRIPTION
First of two stacked PRs splitting the cache-interceptor overhaul (was #52). This one is the foundation: freshness/parsing/storage correctness with **no origin revalidation**. The revalidation machinery stacks on top in a follow-up.

## What's here
- **Vendored cache-control parser** (drops the `cache-control-parser` dependency): qualified `no-cache=`/`private=` field lists, `only-if-cached`/`max-stale`/`min-fresh`, and restrictive handling of duplicate, **negative**, and malformed (`public=`) directives. Plus a strict RFC 9110 `parseHttpDate`.
- **Freshness math**: corrected initial age (§4.2.3 — `cachedAt` backdated, origin `Age` stripped at store time and recomputed on serve), `Expires` fallback with invalid-`Expires`-is-expired (§5.3), `immutable` default, and opt-in `heuristic` / `defaultTTL` (200 responses only).
- **RFC 9111 §3.5 authorization permits**: `s-maxage` and `must-revalidate` accepted alongside `public`, with the store-side and serve-side gates in lockstep; duplicated (array) `authorization` refused.
- **Header stripping** (§3.1/§5.2.2.4/§5.2.2.7): hop-by-hop, `Connection`-listed, and qualified-directive fields stripped before storing (`isHopByHop` exported from the proxy interceptor for reuse).
- **RFC 9111 §4.4 invalidation**: unsafe methods delete the target URI plus same-origin `Location`/`Content-Location` on a 2xx/3xx; the SQLite store gains `delete()` (which also splices the pending insert batch to avoid resurrection).
- **Store hardening**: schema **v11** adds a `staleAt` column (here freshness == retention; the revalidation PR uses the split), supersede-on-write and receipt-ordered reads so hot keys stop accumulating duplicate rows.
- **Query in key** (undici PR #5081) for standalone compositions; flat-array request headers normalized before key building.

## Deliberately not here
Responses requiring origin revalidation (`must-revalidate`, `proxy-revalidate`, unqualified `no-cache`, `stale-while-revalidate`, `stale-if-error`) are **not stored yet** — the follow-up PR turns them into stored-and-validated entries. Request deduplication is out of scope for both.

## Notes
- Schema bump to v11 invalidates existing on-disk caches on deploy (old-version tables are dropped automatically).
- Incorporates the Copilot findings from #52 (negative delta-seconds, malformed valueless directives).
- Tests: new `test/cache-storability.js` plus updated suites; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)