### PR TITLE
feat(cache): origin revalidation, stale-while-revalidate, stale-if-error

### DIFF
--- a/lib/interceptor/cache-revalidation.js
+++ b/lib/interceptor/cache-revalidation.js
@@ -1,0 +1,433 @@
+import { parseCacheControl } from '../utils.js'
+import { isHopByHop } from './proxy.js'
+import {
+  CacheHandler,
+  DEFAULT_MAX_ENTRY_TTL,
+  cacheOptsOf,
+  computeEntryTimes,
+  conditionalHeaders,
+  determineAge,
+  determineLifetime,
+  isEtagUsable,
+  parseVary,
+  serveFromCache,
+} from './cache.js'
+
+const NOOP = () => {}
+
+// In-flight background stale-while-revalidate refreshes, so a hot stale key
+// spawns one refresh, not a herd. Keyed per cache store (a WeakMap, so a
+// discarded store's guard set is collected with it): the guard is only
+// meaningful within a single store, and a module-global keyed by URL alone
+// would let refreshes for unrelated stores block each other. Within a store
+// the key also includes the selected Vary variant so distinct representations
+// of the same URL don't share one refresh slot.
+const backgroundRefreshes = new WeakMap()
+
+/**
+ * Stable, unambiguous serialization of a Vary selector map for use as part of
+ * an in-flight refresh key: distinct representations of the same URL (e.g.
+ * different Accept-Encoding) must not share one refresh slot. Sorted keys make
+ * it order-independent; JSON keeps the null sentinel distinct from an empty
+ * string value.
+ */
+function varyKey(vary) {
+  if (!vary) {
+    return ''
+  }
+  const names = Object.keys(vary).sort()
+  return JSON.stringify(names.map((name) => [name, vary[name]]))
+}
+
+/**
+ * Drives a conditional (revalidation) request to the origin for a stale
+ * stored entry (RFC 9111 §4.3). Decision at response headers:
+ * - 304: the entry is valid — freshen it (§4.3.4) and serve it.
+ * - 5xx within the stale-if-error window (RFC 5861 §4, incl. undici PR
+ *   #5513's pre-response connection errors): discard the error and serve the
+ *   stale entry.
+ * - anything else: a real replacement — stream it through a CacheHandler to
+ *   the user handler, storing it on the way.
+ *
+ * The user handler's response callbacks are DEFERRED until that decision, but
+ * onConnect is forwarded eagerly with a bridging abort — the user (e.g. a
+ * signal listener in request()) must be able to tear down the in-flight
+ * conditional request; nothing below the cache observes opts.signal
+ * mid-flight. Delivery paths re-invoke onConnect (serveFromCache / the pass
+ * CacheHandler drive their own connect), which handlers in this pipeline
+ * already tolerate — the retry interceptor re-connects the same handler on
+ * every attempt.
+ */
+export class RevalidationHandler {
+  #key
+  #entry
+  #store
+  #logger
+  #opts
+  #cacheOpts
+  #userHandler
+  #allowStaleOnError
+  #noStore
+  /** @type {null | 'pass' | 'validated' | 'stale'} */
+  #mode = null
+  /** @type {CacheHandler | import('../utils.js').DecoratorHandler | object | null} */
+  #inner = null
+  /** @type {((reason?: any) => void) | null} */
+  #abort = null
+  /** @type {Record<string, string | string[]> | null} */
+  #headers304 = null
+  #delivered = false
+  #userAborted = false
+  #userAbortReason = null
+
+  constructor(key, entry, opts, { store, logger, handler, allowStaleOnError, noStore, cacheOpts }) {
+    this.#key = key
+    this.#entry = entry
+    this.#store = store
+    this.#logger = logger
+    this.#opts = opts
+    this.#cacheOpts = cacheOpts
+    this.#userHandler = handler
+    this.#allowStaleOnError = allowStaleOnError
+    this.#noStore = noStore ?? false
+  }
+
+  onConnect(abort) {
+    this.#abort = abort
+    // Eager connect: hand the user a bridging abort so a caller abort (e.g.
+    // a signal firing in request()) tears down the in-flight conditional
+    // request instead of being silently ignored until the origin answers.
+    this.#userHandler.onConnect((reason) => {
+      if (!this.#delivered && !this.#userAborted) {
+        this.#userAborted = true
+        this.#userAbortReason = reason
+        this.#abort?.(reason)
+      }
+    })
+  }
+
+  onUpgrade(statusCode, headers, socket) {
+    // Upgrades are gated out before the cache interceptor engages; nothing to
+    // do but not crash if one slips through.
+    socket?.destroy?.()
+  }
+
+  onHeaders(statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // Informational (1xx) interim responses — e.g. 103 Early Hints — are
+      // not the revalidation answer; stay undecided and keep reading.
+      return true
+    }
+
+    if (statusCode === 304) {
+      this.#mode = 'validated'
+      this.#headers304 = headers
+      return true
+    }
+
+    if (this.#allowStaleOnError && statusCode >= 500 && statusCode <= 504) {
+      this.#mode = 'stale'
+      // The decision to serve stale is already made — don't wait for the 5xx
+      // body to drain (it can be large and only adds latency/bandwidth).
+      // Deliver the stale entry now and abort the in-flight request; the
+      // resulting onError is suppressed by the #delivered guard.
+      this.#deliver(this.#entry)
+      this.#abort?.(new Error('stale-if-error: serving stale cached response'))
+      return false
+    }
+
+    this.#mode = 'pass'
+    // RFC 9111 §5.2.1.5: a request no-store forbids storing the replacement
+    // response — stream it to the user handler without the CacheHandler wrap.
+    this.#inner = this.#noStore
+      ? this.#userHandler
+      : new CacheHandler(this.#key, {
+          ...this.#cacheOpts,
+          store: this.#store,
+          logger: this.#logger,
+          handler: this.#userHandler,
+        })
+    this.#inner.onConnect((reason) => this.#abort?.(reason))
+    return this.#inner.onHeaders(statusCode, headers, resume)
+  }
+
+  onData(chunk) {
+    return this.#mode === 'pass' ? this.#inner.onData(chunk) : true
+  }
+
+  onComplete(trailers) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onComplete(trailers)
+    }
+    // Freshen even when the user aborted mid-flight — the 304 validated the
+    // entry either way, and the store write benefits every other caller.
+    this.#deliver(this.#mode === 'validated' ? this.#freshen() : this.#entry)
+  }
+
+  onError(err) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onError(err)
+    }
+    if (this.#userAborted) {
+      // The (probable) cause of this error is the user's own abort — a
+      // stale-if-error serve would convert their cancellation into a
+      // successful response.
+      return this.#fail(this.#userAbortReason ?? err)
+    }
+    if (this.#mode === 'validated') {
+      // The 304 already validated the entry; a broken tail on the (empty)
+      // validation response doesn't invalidate it.
+      return this.#deliver(this.#freshen())
+    }
+    if (this.#mode === 'stale' || this.#allowStaleOnError) {
+      // Pre-response connection errors (ECONNREFUSED, reset, ...) count as
+      // origin errors for stale-if-error — RFC 5861's definition explicitly
+      // covers an unreachable origin (undici PR #5513). Mid-body failures of
+      // a replacement response are 'pass' mode and propagate above.
+      return this.#deliver(this.#entry)
+    }
+    this.#fail(err)
+  }
+
+  #deliver(entry) {
+    if (this.#delivered) {
+      return
+    }
+    this.#delivered = true
+    if (this.#userAborted) {
+      this.#userHandler.onError(this.#userAbortReason ?? new Error('aborted'))
+    } else {
+      serveFromCache(entry, this.#opts, this.#userHandler)
+    }
+  }
+
+  #fail(err) {
+    if (!this.#delivered) {
+      this.#delivered = true
+      this.#userHandler.onError(err)
+    }
+  }
+
+  /**
+   * RFC 9111 §4.3.4: merge the 304's headers over the stored ones and reset
+   * the freshness clock. Returns the entry to serve; the store is only
+   * updated when the merged response is still storable.
+   */
+  #freshen() {
+    const entry = this.#entry
+    const headers304 = this.#headers304 ?? {}
+    try {
+      const now = Date.now()
+
+      // Same exclusions as at store time — hop-by-hop, fields listed in the
+      // 304's Connection header — plus Set-Cookie (must never enter a shared
+      // entry) and the body-describing fields, for which the stored body is
+      // authoritative.
+      const excludedHeaders = new Set(['age', 'set-cookie', 'content-length', 'content-range'])
+      const connection = headers304.connection
+      if (typeof connection === 'string') {
+        for (const name of connection.split(',')) {
+          excludedHeaders.add(name.trim().toLowerCase())
+        }
+      } else if (Array.isArray(connection)) {
+        for (const line of connection) {
+          for (const name of `${line}`.split(',')) {
+            excludedHeaders.add(name.trim().toLowerCase())
+          }
+        }
+      }
+
+      const merged = Object.create(null)
+      for (const name of Object.keys(entry.headers ?? {})) {
+        merged[name] = entry.headers[name]
+      }
+      for (const name of Object.keys(headers304)) {
+        const lower = name.toLowerCase()
+        if (isHopByHop(lower) || excludedHeaders.has(lower)) {
+          continue
+        }
+        const val = headers304[name]
+        merged[lower] = Array.isArray(val) ? val.slice() : val
+      }
+
+      // RFC 9110 §6.6.1: a 304 without a Date header is assigned the receipt
+      // time. Without this, the stored (old) Date drives the corrected age
+      // below and the freshened entry lands stale-on-arrival — permanently
+      // revalidating on every hit despite the origin granting freshness.
+      if (headers304.date == null) {
+        merged.date = new Date(now).toUTCString()
+      }
+
+      const cacheControlDirectives = parseCacheControl(merged['cache-control']) ?? {}
+      if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
+        // The origin has withdrawn (shared-)cacheability: serve this one
+        // validated use, but don't freshen the stored entry — it stays stale
+        // and keeps revalidating until it ages out.
+        return { ...entry, headers: merged }
+      }
+
+      // Qualified no-cache=/private= field lists (possibly newly added by
+      // the 304) must not survive in the stored — or served — headers, even
+      // when the named field came from the original stored response.
+      for (const directive of ['no-cache', 'private']) {
+        if (Array.isArray(cacheControlDirectives[directive])) {
+          for (const name of cacheControlDirectives[directive]) {
+            delete merged[name]
+          }
+        }
+      }
+
+      const etag =
+        typeof merged.etag === 'string' && isEtagUsable(merged.etag)
+          ? merged.etag
+          : (entry.etag ?? '')
+      const hasValidator = etag !== '' || typeof merged['last-modified'] === 'string'
+
+      let lifetimeInfo = determineLifetime(
+        entry.statusCode,
+        merged,
+        cacheControlDirectives,
+        this.#cacheOpts,
+        now,
+      )
+      if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
+        lifetimeInfo = { lifetime: 0, explicit: true }
+      }
+      if (lifetimeInfo == null) {
+        return { ...entry, headers: merged }
+      }
+
+      // Clamp the corrected age to the stored entry's own current age
+      // (now - cachedAt already includes the original initial age, RFC 9111
+      // §4.2.3): a skewed/old Date on the 304 must not push the freshened
+      // entry further into the past than the response it just validated.
+      const age = Math.min(
+        determineAge(merged, now),
+        Math.max(0, Math.floor((now - entry.cachedAt) / 1000)),
+      )
+      const times = computeEntryTimes(
+        lifetimeInfo.lifetime,
+        lifetimeInfo.explicit,
+        age,
+        cacheControlDirectives,
+        this.#cacheOpts.maxEntryTTL ?? this.#store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL,
+        hasValidator,
+        now,
+      )
+      if (times == null) {
+        return { ...entry, headers: merged }
+      }
+
+      // RFC 9111 §4.3.4: the 304 can carry an updated Vary. Recompute the
+      // selector map from the merged Vary against this request's headers so
+      // the stored metadata stays consistent with the served headers and
+      // variant matching doesn't break if the origin changed Vary. A merged
+      // Vary of '*' (or a non-string duplicate) makes the entry uncacheable —
+      // serve this validated use but don't re-store it.
+      const vary = parseVary(merged.vary, this.#key.headers)
+      if (vary == null) {
+        return { ...entry, headers: merged }
+      }
+
+      const freshened = {
+        // 206 entries never take the revalidation path, so the stored body is
+        // the full representation: start 0, end = byte length (0 for HEAD).
+        body: entry.body ?? null,
+        start: 0,
+        end: entry.body ? entry.body.byteLength : 0,
+        statusCode: entry.statusCode,
+        statusMessage: entry.statusMessage ?? '',
+        headers: merged,
+        cacheControlDirectives,
+        etag,
+        vary,
+        cachedAt: times.cachedAt,
+        staleAt: times.staleAt,
+        deleteAt: times.deleteAt,
+      }
+
+      // RFC 9111 §5.2.1.5: a request no-store forbids storing any part of
+      // this request's response — serve the freshened value, don't write it.
+      if (!this.#noStore) {
+        try {
+          this.#store.set(this.#key, freshened)
+        } catch (err) {
+          if (err.message === 'database is locked') {
+            this.#logger?.debug({ err }, 'failed to freshen cache entry')
+          } else {
+            this.#logger?.error({ err }, 'failed to freshen cache entry')
+          }
+        }
+      }
+
+      return freshened
+    } catch (err) {
+      // Freshening must never break delivery of a validated entry.
+      this.#logger?.error({ err }, 'failed to freshen cache entry')
+      return entry
+    }
+  }
+}
+
+/**
+ * Fire-and-forget background refresh for stale-while-revalidate (RFC 5861
+ * §3): the caller was already served the stale entry; only the store observes
+ * the outcome. Re-enters the dispatch chain below the cache interceptor.
+ */
+export function backgroundRefresh(dispatch, opts, key, store, entry) {
+  let inflight = backgroundRefreshes.get(store)
+  if (inflight == null) {
+    inflight = new Set()
+    backgroundRefreshes.set(store, inflight)
+  }
+  const refreshKey = `${key.method}:${key.origin}${key.path} ${varyKey(entry.vary)}`
+  if (inflight.has(refreshKey)) {
+    return
+  }
+  inflight.add(refreshKey)
+
+  let finished = false
+  const done = () => {
+    if (!finished) {
+      finished = true
+      inflight.delete(refreshKey)
+    }
+  }
+
+  const silentHandler = {
+    onConnect: NOOP,
+    onHeaders: () => true,
+    onData: () => true,
+    onComplete: done,
+    onError: (err) => {
+      done()
+      opts.logger?.debug({ err }, 'cache: background revalidation failed')
+    },
+  }
+
+  try {
+    // Strip caller-specific request state: the body (already consumed or
+    // owned by the caller) and the signal (a caller abort after being served
+    // stale must not kill the shared refresh).
+    const bgOpts = {
+      ...opts,
+      headers: conditionalHeaders(key.headers ?? {}, entry),
+      body: null,
+      signal: undefined,
+    }
+    dispatch(
+      bgOpts,
+      new RevalidationHandler(key, entry, bgOpts, {
+        store,
+        logger: opts.logger,
+        handler: silentHandler,
+        allowStaleOnError: false,
+        noStore: false,
+        cacheOpts: cacheOptsOf(opts),
+      }),
+    )
+  } catch (err) {
+    done()
+    opts.logger?.debug({ err }, 'cache: background revalidation failed')
+  }
+}

--- a/lib/interceptor/cache-revalidation.js
+++ b/lib/interceptor/cache-revalidation.js
@@ -73,6 +73,10 @@ export class RevalidationHandler {
   #userHandler
   #allowStaleOnError
   #noStore
+  #write
+  #id
+  #url
+  #lookupMs
   /** @type {null | 'pass' | 'validated' | 'stale'} */
   #mode = null
   /** @type {CacheHandler | import('../utils.js').DecoratorHandler | object | null} */
@@ -85,7 +89,12 @@ export class RevalidationHandler {
   #userAborted = false
   #userAbortReason = null
 
-  constructor(key, entry, opts, { store, logger, handler, allowStaleOnError, noStore, cacheOpts }) {
+  constructor(
+    key,
+    entry,
+    opts,
+    { store, logger, handler, allowStaleOnError, noStore, cacheOpts, write, id, url, lookupMs },
+  ) {
     this.#key = key
     this.#entry = entry
     this.#store = store
@@ -95,6 +104,13 @@ export class RevalidationHandler {
     this.#userHandler = handler
     this.#allowStaleOnError = allowStaleOnError
     this.#noStore = noStore ?? false
+    // Trace context (null when tracing is off / for background refresh): the
+    // eventual serveFromCache and pass-mode CacheHandler emit their docs with
+    // it, so a synchronous revalidation traces like any other lookup/store.
+    this.#write = write ?? null
+    this.#id = id ?? null
+    this.#url = url ?? null
+    this.#lookupMs = lookupMs ?? null
   }
 
   onConnect(abort) {
@@ -151,6 +167,9 @@ export class RevalidationHandler {
           store: this.#store,
           logger: this.#logger,
           handler: this.#userHandler,
+          write: this.#write,
+          id: this.#id,
+          url: this.#url,
         })
     this.#inner.onConnect((reason) => this.#abort?.(reason))
     return this.#inner.onHeaders(statusCode, headers, resume)
@@ -202,7 +221,7 @@ export class RevalidationHandler {
     if (this.#userAborted) {
       this.#userHandler.onError(this.#userAbortReason ?? new Error('aborted'))
     } else {
-      serveFromCache(entry, this.#opts, this.#userHandler)
+      serveFromCache(entry, this.#opts, this.#userHandler, this.#write, this.#url, this.#lookupMs)
     }
   }
 

--- a/lib/interceptor/cache-revalidation.js
+++ b/lib/interceptor/cache-revalidation.js
@@ -15,6 +15,11 @@ import {
 
 const NOOP = () => {}
 
+// RFC 5861 §4: the statuses that count as an "error" for stale-if-error are
+// exactly 500, 502, 503 and 504. 501 (Not Implemented) and 505+ are NOT errors
+// in this sense, so a `>= 500 && <= 504` range would wrongly include 501.
+const STALE_IF_ERROR_STATUSES = new Set([500, 502, 503, 504])
+
 // In-flight background stale-while-revalidate refreshes, so a hot stale key
 // spawns one refresh, not a herd. Keyed per cache store (a WeakMap, so a
 // discarded store's guard set is collected with it): the guard is only
@@ -43,9 +48,9 @@ function varyKey(vary) {
  * Drives a conditional (revalidation) request to the origin for a stale
  * stored entry (RFC 9111 §4.3). Decision at response headers:
  * - 304: the entry is valid — freshen it (§4.3.4) and serve it.
- * - 5xx within the stale-if-error window (RFC 5861 §4, incl. undici PR
- *   #5513's pre-response connection errors): discard the error and serve the
- *   stale entry.
+ * - a 500/502/503/504 within the stale-if-error window (RFC 5861 §4's error
+ *   statuses, incl. undici PR #5513's pre-response connection errors): discard
+ *   the error and serve the stale entry.
  * - anything else: a real replacement — stream it through a CacheHandler to
  *   the user handler, storing it on the way.
  *
@@ -125,9 +130,9 @@ export class RevalidationHandler {
       return true
     }
 
-    if (this.#allowStaleOnError && statusCode >= 500 && statusCode <= 504) {
+    if (this.#allowStaleOnError && STALE_IF_ERROR_STATUSES.has(statusCode)) {
       this.#mode = 'stale'
-      // The decision to serve stale is already made — don't wait for the 5xx
+      // The decision to serve stale is already made — don't wait for the error
       // body to drain (it can be large and only adds latency/bandwidth).
       // Deliver the stale entry now and abort the in-flight request; the
       // resulting onError is suppressed by the #delivered guard.

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -10,11 +10,11 @@ import {
 } from '../utils.js'
 import { isHopByHop } from './proxy.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
-import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
+import { RevalidationHandler, backgroundRefresh } from './cache-revalidation.js'
 
 let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
-const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600 // seconds
+export const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600 // seconds
 // Bounded retention for entries kept solely for conditional revalidation
 // (zero/expired freshness but a usable validator): long enough that the
 // "always validate" origin pattern pays a 304 instead of a full 200, short
@@ -24,10 +24,6 @@ const REVALIDATION_RETENTION = 24 * 3600 // seconds
 // 1-year default, capped by maxEntryTTL below.
 const IMMUTABLE_LIFETIME = 31556952 // seconds
 const NOOP = () => {}
-
-// In-flight background stale-while-revalidate refreshes keyed by
-// method + url, so a hot stale key spawns one refresh, not a herd.
-const backgroundRefreshes = new Set()
 
 /**
  * Explicit (or opt-in heuristic) freshness lifetime in seconds, or null when
@@ -40,7 +36,7 @@ const backgroundRefreshes = new Set()
  *
  * @returns {{ lifetime: number, explicit: boolean } | null}
  */
-function determineLifetime(
+export function determineLifetime(
   statusCode,
   headers,
   cacheControlDirectives,
@@ -100,7 +96,7 @@ function determineLifetime(
  * origin Date). A response relayed through intermediaries that don't add Age
  * would otherwise get an over-extended TTL and be served stale.
  */
-function determineAge(headers, now) {
+export function determineAge(headers, now) {
   const rawAge = headers.age
   // A duplicated Age header arrives as an array; take the first value.
   const rawAgeValue = Array.isArray(rawAge) ? rawAge[0] : rawAge
@@ -131,7 +127,7 @@ function determineAge(headers, now) {
  * validator-bearing entries; everything is capped by maxEntryTTL, measured
  * from (backdated) cachedAt.
  */
-function computeEntryTimes(
+export function computeEntryTimes(
   lifetime,
   explicit,
   age,
@@ -187,6 +183,43 @@ function forbidsServingStale(entry) {
 }
 
 /**
+ * Builds the Vary selector map (RFC 9111 §4.1): for each field named in the
+ * response Vary header, records the request's value (a null sentinel when the
+ * header was absent — absent-vs-present is a mismatch, so an empty map must
+ * NOT act as a wildcard). Selector names are lowercased and stored on a null
+ * prototype: names come from the (server-controlled) Vary header, so a
+ * `__proto__` entry on a plain `{}` would hit the Object.prototype setter and
+ * be silently dropped.
+ *
+ * Returns null when the response is NOT cacheable on Vary grounds: a
+ * non-string Vary (duplicated header lines) or a Vary containing '*' (which
+ * never matches, RFC 9111 §4.1).
+ *
+ * @returns {Record<string, string | string[] | null> | null}
+ */
+export function parseVary(varyHeader, requestHeaders) {
+  const vary = Object.create(null)
+  if (varyHeader == null) {
+    return vary
+  }
+  if (typeof varyHeader !== 'string') {
+    return null
+  }
+  for (const name of varyHeader.split(',').map((key) => key.trim().toLowerCase())) {
+    if (name === '*') {
+      return null
+    }
+    if (name === '') {
+      // Empty field-name (a bare/trailing comma, or `Vary:` with no value) is
+      // not a selector — skip it so it can't become a spurious '' key.
+      continue
+    }
+    vary[name] = requestHeaders[name] ?? null
+  }
+  return vary
+}
+
+/**
  * Conditional request headers for revalidating a stored entry (RFC 9111
  * §4.3.1). Per RFC 9110 §13.1.3 and undici PR #5512, If-Modified-Since echoes
  * the stored Last-Modified VERBATIM when available (nginx's default
@@ -196,7 +229,7 @@ function forbidsServingStale(entry) {
  * The stored vary values need no replay: the store only returns entries whose
  * selecting headers already match this request.
  */
-function conditionalHeaders(headers, entry) {
+export function conditionalHeaders(headers, entry) {
   const condHeaders = { ...headers }
   if (entry.etag) {
     condHeaders['if-none-match'] = entry.etag
@@ -212,7 +245,7 @@ function conditionalHeaders(headers, entry) {
   return condHeaders
 }
 
-class CacheHandler extends DecoratorHandler {
+export class CacheHandler extends DecoratorHandler {
   #key
   #value
   #store
@@ -392,27 +425,11 @@ class CacheHandler extends DecoratorHandler {
     // serve stale, ...), which the read path enforces from the persisted
     // cacheControlDirectives.
 
-    // Null prototype: selector names come from the response Vary header and
-    // request header names are caller-controlled — on a plain `{}` a
-    // `__proto__` key would hit the prototype setter and be silently dropped.
-    const vary = Object.create(null)
-    if (headers.vary) {
-      if (typeof headers.vary !== 'string') {
-        return this.#skip('vary-invalid', statusCode, headers, resume)
-      }
-
-      for (const key of headers.vary.split(',').map((key) => key.trim().toLowerCase())) {
-        if (key === '*') {
-          // RFC 9111 §4.1: a Vary field containing '*' never matches.
-          return this.#skip('vary-star', statusCode, headers, resume)
-        }
-        // Record every selecting header, using a null sentinel when it was
-        // absent from the request. RFC 9111 §4.1: absent-vs-present is a
-        // mismatch, so an empty vary object must NOT act as a wildcard that
-        // matches requests which later supply the header. headerValueEquals
-        // treats null/absent as equal only to another null/absent.
-        vary[key] = this.#key.headers[key] ?? null
-      }
+    // parseVary returns null when the response can't be cached on Vary
+    // grounds (a non-string Vary header, or one containing '*').
+    const vary = parseVary(headers.vary, this.#key.headers)
+    if (vary == null) {
+      return super.onHeaders(statusCode, headers, resume)
     }
 
     const now = Date.now()
@@ -588,325 +605,6 @@ class CacheHandler extends DecoratorHandler {
 }
 
 /**
- * Drives a conditional (revalidation) request to the origin for a stale
- * stored entry (RFC 9111 §4.3). Decision at response headers:
- * - 304: the entry is valid — freshen it (§4.3.4) and serve it.
- * - 5xx within the stale-if-error window (RFC 5861 §4, incl. undici PR
- *   #5513's pre-response connection errors): discard the error and serve the
- *   stale entry.
- * - anything else: a real replacement — stream it through a CacheHandler to
- *   the user handler, storing it on the way.
- *
- * The user handler's response callbacks are DEFERRED until that decision, but
- * onConnect is forwarded eagerly with a bridging abort — the user (e.g. a
- * signal listener in request()) must be able to tear down the in-flight
- * conditional request; nothing below the cache observes opts.signal
- * mid-flight. Delivery paths re-invoke onConnect (serveFromCache / the pass
- * CacheHandler drive their own connect), which handlers in this pipeline
- * already tolerate — the retry interceptor re-connects the same handler on
- * every attempt.
- */
-class RevalidationHandler {
-  #key
-  #entry
-  #store
-  #logger
-  #opts
-  #cacheOpts
-  #userHandler
-  #allowStaleOnError
-  #noStore
-  /** @type {null | 'pass' | 'validated' | 'stale'} */
-  #mode = null
-  /** @type {CacheHandler | import('../utils.js').DecoratorHandler | object | null} */
-  #inner = null
-  /** @type {((reason?: any) => void) | null} */
-  #abort = null
-  /** @type {Record<string, string | string[]> | null} */
-  #headers304 = null
-  #delivered = false
-  #userAborted = false
-  #userAbortReason = null
-
-  constructor(key, entry, opts, { store, logger, handler, allowStaleOnError, noStore, cacheOpts }) {
-    this.#key = key
-    this.#entry = entry
-    this.#store = store
-    this.#logger = logger
-    this.#opts = opts
-    this.#cacheOpts = cacheOpts
-    this.#userHandler = handler
-    this.#allowStaleOnError = allowStaleOnError
-    this.#noStore = noStore ?? false
-  }
-
-  onConnect(abort) {
-    this.#abort = abort
-    // Eager connect: hand the user a bridging abort so a caller abort (e.g.
-    // a signal firing in request()) tears down the in-flight conditional
-    // request instead of being silently ignored until the origin answers.
-    this.#userHandler.onConnect((reason) => {
-      if (!this.#delivered && !this.#userAborted) {
-        this.#userAborted = true
-        this.#userAbortReason = reason
-        this.#abort?.(reason)
-      }
-    })
-  }
-
-  onUpgrade(statusCode, headers, socket) {
-    // Upgrades are gated out before the cache interceptor engages; nothing to
-    // do but not crash if one slips through.
-    socket?.destroy?.()
-  }
-
-  onHeaders(statusCode, headers, resume) {
-    if (statusCode < 200) {
-      // Informational (1xx) interim responses — e.g. 103 Early Hints — are
-      // not the revalidation answer; stay undecided and keep reading.
-      return true
-    }
-
-    if (statusCode === 304) {
-      this.#mode = 'validated'
-      this.#headers304 = headers
-      return true
-    }
-
-    if (this.#allowStaleOnError && statusCode >= 500 && statusCode <= 504) {
-      this.#mode = 'stale'
-      // The decision to serve stale is already made — don't wait for the 5xx
-      // body to drain (it can be large and only adds latency/bandwidth).
-      // Deliver the stale entry now and abort the in-flight request; the
-      // resulting onError is suppressed by the #delivered guard.
-      this.#deliver(this.#entry)
-      this.#abort?.(new Error('stale-if-error: serving stale cached response'))
-      return false
-    }
-
-    this.#mode = 'pass'
-    // RFC 9111 §5.2.1.5: a request no-store forbids storing the replacement
-    // response — stream it to the user handler without the CacheHandler wrap.
-    this.#inner = this.#noStore
-      ? this.#userHandler
-      : new CacheHandler(this.#key, {
-          ...this.#cacheOpts,
-          store: this.#store,
-          logger: this.#logger,
-          handler: this.#userHandler,
-        })
-    this.#inner.onConnect((reason) => this.#abort?.(reason))
-    return this.#inner.onHeaders(statusCode, headers, resume)
-  }
-
-  onData(chunk) {
-    return this.#mode === 'pass' ? this.#inner.onData(chunk) : true
-  }
-
-  onComplete(trailers) {
-    if (this.#mode === 'pass') {
-      return this.#inner.onComplete(trailers)
-    }
-    // Freshen even when the user aborted mid-flight — the 304 validated the
-    // entry either way, and the store write benefits every other caller.
-    this.#deliver(this.#mode === 'validated' ? this.#freshen() : this.#entry)
-  }
-
-  onError(err) {
-    if (this.#mode === 'pass') {
-      return this.#inner.onError(err)
-    }
-    if (this.#userAborted) {
-      // The (probable) cause of this error is the user's own abort — a
-      // stale-if-error serve would convert their cancellation into a
-      // successful response.
-      return this.#fail(this.#userAbortReason ?? err)
-    }
-    if (this.#mode === 'validated') {
-      // The 304 already validated the entry; a broken tail on the (empty)
-      // validation response doesn't invalidate it.
-      return this.#deliver(this.#freshen())
-    }
-    if (this.#mode === 'stale' || this.#allowStaleOnError) {
-      // Pre-response connection errors (ECONNREFUSED, reset, ...) count as
-      // origin errors for stale-if-error — RFC 5861's definition explicitly
-      // covers an unreachable origin (undici PR #5513). Mid-body failures of
-      // a replacement response are 'pass' mode and propagate above.
-      return this.#deliver(this.#entry)
-    }
-    this.#fail(err)
-  }
-
-  #deliver(entry) {
-    if (this.#delivered) {
-      return
-    }
-    this.#delivered = true
-    if (this.#userAborted) {
-      this.#userHandler.onError(this.#userAbortReason ?? new Error('aborted'))
-    } else {
-      serveFromCache(entry, this.#opts, this.#userHandler)
-    }
-  }
-
-  #fail(err) {
-    if (!this.#delivered) {
-      this.#delivered = true
-      this.#userHandler.onError(err)
-    }
-  }
-
-  /**
-   * RFC 9111 §4.3.4: merge the 304's headers over the stored ones and reset
-   * the freshness clock. Returns the entry to serve; the store is only
-   * updated when the merged response is still storable.
-   */
-  #freshen() {
-    const entry = this.#entry
-    const headers304 = this.#headers304 ?? {}
-    try {
-      const now = Date.now()
-
-      // Same exclusions as at store time — hop-by-hop, fields listed in the
-      // 304's Connection header — plus Set-Cookie (must never enter a shared
-      // entry) and the body-describing fields, for which the stored body is
-      // authoritative.
-      const excludedHeaders = new Set(['age', 'set-cookie', 'content-length', 'content-range'])
-      const connection = headers304.connection
-      if (typeof connection === 'string') {
-        for (const name of connection.split(',')) {
-          excludedHeaders.add(name.trim().toLowerCase())
-        }
-      } else if (Array.isArray(connection)) {
-        for (const line of connection) {
-          for (const name of `${line}`.split(',')) {
-            excludedHeaders.add(name.trim().toLowerCase())
-          }
-        }
-      }
-
-      const merged = Object.create(null)
-      for (const name of Object.keys(entry.headers ?? {})) {
-        merged[name] = entry.headers[name]
-      }
-      for (const name of Object.keys(headers304)) {
-        const lower = name.toLowerCase()
-        if (isHopByHop(lower) || excludedHeaders.has(lower)) {
-          continue
-        }
-        const val = headers304[name]
-        merged[lower] = Array.isArray(val) ? val.slice() : val
-      }
-
-      // RFC 9110 §6.6.1: a 304 without a Date header is assigned the receipt
-      // time. Without this, the stored (old) Date drives the corrected age
-      // below and the freshened entry lands stale-on-arrival — permanently
-      // revalidating on every hit despite the origin granting freshness.
-      if (headers304.date == null) {
-        merged.date = new Date(now).toUTCString()
-      }
-
-      const cacheControlDirectives = parseCacheControl(merged['cache-control']) ?? {}
-      if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
-        // The origin has withdrawn (shared-)cacheability: serve this one
-        // validated use, but don't freshen the stored entry — it stays stale
-        // and keeps revalidating until it ages out.
-        return { ...entry, headers: merged }
-      }
-
-      // Qualified no-cache=/private= field lists (possibly newly added by
-      // the 304) must not survive in the stored — or served — headers, even
-      // when the named field came from the original stored response.
-      for (const directive of ['no-cache', 'private']) {
-        if (Array.isArray(cacheControlDirectives[directive])) {
-          for (const name of cacheControlDirectives[directive]) {
-            delete merged[name]
-          }
-        }
-      }
-
-      const etag =
-        typeof merged.etag === 'string' && isEtagUsable(merged.etag)
-          ? merged.etag
-          : (entry.etag ?? '')
-      const hasValidator = etag !== '' || typeof merged['last-modified'] === 'string'
-
-      let lifetimeInfo = determineLifetime(
-        entry.statusCode,
-        merged,
-        cacheControlDirectives,
-        this.#cacheOpts,
-        now,
-      )
-      if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
-        lifetimeInfo = { lifetime: 0, explicit: true }
-      }
-      if (lifetimeInfo == null) {
-        return { ...entry, headers: merged }
-      }
-
-      // Clamp the corrected age to the stored entry's own current age
-      // (now - cachedAt already includes the original initial age, RFC 9111
-      // §4.2.3): a skewed/old Date on the 304 must not push the freshened
-      // entry further into the past than the response it just validated.
-      const age = Math.min(
-        determineAge(merged, now),
-        Math.max(0, Math.floor((now - entry.cachedAt) / 1000)),
-      )
-      const times = computeEntryTimes(
-        lifetimeInfo.lifetime,
-        lifetimeInfo.explicit,
-        age,
-        cacheControlDirectives,
-        this.#cacheOpts.maxEntryTTL ?? this.#store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL,
-        hasValidator,
-        now,
-      )
-      if (times == null) {
-        return { ...entry, headers: merged }
-      }
-
-      const freshened = {
-        // 206 entries never take the revalidation path, so the stored body is
-        // the full representation: start 0, end = byte length (0 for HEAD).
-        body: entry.body ?? null,
-        start: 0,
-        end: entry.body ? entry.body.byteLength : 0,
-        statusCode: entry.statusCode,
-        statusMessage: entry.statusMessage ?? '',
-        headers: merged,
-        cacheControlDirectives,
-        etag,
-        vary: entry.vary,
-        cachedAt: times.cachedAt,
-        staleAt: times.staleAt,
-        deleteAt: times.deleteAt,
-      }
-
-      // RFC 9111 §5.2.1.5: a request no-store forbids storing any part of
-      // this request's response — serve the freshened value, don't write it.
-      if (!this.#noStore) {
-        try {
-          this.#store.set(this.#key, freshened)
-        } catch (err) {
-          if (err.message === 'database is locked') {
-            this.#logger?.debug({ err }, 'failed to freshen cache entry')
-          } else {
-            this.#logger?.error({ err }, 'failed to freshen cache entry')
-          }
-        }
-      }
-
-      return freshened
-    } catch (err) {
-      // Freshening must never break delivery of a validated entry.
-      this.#logger?.error({ err }, 'failed to freshen cache entry')
-      return entry
-    }
-  }
-}
-
-/**
  * RFC 9111 §4.4: a non-error response to an unsafe method invalidates the
  * stored entries for the target URI and any same-origin Location /
  * Content-Location URIs (undici PR #5514). Cross-origin targets are skipped —
@@ -1076,70 +774,12 @@ function makeKey(opts) {
   return key
 }
 
-function cacheOptsOf(opts) {
+export function cacheOptsOf(opts) {
   return {
     maxEntrySize: opts.cache.maxEntrySize,
     maxEntryTTL: opts.cache.maxEntryTTL,
     heuristic: opts.cache.heuristic,
     defaultTTL: opts.cache.defaultTTL,
-  }
-}
-
-/**
- * Fire-and-forget background refresh for stale-while-revalidate (RFC 5861
- * §3): the caller was already served the stale entry; only the store observes
- * the outcome. Re-enters the dispatch chain below the cache interceptor.
- */
-function backgroundRefresh(dispatch, opts, key, store, entry) {
-  const refreshKey = `${key.method}:${key.origin}${key.path}`
-  if (backgroundRefreshes.has(refreshKey)) {
-    return
-  }
-  backgroundRefreshes.add(refreshKey)
-
-  let finished = false
-  const done = () => {
-    if (!finished) {
-      finished = true
-      backgroundRefreshes.delete(refreshKey)
-    }
-  }
-
-  const silentHandler = {
-    onConnect: NOOP,
-    onHeaders: () => true,
-    onData: () => true,
-    onComplete: done,
-    onError: (err) => {
-      done()
-      opts.logger?.debug({ err }, 'cache: background revalidation failed')
-    },
-  }
-
-  try {
-    // Strip caller-specific request state: the body (already consumed or
-    // owned by the caller) and the signal (a caller abort after being served
-    // stale must not kill the shared refresh).
-    const bgOpts = {
-      ...opts,
-      headers: conditionalHeaders(key.headers ?? {}, entry),
-      body: null,
-      signal: undefined,
-    }
-    dispatch(
-      bgOpts,
-      new RevalidationHandler(key, entry, bgOpts, {
-        store,
-        logger: opts.logger,
-        handler: silentHandler,
-        allowStaleOnError: false,
-        noStore: false,
-        cacheOpts: cacheOptsOf(opts),
-      }),
-    )
-  } catch (err) {
-    done()
-    opts.logger?.debug({ err }, 'cache: background revalidation failed')
   }
 }
 
@@ -1430,11 +1070,7 @@ export default () => (dispatch) => (opts, handler) => {
   )
 }
 
-/**
- * @param {'hit' | 'miss'} [result] lookup outcome for the undici:cache doc
- * @param {string | null} [reason]
- */
-function serveFromCache(entry, opts, handler, write, url, lookupMs, result = 'hit', reason = null) {
+export function serveFromCache(entry, opts, handler) {
   const { statusCode, trailers, body } = entry
 
   let headers = entry.headers
@@ -1543,7 +1179,7 @@ function weakMatch(ifNoneMatch, etag) {
  * @param {string|any} etag
  * @returns {boolean}
  */
-function isEtagUsable(etag) {
+export function isEtagUsable(etag) {
   if (typeof etag !== 'string') {
     return false
   }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -15,32 +15,19 @@ import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
 const DEFAULT_MAX_ENTRY_TTL = 30 * 24 * 3600 // seconds
+// Bounded retention for entries kept solely for conditional revalidation
+// (zero/expired freshness but a usable validator): long enough that the
+// "always validate" origin pattern pays a 304 instead of a full 200, short
+// enough not to pin dead content. Mirrors undici PR #5515 (24h).
+const REVALIDATION_RETENTION = 24 * 3600 // seconds
 // RFC 8246 'immutable' has no lifetime of its own; this is the customary
 // 1-year default, capped by maxEntryTTL below.
 const IMMUTABLE_LIFETIME = 31556952 // seconds
 const NOOP = () => {}
 
-// Emit the per-dispatch `undici:cache` lookup doc at the outcome decision
-// (hit/miss/bypass). Call sites gate on the write fn captured once at the
-// dispatch entry (log.js style), so the off path pays no doc building; result
-// and reason stay low-cardinality (they become ES keywords).
-function traceLookup(write, opts, url, result, reason, statusCode, ageSec, sizeBytes, lookupMs) {
-  traceSafe(
-    write,
-    {
-      id: opts.id ?? null,
-      method: opts.method ?? null,
-      url,
-      result,
-      reason,
-      statusCode,
-      ageSec,
-      sizeBytes,
-      lookupMs,
-    },
-    'undici:cache',
-  )
-}
+// In-flight background stale-while-revalidate refreshes keyed by
+// method + url, so a hot stale key spawns one refresh, not a herd.
+const backgroundRefreshes = new Set()
 
 /**
  * Explicit (or opt-in heuristic) freshness lifetime in seconds, or null when
@@ -133,31 +120,96 @@ function determineAge(headers, now) {
  * Computes the entry's absolute times, or null when it shouldn't be stored.
  *
  * cachedAt is backdated by the corrected initial age so all downstream age
- * math (served Age header, freshness checks) reduces to `now - cachedAt`; the
- * origin Age header is stripped before storing to match.
+ * math (served Age header, freshness and request-directive checks) reduces to
+ * `now - cachedAt`; the origin Age header is stripped before storing to match.
  *
- * This cache does not retain entries past freshness for revalidation, so
- * deleteAt == staleAt: an entry is dropped by the store as soon as it goes
- * stale, and the read path never serves a stale entry. (The staleAt column
- * exists for forward compatibility with revalidation.) Everything is capped
- * by maxEntryTTL, measured from the (backdated) cachedAt.
+ * staleAt splits freshness from retention: entries are RETAINED past staleAt
+ * (deleteAt) so a stale hit can be revalidated with a conditional request
+ * instead of refetched in full. Retention is 2x the freshness lifetime
+ * (undici PR #4913's revalidation buffer), extended by stale-while-revalidate
+ * / stale-if-error windows (RFC 5861) and to REVALIDATION_RETENTION for
+ * validator-bearing entries; everything is capped by maxEntryTTL, measured
+ * from (backdated) cachedAt.
  */
-function computeEntryTimes(lifetime, age, maxEntryTTL, now) {
+function computeEntryTimes(
+  lifetime,
+  explicit,
+  age,
+  cacheControlDirectives,
+  maxEntryTTL,
+  hasValidator,
+  now,
+) {
   if (!Number.isFinite(lifetime)) {
     return null
   }
 
-  const freshness = Math.min(lifetime, maxEntryTTL) // seconds
-  if (freshness - age <= 0) {
-    // Stale on arrival — not worth storing.
+  const freshness = Math.min(lifetime, maxEntryTTL) // seconds; may be <= 0
+  if (freshness - age <= 0 && !(hasValidator && explicit)) {
+    // Stale on arrival and no cheap way to revalidate — not worth storing.
     return null
   }
 
   const cachedAt = now - age * 1000
   const staleAt = cachedAt + freshness * 1000
-  const deleteAt = staleAt
+
+  const swr = cacheControlDirectives['stale-while-revalidate']
+  const sie = cacheControlDirectives['stale-if-error']
+  const staleOffset = Math.max(freshness, 0)
+  let retention = staleOffset * 2
+  if (typeof swr === 'number' && swr > 0) {
+    retention = Math.max(retention, staleOffset + swr)
+  }
+  if (typeof sie === 'number' && sie > 0) {
+    retention = Math.max(retention, staleOffset + sie)
+  }
+  if (hasValidator && explicit) {
+    retention = Math.max(retention, age + REVALIDATION_RETENTION)
+  }
+  retention = Math.min(retention, maxEntryTTL)
+
+  const deleteAt = cachedAt + retention * 1000
+  if (deleteAt <= now) {
+    return null
+  }
 
   return { cachedAt, staleAt, deleteAt }
+}
+
+/**
+ * RFC 9111 §5.2.2.2 / §5.2.2.8 (and undici PR #5511): must-revalidate and
+ * proxy-revalidate (we are a shared cache) veto every stale-serving path —
+ * max-stale, stale-while-revalidate and stale-if-error.
+ */
+function forbidsServingStale(entry) {
+  const directives = entry.cacheControlDirectives
+  return directives?.['must-revalidate'] === true || directives?.['proxy-revalidate'] === true
+}
+
+/**
+ * Conditional request headers for revalidating a stored entry (RFC 9111
+ * §4.3.1). Per RFC 9110 §13.1.3 and undici PR #5512, If-Modified-Since echoes
+ * the stored Last-Modified VERBATIM when available (nginx's default
+ * `if_modified_since exact` requires a byte-identical value), falling back to
+ * the response Date, then to the (backdated) receipt time.
+ *
+ * The stored vary values need no replay: the store only returns entries whose
+ * selecting headers already match this request.
+ */
+function conditionalHeaders(headers, entry) {
+  const condHeaders = { ...headers }
+  if (entry.etag) {
+    condHeaders['if-none-match'] = entry.etag
+  }
+  const lastModified = entry.headers?.['last-modified']
+  const date = entry.headers?.date
+  condHeaders['if-modified-since'] =
+    typeof lastModified === 'string'
+      ? lastModified
+      : typeof date === 'string'
+        ? date
+        : new Date(entry.cachedAt).toUTCString()
+  return condHeaders
 }
 
 class CacheHandler extends DecoratorHandler {
@@ -334,19 +386,11 @@ class CacheHandler extends DecoratorHandler {
       // Do nothing. We don't transform responses...
     }
 
-    if (
-      cacheControlDirectives['must-revalidate'] ||
-      cacheControlDirectives['proxy-revalidate'] ||
-      cacheControlDirectives['stale-while-revalidate'] != null ||
-      cacheControlDirectives['stale-if-error'] != null ||
-      cacheControlDirectives['no-cache'] === true
-    ) {
-      // These directives require origin revalidation, which this cache does
-      // not yet perform — so the responses are not stored (a follow-up adds
-      // conditional revalidation and turns these into stored-and-validated
-      // entries).
-      return this.#skip('revalidate', statusCode, headers, resume)
-    }
+    // must-revalidate / proxy-revalidate / unqualified no-cache /
+    // stale-while-revalidate / stale-if-error responses ARE stored: the
+    // directives constrain how the entry may be reused (validate first, never
+    // serve stale, ...), which the read path enforces from the persisted
+    // cacheControlDirectives.
 
     // Null prototype: selector names come from the response Vary header and
     // request header names are caller-controlled — on a plain `{}` a
@@ -373,20 +417,35 @@ class CacheHandler extends DecoratorHandler {
 
     const now = Date.now()
 
-    const lifetimeInfo = determineLifetime(
+    let lifetimeInfo = determineLifetime(
       statusCode,
       headers,
       cacheControlDirectives,
       { heuristic: this.#heuristic, defaultTTL: this.#defaultTTL },
       now,
     )
+    if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
+      // Store-and-revalidate (undici PR #5515): no expiration information at
+      // all, but unqualified no-cache plus a validator means every reuse can
+      // cost a 304 instead of a full 200.
+      lifetimeInfo = { lifetime: 0, explicit: true }
+    }
     if (lifetimeInfo == null) {
       return this.#skip('no-lifetime', statusCode, headers, resume)
     }
 
     const etag = typeof headers.etag === 'string' && isEtagUsable(headers.etag) ? headers.etag : ''
+    const hasValidator = etag !== '' || typeof headers['last-modified'] === 'string'
     const age = determineAge(headers, now)
-    const times = computeEntryTimes(lifetimeInfo.lifetime, age, this.#maxEntryTTL, now)
+    const times = computeEntryTimes(
+      lifetimeInfo.lifetime,
+      lifetimeInfo.explicit,
+      age,
+      cacheControlDirectives,
+      this.#maxEntryTTL,
+      hasValidator,
+      now,
+    )
     if (times == null) {
       return this.#skip('stale', statusCode, headers, resume)
     }
@@ -525,6 +584,325 @@ class CacheHandler extends DecoratorHandler {
     }
 
     super.onComplete(trailers)
+  }
+}
+
+/**
+ * Drives a conditional (revalidation) request to the origin for a stale
+ * stored entry (RFC 9111 §4.3). Decision at response headers:
+ * - 304: the entry is valid — freshen it (§4.3.4) and serve it.
+ * - 5xx within the stale-if-error window (RFC 5861 §4, incl. undici PR
+ *   #5513's pre-response connection errors): discard the error and serve the
+ *   stale entry.
+ * - anything else: a real replacement — stream it through a CacheHandler to
+ *   the user handler, storing it on the way.
+ *
+ * The user handler's response callbacks are DEFERRED until that decision, but
+ * onConnect is forwarded eagerly with a bridging abort — the user (e.g. a
+ * signal listener in request()) must be able to tear down the in-flight
+ * conditional request; nothing below the cache observes opts.signal
+ * mid-flight. Delivery paths re-invoke onConnect (serveFromCache / the pass
+ * CacheHandler drive their own connect), which handlers in this pipeline
+ * already tolerate — the retry interceptor re-connects the same handler on
+ * every attempt.
+ */
+class RevalidationHandler {
+  #key
+  #entry
+  #store
+  #logger
+  #opts
+  #cacheOpts
+  #userHandler
+  #allowStaleOnError
+  #noStore
+  /** @type {null | 'pass' | 'validated' | 'stale'} */
+  #mode = null
+  /** @type {CacheHandler | import('../utils.js').DecoratorHandler | object | null} */
+  #inner = null
+  /** @type {((reason?: any) => void) | null} */
+  #abort = null
+  /** @type {Record<string, string | string[]> | null} */
+  #headers304 = null
+  #delivered = false
+  #userAborted = false
+  #userAbortReason = null
+
+  constructor(key, entry, opts, { store, logger, handler, allowStaleOnError, noStore, cacheOpts }) {
+    this.#key = key
+    this.#entry = entry
+    this.#store = store
+    this.#logger = logger
+    this.#opts = opts
+    this.#cacheOpts = cacheOpts
+    this.#userHandler = handler
+    this.#allowStaleOnError = allowStaleOnError
+    this.#noStore = noStore ?? false
+  }
+
+  onConnect(abort) {
+    this.#abort = abort
+    // Eager connect: hand the user a bridging abort so a caller abort (e.g.
+    // a signal firing in request()) tears down the in-flight conditional
+    // request instead of being silently ignored until the origin answers.
+    this.#userHandler.onConnect((reason) => {
+      if (!this.#delivered && !this.#userAborted) {
+        this.#userAborted = true
+        this.#userAbortReason = reason
+        this.#abort?.(reason)
+      }
+    })
+  }
+
+  onUpgrade(statusCode, headers, socket) {
+    // Upgrades are gated out before the cache interceptor engages; nothing to
+    // do but not crash if one slips through.
+    socket?.destroy?.()
+  }
+
+  onHeaders(statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // Informational (1xx) interim responses — e.g. 103 Early Hints — are
+      // not the revalidation answer; stay undecided and keep reading.
+      return true
+    }
+
+    if (statusCode === 304) {
+      this.#mode = 'validated'
+      this.#headers304 = headers
+      return true
+    }
+
+    if (this.#allowStaleOnError && statusCode >= 500 && statusCode <= 504) {
+      this.#mode = 'stale'
+      // The decision to serve stale is already made — don't wait for the 5xx
+      // body to drain (it can be large and only adds latency/bandwidth).
+      // Deliver the stale entry now and abort the in-flight request; the
+      // resulting onError is suppressed by the #delivered guard.
+      this.#deliver(this.#entry)
+      this.#abort?.(new Error('stale-if-error: serving stale cached response'))
+      return false
+    }
+
+    this.#mode = 'pass'
+    // RFC 9111 §5.2.1.5: a request no-store forbids storing the replacement
+    // response — stream it to the user handler without the CacheHandler wrap.
+    this.#inner = this.#noStore
+      ? this.#userHandler
+      : new CacheHandler(this.#key, {
+          ...this.#cacheOpts,
+          store: this.#store,
+          logger: this.#logger,
+          handler: this.#userHandler,
+        })
+    this.#inner.onConnect((reason) => this.#abort?.(reason))
+    return this.#inner.onHeaders(statusCode, headers, resume)
+  }
+
+  onData(chunk) {
+    return this.#mode === 'pass' ? this.#inner.onData(chunk) : true
+  }
+
+  onComplete(trailers) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onComplete(trailers)
+    }
+    // Freshen even when the user aborted mid-flight — the 304 validated the
+    // entry either way, and the store write benefits every other caller.
+    this.#deliver(this.#mode === 'validated' ? this.#freshen() : this.#entry)
+  }
+
+  onError(err) {
+    if (this.#mode === 'pass') {
+      return this.#inner.onError(err)
+    }
+    if (this.#userAborted) {
+      // The (probable) cause of this error is the user's own abort — a
+      // stale-if-error serve would convert their cancellation into a
+      // successful response.
+      return this.#fail(this.#userAbortReason ?? err)
+    }
+    if (this.#mode === 'validated') {
+      // The 304 already validated the entry; a broken tail on the (empty)
+      // validation response doesn't invalidate it.
+      return this.#deliver(this.#freshen())
+    }
+    if (this.#mode === 'stale' || this.#allowStaleOnError) {
+      // Pre-response connection errors (ECONNREFUSED, reset, ...) count as
+      // origin errors for stale-if-error — RFC 5861's definition explicitly
+      // covers an unreachable origin (undici PR #5513). Mid-body failures of
+      // a replacement response are 'pass' mode and propagate above.
+      return this.#deliver(this.#entry)
+    }
+    this.#fail(err)
+  }
+
+  #deliver(entry) {
+    if (this.#delivered) {
+      return
+    }
+    this.#delivered = true
+    if (this.#userAborted) {
+      this.#userHandler.onError(this.#userAbortReason ?? new Error('aborted'))
+    } else {
+      serveFromCache(entry, this.#opts, this.#userHandler)
+    }
+  }
+
+  #fail(err) {
+    if (!this.#delivered) {
+      this.#delivered = true
+      this.#userHandler.onError(err)
+    }
+  }
+
+  /**
+   * RFC 9111 §4.3.4: merge the 304's headers over the stored ones and reset
+   * the freshness clock. Returns the entry to serve; the store is only
+   * updated when the merged response is still storable.
+   */
+  #freshen() {
+    const entry = this.#entry
+    const headers304 = this.#headers304 ?? {}
+    try {
+      const now = Date.now()
+
+      // Same exclusions as at store time — hop-by-hop, fields listed in the
+      // 304's Connection header — plus Set-Cookie (must never enter a shared
+      // entry) and the body-describing fields, for which the stored body is
+      // authoritative.
+      const excludedHeaders = new Set(['age', 'set-cookie', 'content-length', 'content-range'])
+      const connection = headers304.connection
+      if (typeof connection === 'string') {
+        for (const name of connection.split(',')) {
+          excludedHeaders.add(name.trim().toLowerCase())
+        }
+      } else if (Array.isArray(connection)) {
+        for (const line of connection) {
+          for (const name of `${line}`.split(',')) {
+            excludedHeaders.add(name.trim().toLowerCase())
+          }
+        }
+      }
+
+      const merged = Object.create(null)
+      for (const name of Object.keys(entry.headers ?? {})) {
+        merged[name] = entry.headers[name]
+      }
+      for (const name of Object.keys(headers304)) {
+        const lower = name.toLowerCase()
+        if (isHopByHop(lower) || excludedHeaders.has(lower)) {
+          continue
+        }
+        const val = headers304[name]
+        merged[lower] = Array.isArray(val) ? val.slice() : val
+      }
+
+      // RFC 9110 §6.6.1: a 304 without a Date header is assigned the receipt
+      // time. Without this, the stored (old) Date drives the corrected age
+      // below and the freshened entry lands stale-on-arrival — permanently
+      // revalidating on every hit despite the origin granting freshness.
+      if (headers304.date == null) {
+        merged.date = new Date(now).toUTCString()
+      }
+
+      const cacheControlDirectives = parseCacheControl(merged['cache-control']) ?? {}
+      if (cacheControlDirectives['no-store'] || cacheControlDirectives.private === true) {
+        // The origin has withdrawn (shared-)cacheability: serve this one
+        // validated use, but don't freshen the stored entry — it stays stale
+        // and keeps revalidating until it ages out.
+        return { ...entry, headers: merged }
+      }
+
+      // Qualified no-cache=/private= field lists (possibly newly added by
+      // the 304) must not survive in the stored — or served — headers, even
+      // when the named field came from the original stored response.
+      for (const directive of ['no-cache', 'private']) {
+        if (Array.isArray(cacheControlDirectives[directive])) {
+          for (const name of cacheControlDirectives[directive]) {
+            delete merged[name]
+          }
+        }
+      }
+
+      const etag =
+        typeof merged.etag === 'string' && isEtagUsable(merged.etag)
+          ? merged.etag
+          : (entry.etag ?? '')
+      const hasValidator = etag !== '' || typeof merged['last-modified'] === 'string'
+
+      let lifetimeInfo = determineLifetime(
+        entry.statusCode,
+        merged,
+        cacheControlDirectives,
+        this.#cacheOpts,
+        now,
+      )
+      if (lifetimeInfo == null && cacheControlDirectives['no-cache'] === true) {
+        lifetimeInfo = { lifetime: 0, explicit: true }
+      }
+      if (lifetimeInfo == null) {
+        return { ...entry, headers: merged }
+      }
+
+      // Clamp the corrected age to the stored entry's own current age
+      // (now - cachedAt already includes the original initial age, RFC 9111
+      // §4.2.3): a skewed/old Date on the 304 must not push the freshened
+      // entry further into the past than the response it just validated.
+      const age = Math.min(
+        determineAge(merged, now),
+        Math.max(0, Math.floor((now - entry.cachedAt) / 1000)),
+      )
+      const times = computeEntryTimes(
+        lifetimeInfo.lifetime,
+        lifetimeInfo.explicit,
+        age,
+        cacheControlDirectives,
+        this.#cacheOpts.maxEntryTTL ?? this.#store.maxEntryTTL ?? DEFAULT_MAX_ENTRY_TTL,
+        hasValidator,
+        now,
+      )
+      if (times == null) {
+        return { ...entry, headers: merged }
+      }
+
+      const freshened = {
+        // 206 entries never take the revalidation path, so the stored body is
+        // the full representation: start 0, end = byte length (0 for HEAD).
+        body: entry.body ?? null,
+        start: 0,
+        end: entry.body ? entry.body.byteLength : 0,
+        statusCode: entry.statusCode,
+        statusMessage: entry.statusMessage ?? '',
+        headers: merged,
+        cacheControlDirectives,
+        etag,
+        vary: entry.vary,
+        cachedAt: times.cachedAt,
+        staleAt: times.staleAt,
+        deleteAt: times.deleteAt,
+      }
+
+      // RFC 9111 §5.2.1.5: a request no-store forbids storing any part of
+      // this request's response — serve the freshened value, don't write it.
+      if (!this.#noStore) {
+        try {
+          this.#store.set(this.#key, freshened)
+        } catch (err) {
+          if (err.message === 'database is locked') {
+            this.#logger?.debug({ err }, 'failed to freshen cache entry')
+          } else {
+            this.#logger?.error({ err }, 'failed to freshen cache entry')
+          }
+        }
+      }
+
+      return freshened
+    } catch (err) {
+      // Freshening must never break delivery of a validated entry.
+      this.#logger?.error({ err }, 'failed to freshen cache entry')
+      return entry
+    }
   }
 }
 
@@ -707,6 +1085,64 @@ function cacheOptsOf(opts) {
   }
 }
 
+/**
+ * Fire-and-forget background refresh for stale-while-revalidate (RFC 5861
+ * §3): the caller was already served the stale entry; only the store observes
+ * the outcome. Re-enters the dispatch chain below the cache interceptor.
+ */
+function backgroundRefresh(dispatch, opts, key, store, entry) {
+  const refreshKey = `${key.method}:${key.origin}${key.path}`
+  if (backgroundRefreshes.has(refreshKey)) {
+    return
+  }
+  backgroundRefreshes.add(refreshKey)
+
+  let finished = false
+  const done = () => {
+    if (!finished) {
+      finished = true
+      backgroundRefreshes.delete(refreshKey)
+    }
+  }
+
+  const silentHandler = {
+    onConnect: NOOP,
+    onHeaders: () => true,
+    onData: () => true,
+    onComplete: done,
+    onError: (err) => {
+      done()
+      opts.logger?.debug({ err }, 'cache: background revalidation failed')
+    },
+  }
+
+  try {
+    // Strip caller-specific request state: the body (already consumed or
+    // owned by the caller) and the signal (a caller abort after being served
+    // stale must not kill the shared refresh).
+    const bgOpts = {
+      ...opts,
+      headers: conditionalHeaders(key.headers ?? {}, entry),
+      body: null,
+      signal: undefined,
+    }
+    dispatch(
+      bgOpts,
+      new RevalidationHandler(key, entry, bgOpts, {
+        store,
+        logger: opts.logger,
+        handler: silentHandler,
+        allowStaleOnError: false,
+        noStore: false,
+        cacheOpts: cacheOptsOf(opts),
+      }),
+    )
+  } catch (err) {
+    done()
+    opts.logger?.debug({ err }, 'cache: background revalidation failed')
+  }
+}
+
 export default () => (dispatch) => (opts, handler) => {
   if (!opts.cache || opts.upgrade) {
     return dispatch(opts, handler)
@@ -812,59 +1248,45 @@ export default () => (dispatch) => (opts, handler) => {
     }
   }
 
-  const cacheHandler = () =>
-    new CacheHandler(key, {
-      ...cacheOptsOf(opts),
-      store,
-      logger: opts.logger,
-      handler,
-      write,
-      id: opts.id ?? null,
-      url,
-    })
+  // Freshness for THIS request: the entry's staleAt, tightened by the
+  // caller's max-age / min-fresh (RFC 9111 §5.2.1.1 / §5.2.1.3). Date.now()
+  // rather than getFastNow(): zero-TTL revalidation entries (staleAt ==
+  // cachedAt) would read as fresh for up to a second on the lagging clock.
+  //
+  // requestAccepts is tracked separately from origin freshness because it
+  // constrains EVERY serving path below, including the stale-serving windows
+  // (max-stale, stale-while-revalidate, stale-if-error): those directives
+  // relax the response-computed staleness bound, they must not un-reject an
+  // entry the caller's own age bounds refused — otherwise an origin emitting
+  // stale-while-revalidate would silently disable clients' max-age=0.
+  const now = Date.now()
+  const requestAccepts =
+    entry == null ||
+    // `!= null`: max-age=0 parses to 0 (falsy) but still demands a response
+    // no older than 0 seconds.
+    ((requestCacheControl['max-age'] == null ||
+      (now - entry.cachedAt) / 1000 < requestCacheControl['max-age']) &&
+      (requestCacheControl['min-fresh'] == null ||
+        entry.staleAt - now > requestCacheControl['min-fresh'] * 1000))
+  const fresh = entry != null && now < entry.staleAt && requestAccepts
 
-  // Request Cache-Control directives that this cache does not evaluate locally
-  // (a follow-up adds conditional revalidation and local evaluation) cause a
-  // bypass to the origin. These constrain REUSE of a stored response, not the
-  // storage of a fresh one — so the bypass still writes the origin response
-  // back through CacheHandler for later callers (undici PR #5510), unless the
-  // request's own no-store forbids storing. only-if-cached is the exception:
-  // it forbids contacting the origin, so it is handled from the cache below
-  // instead of bypassing.
-  const bypass =
-    !onlyIfCached &&
-    // != null: 'max-age=0' parses to 0 (falsy) but still demands revalidation.
-    (requestCacheControl['max-age'] != null ||
-      requestCacheControl['no-cache'] === true ||
-      requestCacheControl['stale-if-error'] != null ||
-      requestCacheControl['max-stale'] != null ||
-      requestCacheControl['min-fresh'] != null)
+  // Validation demanded regardless of freshness: the request's no-cache (or
+  // Pragma), or the stored response's unqualified no-cache (§5.2.2.4).
+  const mustRevalidate =
+    entry != null &&
+    (requestCacheControl['no-cache'] === true ||
+      entry.cacheControlDirectives?.['no-cache'] === true)
 
-  if (bypass) {
-    if (write !== null) {
-      // Name the (first, in evaluation order) directive that forced the
-      // bypass; the fallthrough is min-fresh by construction of `bypass`.
-      const reason =
-        requestCacheControl['max-age'] != null
-          ? 'max-age'
-          : requestCacheControl['no-cache'] === true
-            ? 'no-cache'
-            : requestCacheControl['stale-if-error'] != null
-              ? 'stale-if-error'
-              : requestCacheControl['max-stale'] != null
-                ? 'max-stale'
-                : 'min-fresh'
-      traceLookup(write, opts, url, 'bypass', reason, null, null, null, lookupMs)
-    }
-    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
-  }
-
-  // RFC 9110 Section 13: evaluate conditional request headers against the
-  // cached entry. The store only returns entries that are still fresh
-  // (deleteAt === staleAt), so a returned entry is always servable.
+  // RFC 9110 Section 13: Evaluate conditional request headers against cached
+  // entry — only against a FRESH entry that doesn't demand validation;
+  // answering 304 from a stale entry without validating would violate RFC
+  // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
+  // where the caller's own validators do the validation (a 304 flows through
+  // to the caller; a 200 replacement is stored by CacheHandler).
   // typeof guards: duplicated conditional headers arrive as arrays — treat
   // them as non-matching and bypass to origin rather than crashing.
-  if (entry && headers['if-none-match']) {
+  const servableFromCache = entry != null && fresh && !mustRevalidate
+  if (servableFromCache && headers['if-none-match']) {
     if (
       typeof headers['if-none-match'] === 'string' &&
       entry.etag &&
@@ -881,8 +1303,7 @@ export default () => (dispatch) => (opts, handler) => {
     }
     // Etag didn't match — bypass to origin.
     entry = undefined
-    missReason = 'etag'
-  } else if (entry && headers['if-modified-since']) {
+  } else if (servableFromCache && headers['if-modified-since']) {
     const lastModified = entry.headers?.['last-modified']
     if (
       typeof headers['if-modified-since'] === 'string' &&
@@ -900,7 +1321,8 @@ export default () => (dispatch) => (opts, handler) => {
     }
     // No last-modified or modified since — bypass to origin.
     entry = undefined
-    missReason = 'modified'
+  } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
+    entry = undefined
   }
 
   if (headers['if-match'] || headers['if-unmodified-since'] || headers['if-range']) {
@@ -911,31 +1333,101 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  if (!entry && !onlyIfCached) {
-    if (write !== null) {
-      traceLookup(write, opts, url, 'miss', missReason, null, null, null, lookupMs)
+  const cacheHandler = () =>
+    new CacheHandler(key, {
+      ...cacheOptsOf(opts),
+      store,
+      logger: opts.logger,
+      handler,
+    })
+
+  if (!entry) {
+    if (onlyIfCached) {
+      // RFC 9111 §5.2.1.7: no stored response usable without contacting the
+      // origin — 504.
+      return serveFromCache({ statusCode: 504 }, opts, handler)
     }
-    // A miss keeps the CacheHandler write-back unless the request's no-store
-    // forbids storing.
+    // Request directives (no-cache, max-age, ...) constrain REUSE of a stored
+    // response, not storage of a fresh one (undici PR #5510): every miss path
+    // keeps the CacheHandler write-back so one client's freshness override
+    // doesn't disable caching of the URL for everyone. Only the request's
+    // no-store forbids storing.
     return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
   }
 
-  // A hit (fresh, per the store) is served; only-if-cached with no usable
-  // entry yields 504 (RFC 9111 §5.2.1.7) — the cache could NOT satisfy the
-  // request, so its doc must not pollute hit-rate aggregations: it is a miss
-  // the request forbade going to origin for.
-  return entry
-    ? serveFromCache(entry, opts, handler, write, url, lookupMs)
-    : serveFromCache(
-        { statusCode: 504 },
-        opts,
-        handler,
-        write,
-        url,
-        lookupMs,
-        'miss',
-        'only-if-cached',
-      )
+  if (fresh && !mustRevalidate) {
+    return serveFromCache(entry, opts, handler)
+  }
+
+  // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
+  // max-stale parses to Infinity: any staleness) — vetoed by the response's
+  // must-revalidate/proxy-revalidate (§5.2.2.2) and by the caller's own
+  // max-age/min-fresh bounds (requestAccepts).
+  if (
+    !mustRevalidate &&
+    requestAccepts &&
+    requestCacheControl['max-stale'] != null &&
+    !forbidsServingStale(entry) &&
+    now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
+  ) {
+    return serveFromCache(entry, opts, handler)
+  }
+
+  if (onlyIfCached) {
+    // Stale (or validation-demanding) entry and the origin is off-limits.
+    return serveFromCache({ statusCode: 504 }, opts, handler)
+  }
+
+  if (entry.statusCode === 206) {
+    // Range entries can't be revalidated as a whole representation — refetch.
+    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
+  }
+
+  // RFC 5861 §3 stale-while-revalidate: serve the stale entry immediately and
+  // refresh in the background — unless validation is demanded, the response
+  // forbids serving stale, or the caller's own max-age/min-fresh bounds
+  // rejected the entry (they demand a validated/younger response NOW).
+  if (
+    !mustRevalidate &&
+    requestAccepts &&
+    !forbidsServingStale(entry) &&
+    typeof entry.cacheControlDirectives?.['stale-while-revalidate'] === 'number' &&
+    now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
+  ) {
+    try {
+      serveFromCache(entry, opts, handler)
+    } finally {
+      backgroundRefresh(dispatch, opts, key, store, entry)
+    }
+    return
+  }
+
+  // Synchronous revalidation (RFC 9111 §4.3): conditional request; 304
+  // freshens and serves the entry, an error within the stale-if-error window
+  // (RFC 5861 §4: response directive first, request directive fallback —
+  // vetoed by must-revalidate/proxy-revalidate) serves the stale entry, and
+  // anything else replaces it.
+  const staleIfError =
+    entry.cacheControlDirectives?.['stale-if-error'] ?? requestCacheControl['stale-if-error']
+  const allowStaleOnError =
+    !mustRevalidate &&
+    requestAccepts &&
+    !forbidsServingStale(entry) &&
+    typeof staleIfError === 'number' &&
+    staleIfError > 0 &&
+    now <= entry.staleAt + staleIfError * 1000
+
+  return dispatch(
+    { ...opts, headers: conditionalHeaders(headers, entry) },
+    new RevalidationHandler(key, entry, opts, {
+      store,
+      logger: opts.logger,
+      handler,
+      allowStaleOnError,
+      noStore: requestCacheControl['no-store'] === true,
+      cacheOpts: cacheOptsOf(opts),
+    }),
+  )
 }
 
 /**

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -902,12 +902,20 @@ export default () => (dispatch) => (opts, handler) => {
   const now = Date.now()
   const requestAccepts =
     entry == null ||
-    // `!= null`: max-age=0 parses to 0 (falsy) but still demands a response
-    // no older than 0 seconds.
+    // Bounds are inclusive (RFC 9111 §5.2.1.1/§5.2.1.3): the client accepts an
+    // age that does NOT exceed max-age (age <= max-age) and freshness lasting
+    // AT LEAST min-fresh (remaining >= min-fresh). Strict comparisons would
+    // spuriously revalidate at the exact boundary (e.g. age == max-age).
+    //
+    // max-age=0 is the deliberate exception: it always forces revalidation
+    // (the fetch cache:'no-cache' idiom, undici #5504) and must not accept an
+    // age-0 entry, so it is excluded from the inclusive form via `> 0`. The
+    // `== null` guard also keeps 0 (falsy) from being read as "absent".
     ((requestCacheControl['max-age'] == null ||
-      (now - entry.cachedAt) / 1000 < requestCacheControl['max-age']) &&
+      (requestCacheControl['max-age'] > 0 &&
+        (now - entry.cachedAt) / 1000 <= requestCacheControl['max-age'])) &&
       (requestCacheControl['min-fresh'] == null ||
-        entry.staleAt - now > requestCacheControl['min-fresh'] * 1000))
+        entry.staleAt - now >= requestCacheControl['min-fresh'] * 1000))
   const fresh = entry != null && now < entry.staleAt && requestAccepts
 
   // Validation demanded regardless of freshness: the request's no-cache (or

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -348,10 +348,16 @@ export class CacheHandler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, headers, resume) {
-    if (statusCode !== 307 && statusCode !== 200 && statusCode !== 206) {
-      // Not a cacheable status: pass through with no store doc (only cacheable
-      // statuses that then fail a gate emit a skip doc).
+    if (statusCode < 200) {
+      // Interim 1xx (e.g. 103 Early Hints) is not the final response — pass it
+      // through with no store doc; the final response emits its own.
       return super.onHeaders(statusCode, headers, resume)
+    }
+
+    if (statusCode !== 307 && statusCode !== 200 && statusCode !== 206) {
+      // A non-cacheable FINAL status (404, 500, ...): emit the skip doc so the
+      // reason a response wasn't cached is visible, like every other gate.
+      return this.#skip('status', statusCode, headers, resume)
     }
 
     // 'trailer' is the RFC 9110 field name; 'trailers' is kept for backwards
@@ -741,6 +747,19 @@ function tryGetEntry(store, key, logger) {
 
 /**
  * Builds the cache key shared by the get and set paths.
+ *
+ * INVARIANT: the key is scoped to the LOGICAL origin — `opts.origin` as the
+ * caller requested it (scheme + host + port), never a DNS-resolved IP. HTTP
+ * caching is defined over the target URI's authority (the host), so keying on
+ * the physical IP would be wrong three ways: DNS round-robin would fragment
+ * one resource across rotating IPs (hit-rate collapse); IP churn would orphan
+ * entries; and — the real hazard — multiple hosts behind one IP (CDNs, shared
+ * load balancers) would COLLIDE on a single key and serve each other's bodies
+ * (cache poisoning). This holds because the cache interceptor runs BEFORE the
+ * dns interceptor that rewrites `opts.origin` to the resolved IP (dns pins the
+ * Host header and resolves for the connection only, below the cache). A
+ * composition that places an origin→IP rewrite ABOVE the cache would break
+ * this — keep the cache outboard of DNS resolution.
  */
 function makeKey(opts) {
   // Build the key the same way for lookups and stores: makeCacheKey

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -815,8 +815,14 @@ function originAllowed(origin, origins) {
       if (allowed.toLowerCase() === requestOrigin) {
         return true
       }
-    } else if (allowed.test(requestOrigin)) {
-      return true
+    } else {
+      // RegExp#test advances lastIndex for global/sticky (g/y) patterns, so a
+      // reused whitelist RegExp would match intermittently across requests.
+      // Reset first (a no-op for non-g/y patterns) to keep matching stateless.
+      allowed.lastIndex = 0
+      if (allowed.test(requestOrigin)) {
+        return true
+      }
     }
   }
   return false
@@ -1056,7 +1062,12 @@ export default ({ origins } = {}) => {
       try {
         serveFromCache(entry, opts, handler)
       } finally {
-        backgroundRefresh(dispatch, opts, key, store, entry)
+        // RFC 9111 §5.2.1.5: a request no-store forbids storing ANY response to
+        // it, and the background refresh's sole effect is to write the store —
+        // so skip it entirely (issuing a fetch we couldn't store is pure waste).
+        if (!requestCacheControl['no-store']) {
+          backgroundRefresh(dispatch, opts, key, store, entry)
+        }
       }
       return
     }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -10,6 +10,13 @@ import {
 } from '../utils.js'
 import { isHopByHop } from './proxy.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
+// cache-revalidation.js imports helpers back from this module — a deliberate
+// cycle. INVARIANT: every binding shared across the two files (in either
+// direction) is referenced ONLY at call time, inside functions/methods, never
+// during module evaluation. ESM live bindings resolve those by the time
+// anything runs, so the cycle is safe. Do NOT use a cross-module import at
+// top level (e.g. to initialize a module-scope const) or the binding will be
+// in its TDZ and read as undefined.
 import { RevalidationHandler, backgroundRefresh } from './cache-revalidation.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 
@@ -436,9 +443,10 @@ export class CacheHandler extends DecoratorHandler {
     // serve stale, ...), which the read path enforces from the persisted
     // cacheControlDirectives.
 
-    // parseVary returns null when the response can't be cached on Vary
-    // grounds (a non-string Vary header; the '*' form was already caught by the
-    // trailer/vary-star gate above).
+    // parseVary returns null when the response can't be cached on Vary grounds:
+    // a non-string (duplicated) Vary header, OR a member '*' inside a list (e.g.
+    // `Vary: Accept, *`). The gate above only catches the bare `Vary: *`, so a
+    // list containing '*' reaches — and is rejected by — parseVary here.
     const vary = parseVary(headers.vary, this.#key.headers)
     if (vary == null) {
       return this.#skip('vary-invalid', statusCode, headers, resume)

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -1017,9 +1017,17 @@ export default ({ origins } = {}) => {
 
     // Validation demanded regardless of freshness: the request's no-cache (or
     // Pragma), or the stored response's unqualified no-cache (§5.2.2.4).
+    //
+    // Request no-cache: `!= null` (any presence), not `=== true`. The request
+    // directive has no qualified form (RFC 9111 §5.2.1.4), but a client sending
+    // the malformed `no-cache="field"` parses to an array — fail safe and treat
+    // ANY presence as "must revalidate" rather than serving without validation.
+    // Response no-cache stays `=== true`: only the UNQUALIFIED response form
+    // forces full revalidation; the qualified `no-cache="field"` form is a
+    // field-strip directive (§5.2.2.4), handled at store/freshen time.
     const mustRevalidate =
       entry != null &&
-      (requestCacheControl['no-cache'] === true ||
+      (requestCacheControl['no-cache'] != null ||
         entry.cacheControlDirectives?.['no-cache'] === true)
 
     // RFC 9110 Section 13: Evaluate conditional request headers against cached
@@ -1206,7 +1214,11 @@ export default ({ origins } = {}) => {
         logger: opts.logger,
         handler,
         allowStaleOnError,
-        noStore: requestCacheControl['no-store'] === true,
+        // `!= null` (any presence), matching the truthy no-store checks on the
+        // miss/SWR paths above: a malformed qualified `no-store="field"` (array)
+        // must still suppress storing the revalidation replacement, not slip
+        // through a stricter `=== true`.
+        noStore: requestCacheControl['no-store'] != null,
         cacheOpts: cacheOptsOf(opts),
         write,
         id: opts.id ?? null,

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -783,303 +783,311 @@ export function cacheOptsOf(opts) {
   }
 }
 
-export default () => (dispatch) => (opts, handler) => {
-  if (!opts.cache || opts.upgrade) {
-    return dispatch(opts, handler)
+/**
+ * Validates the optional `origins` whitelist (undici PR #4739): undefined (the
+ * default) caches every origin; otherwise it must be an array of strings or
+ * RegExps. Thrown at interceptor construction so misconfiguration fails fast.
+ */
+function assertCacheOrigins(origins, name) {
+  if (origins === undefined) {
+    return
   }
+  if (!Array.isArray(origins)) {
+    throw new TypeError(`expected ${name} to be an array or undefined, got ${typeof origins}`)
+  }
+  for (let i = 0; i < origins.length; i++) {
+    const origin = origins[i]
+    if (typeof origin !== 'string' && !(origin instanceof RegExp)) {
+      throw new TypeError(`expected ${name}[${i}] to be a string or RegExp, got ${typeof origin}`)
+    }
+  }
+}
 
-  // Capture-once per dispatch (log.js style): the same resolved fn drives the
-  // `undici:cache` lookup doc and is threaded into CacheHandler /
-  // InvalidationHandler for the store/invalidate docs, so a writer flipping
-  // mid-request cannot split a dispatch across writers. Resolution cost when
-  // tracing is off is one property read plus a typeof check.
-  const write = traceWrite(opts.trace)
+/**
+ * Whether the request origin is permitted by the whitelist. String entries
+ * match the whole origin case-insensitively; RegExp entries are tested against
+ * it. An empty array matches nothing (caches no origin).
+ */
+function originAllowed(origin, origins) {
+  const requestOrigin = `${origin}`.toLowerCase()
+  for (const allowed of origins) {
+    if (typeof allowed === 'string') {
+      if (allowed.toLowerCase() === requestOrigin) {
+        return true
+      }
+    } else if (allowed.test(requestOrigin)) {
+      return true
+    }
+  }
+  return false
+}
 
-  if (opts.method !== 'GET' && opts.method !== 'HEAD') {
-    // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
-    // must not invalidate either. Every other method (POST/PUT/DELETE/...)
-    // invalidates the target URI on a non-error response (RFC 9111 §4.4).
-    if (opts.method === 'OPTIONS' || opts.method === 'TRACE') {
+export default ({ origins } = {}) => {
+  assertCacheOrigins(origins, 'opts.origins')
+  return (dispatch) => (opts, handler) => {
+    if (!opts.cache || opts.upgrade) {
       return dispatch(opts, handler)
     }
 
-    const store = getStore(opts)
-    if (typeof store.delete !== 'function') {
-      // User-supplied store without invalidation support.
+    // RFC-agnostic policy gate (undici PR #4739): when an origins whitelist is
+    // configured, a request to any other origin bypasses the cache entirely —
+    // neither stored/served nor invalidated.
+    if (origins !== undefined && !originAllowed(opts.origin, origins)) {
       return dispatch(opts, handler)
     }
+
+    if (opts.method !== 'GET' && opts.method !== 'HEAD') {
+      // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
+      // must not invalidate either. Every other method (POST/PUT/DELETE/...)
+      // invalidates the target URI on a non-error response (RFC 9111 §4.4).
+      if (opts.method === 'OPTIONS' || opts.method === 'TRACE') {
+        return dispatch(opts, handler)
+      }
+
+      const store = getStore(opts)
+      if (typeof store.delete !== 'function') {
+        // User-supplied store without invalidation support.
+        return dispatch(opts, handler)
+      }
+
+      return dispatch(
+        opts,
+        new InvalidationHandler(makeKey(opts), { store, logger: opts.logger, handler }),
+      )
+    }
+
+    // TODO (fix): enable range requests
 
     const key = makeKey(opts)
-    return dispatch(
-      opts,
-      new InvalidationHandler(key, {
+
+    // All request-directive and conditional-header guards below MUST read from
+    // the lowercased key.headers, not raw opts.headers — otherwise a caller
+    // supplying capitalized names (e.g. `Authorization`, `Cache-Control` via the
+    // standalone composition) would silently skip the guards while the store
+    // side (CacheHandler) reads the lowercased form, e.g. serving a non-public
+    // cached response to an authorized request (RFC 9111 §3.5).
+    const headers = key.headers ?? {}
+
+    const rawCacheControl = headers['cache-control']
+    const requestCacheControl = parseCacheControl(rawCacheControl) ?? {}
+
+    // RFC 9111 Section 5.4: Pragma: no-cache should be treated as
+    // Cache-Control: no-cache when Cache-Control is absent.
+    if (rawCacheControl == null && headers.pragma === 'no-cache') {
+      requestCacheControl['no-cache'] = true
+    }
+
+    if (requestCacheControl['no-transform']) {
+      // Do nothing. We don't transform requests...
+    }
+
+    const onlyIfCached = requestCacheControl['only-if-cached'] === true
+    const store = getStore(opts)
+
+    let entry = tryGetEntry(store, key, opts.logger)
+
+    // RFC 9111 §3.5 serve-side authorization gate: a shared cache must not
+    // reuse a stored response for a request with Authorization unless the
+    // response allowed it (public, s-maxage or must-revalidate — the mirror of
+    // the store-side gate in CacheHandler; both sites must stay in lockstep).
+    if (entry && headers.authorization != null) {
+      const directives = entry.cacheControlDirectives
+      if (
+        typeof headers.authorization !== 'string' ||
+        !(
+          directives?.public === true ||
+          directives?.['s-maxage'] != null ||
+          directives?.['must-revalidate'] === true
+        )
+      ) {
+        entry = undefined
+      }
+    }
+
+    // Freshness for THIS request: the entry's staleAt, tightened by the
+    // caller's max-age / min-fresh (RFC 9111 §5.2.1.1 / §5.2.1.3). Date.now()
+    // rather than getFastNow(): zero-TTL revalidation entries (staleAt ==
+    // cachedAt) would read as fresh for up to a second on the lagging clock.
+    //
+    // requestAccepts is tracked separately from origin freshness because it
+    // constrains EVERY serving path below, including the stale-serving windows
+    // (max-stale, stale-while-revalidate, stale-if-error): those directives
+    // relax the response-computed staleness bound, they must not un-reject an
+    // entry the caller's own age bounds refused — otherwise an origin emitting
+    // stale-while-revalidate would silently disable clients' max-age=0.
+    const now = Date.now()
+    // Whole-second, non-negative age — the SAME value serveFromCache emits as the
+    // Age header. RFC 9111 directives are delta-seconds (integers), so evaluating
+    // max-age against a fractional age would reject an entry (e.g. 10.2s vs
+    // max-age=10) that the client sees as within bound via `Age: 10`.
+    const ageSeconds = entry == null ? 0 : Math.max(0, Math.floor((now - entry.cachedAt) / 1000))
+    const requestAccepts =
+      entry == null ||
+      // Bounds are inclusive (RFC 9111 §5.2.1.1/§5.2.1.3): the client accepts an
+      // age that does NOT exceed max-age (age <= max-age) and freshness lasting
+      // AT LEAST min-fresh (remaining >= min-fresh). Strict comparisons would
+      // spuriously revalidate at the exact boundary (e.g. age == max-age).
+      //
+      // max-age=0 is the deliberate exception: it always forces revalidation
+      // (the fetch cache:'no-cache' idiom, undici #5504) and must not accept an
+      // age-0 entry, so it is excluded from the inclusive form via `> 0`. The
+      // `== null` guard also keeps 0 (falsy) from being read as "absent".
+      ((requestCacheControl['max-age'] == null ||
+        (requestCacheControl['max-age'] > 0 && ageSeconds <= requestCacheControl['max-age'])) &&
+        (requestCacheControl['min-fresh'] == null ||
+          entry.staleAt - now >= requestCacheControl['min-fresh'] * 1000))
+    const fresh = entry != null && now < entry.staleAt && requestAccepts
+
+    // Validation demanded regardless of freshness: the request's no-cache (or
+    // Pragma), or the stored response's unqualified no-cache (§5.2.2.4).
+    const mustRevalidate =
+      entry != null &&
+      (requestCacheControl['no-cache'] === true ||
+        entry.cacheControlDirectives?.['no-cache'] === true)
+
+    // RFC 9110 Section 13: Evaluate conditional request headers against cached
+    // entry — only against a FRESH entry that doesn't demand validation;
+    // answering 304 from a stale entry without validating would violate RFC
+    // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
+    // where the caller's own validators do the validation (a 304 flows through
+    // to the caller; a 200 replacement is stored by CacheHandler).
+    // typeof guards: duplicated conditional headers arrive as arrays — treat
+    // them as non-matching and bypass to origin rather than crashing.
+    const servableFromCache = entry != null && fresh && !mustRevalidate
+    if (servableFromCache && headers['if-none-match']) {
+      if (
+        typeof headers['if-none-match'] === 'string' &&
+        entry.etag &&
+        weakMatch(headers['if-none-match'], entry.etag)
+      ) {
+        return serveFromCache(
+          { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
+          opts,
+          handler,
+        )
+      }
+      // Etag didn't match — bypass to origin.
+      entry = undefined
+    } else if (servableFromCache && headers['if-modified-since']) {
+      const lastModified = entry.headers?.['last-modified']
+      if (
+        typeof headers['if-modified-since'] === 'string' &&
+        lastModified &&
+        new Date(lastModified) <= new Date(headers['if-modified-since'])
+      ) {
+        return serveFromCache(
+          { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
+          opts,
+          handler,
+        )
+      }
+      // No last-modified or modified since — bypass to origin.
+      entry = undefined
+    } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
+      entry = undefined
+    }
+
+    if (headers['if-match'] || headers['if-unmodified-since'] || headers['if-range']) {
+      // TODO (fix): evaluate these conditional headers against cached entry.
+      return dispatch(opts, handler)
+    }
+
+    const cacheHandler = () =>
+      new CacheHandler(key, {
+        ...cacheOptsOf(opts),
         store,
         logger: opts.logger,
         handler,
-        write,
-        id: opts.id ?? null,
-        url: write !== null ? traceUrl(key) : null,
+      })
+
+    if (!entry) {
+      if (onlyIfCached) {
+        // RFC 9111 §5.2.1.7: no stored response usable without contacting the
+        // origin — 504.
+        return serveFromCache({ statusCode: 504 }, opts, handler)
+      }
+      // Request directives (no-cache, max-age, ...) constrain REUSE of a stored
+      // response, not storage of a fresh one (undici PR #5510): every miss path
+      // keeps the CacheHandler write-back so one client's freshness override
+      // doesn't disable caching of the URL for everyone. Only the request's
+      // no-store forbids storing.
+      return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
+    }
+
+    if (fresh && !mustRevalidate) {
+      return serveFromCache(entry, opts, handler)
+    }
+
+    // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
+    // max-stale parses to Infinity: any staleness) — vetoed by the response's
+    // must-revalidate/proxy-revalidate (§5.2.2.2) and by the caller's own
+    // max-age/min-fresh bounds (requestAccepts).
+    if (
+      !mustRevalidate &&
+      requestAccepts &&
+      requestCacheControl['max-stale'] != null &&
+      !forbidsServingStale(entry) &&
+      now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
+    ) {
+      return serveFromCache(entry, opts, handler)
+    }
+
+    if (onlyIfCached) {
+      // Stale (or validation-demanding) entry and the origin is off-limits.
+      return serveFromCache({ statusCode: 504 }, opts, handler)
+    }
+
+    if (entry.statusCode === 206) {
+      // Range entries can't be revalidated as a whole representation — refetch.
+      return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
+    }
+
+    // RFC 5861 §3 stale-while-revalidate: serve the stale entry immediately and
+    // refresh in the background — unless validation is demanded, the response
+    // forbids serving stale, or the caller's own max-age/min-fresh bounds
+    // rejected the entry (they demand a validated/younger response NOW).
+    if (
+      !mustRevalidate &&
+      requestAccepts &&
+      !forbidsServingStale(entry) &&
+      typeof entry.cacheControlDirectives?.['stale-while-revalidate'] === 'number' &&
+      now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
+    ) {
+      try {
+        serveFromCache(entry, opts, handler)
+      } finally {
+        backgroundRefresh(dispatch, opts, key, store, entry)
+      }
+      return
+    }
+
+    // Synchronous revalidation (RFC 9111 §4.3): conditional request; 304
+    // freshens and serves the entry, an error within the stale-if-error window
+    // (RFC 5861 §4: response directive first, request directive fallback —
+    // vetoed by must-revalidate/proxy-revalidate) serves the stale entry, and
+    // anything else replaces it.
+    const staleIfError =
+      entry.cacheControlDirectives?.['stale-if-error'] ?? requestCacheControl['stale-if-error']
+    const allowStaleOnError =
+      !mustRevalidate &&
+      requestAccepts &&
+      !forbidsServingStale(entry) &&
+      typeof staleIfError === 'number' &&
+      staleIfError > 0 &&
+      now <= entry.staleAt + staleIfError * 1000
+
+    return dispatch(
+      { ...opts, headers: conditionalHeaders(headers, entry) },
+      new RevalidationHandler(key, entry, opts, {
+        store,
+        logger: opts.logger,
+        handler,
+        allowStaleOnError,
+        noStore: requestCacheControl['no-store'] === true,
+        cacheOpts: cacheOptsOf(opts),
       }),
     )
   }
-
-  // TODO (fix): enable range requests
-
-  const key = makeKey(opts)
-  // Bounded url tag shared by every doc this dispatch emits; the key (not raw
-  // opts) so the tag reflects the canonical path incl. the folded-in query.
-  const url = write !== null ? traceUrl(key) : null
-
-  // All request-directive and conditional-header guards below MUST read from
-  // the lowercased key.headers, not raw opts.headers — otherwise a caller
-  // supplying capitalized names (e.g. `Authorization`, `Cache-Control` via the
-  // standalone composition) would silently skip the guards while the store
-  // side (CacheHandler) reads the lowercased form, e.g. serving a non-public
-  // cached response to an authorized request (RFC 9111 §3.5).
-  const headers = key.headers ?? {}
-
-  const rawCacheControl = headers['cache-control']
-  const requestCacheControl = parseCacheControl(rawCacheControl) ?? {}
-
-  // RFC 9111 Section 5.4: Pragma: no-cache should be treated as
-  // Cache-Control: no-cache when Cache-Control is absent.
-  if (rawCacheControl == null && headers.pragma === 'no-cache') {
-    requestCacheControl['no-cache'] = true
-  }
-
-  if (requestCacheControl['no-transform']) {
-    // Do nothing. We don't transform requests...
-  }
-
-  const onlyIfCached = requestCacheControl['only-if-cached'] === true
-  const store = getStore(opts)
-
-  // The lookup is timed only while tracing is on (performance.now() is not
-  // free); a store get that throws is caught inside tryGetEntry and settles
-  // as a miss with reason 'none'. `missReason` tracks which gate cleared a
-  // returned entry so the eventual miss doc names it.
-  let missReason = 'none'
-  let lookupMs = null
-  let entry
-  if (write !== null) {
-    const lookupStart = performance.now()
-    entry = tryGetEntry(store, key, opts.logger)
-    lookupMs = Math.round(performance.now() - lookupStart)
-  } else {
-    entry = tryGetEntry(store, key, opts.logger)
-  }
-
-  // RFC 9111 §3.5 serve-side authorization gate: a shared cache must not
-  // reuse a stored response for a request with Authorization unless the
-  // response allowed it (public, s-maxage or must-revalidate — the mirror of
-  // the store-side gate in CacheHandler; both sites must stay in lockstep).
-  if (entry && headers.authorization != null) {
-    const directives = entry.cacheControlDirectives
-    if (
-      typeof headers.authorization !== 'string' ||
-      !(
-        directives?.public === true ||
-        directives?.['s-maxage'] != null ||
-        directives?.['must-revalidate'] === true
-      )
-    ) {
-      entry = undefined
-      missReason = 'auth'
-    }
-  }
-
-  // Freshness for THIS request: the entry's staleAt, tightened by the
-  // caller's max-age / min-fresh (RFC 9111 §5.2.1.1 / §5.2.1.3). Date.now()
-  // rather than getFastNow(): zero-TTL revalidation entries (staleAt ==
-  // cachedAt) would read as fresh for up to a second on the lagging clock.
-  //
-  // requestAccepts is tracked separately from origin freshness because it
-  // constrains EVERY serving path below, including the stale-serving windows
-  // (max-stale, stale-while-revalidate, stale-if-error): those directives
-  // relax the response-computed staleness bound, they must not un-reject an
-  // entry the caller's own age bounds refused — otherwise an origin emitting
-  // stale-while-revalidate would silently disable clients' max-age=0.
-  const now = Date.now()
-  // Whole-second, non-negative age — the SAME value serveFromCache emits as the
-  // Age header. RFC 9111 directives are delta-seconds (integers), so evaluating
-  // max-age against a fractional age would reject an entry (e.g. 10.2s vs
-  // max-age=10) that the client sees as within bound via `Age: 10`.
-  const ageSeconds = entry == null ? 0 : Math.max(0, Math.floor((now - entry.cachedAt) / 1000))
-  const requestAccepts =
-    entry == null ||
-    // Bounds are inclusive (RFC 9111 §5.2.1.1/§5.2.1.3): the client accepts an
-    // age that does NOT exceed max-age (age <= max-age) and freshness lasting
-    // AT LEAST min-fresh (remaining >= min-fresh). Strict comparisons would
-    // spuriously revalidate at the exact boundary (e.g. age == max-age).
-    //
-    // max-age=0 is the deliberate exception: it always forces revalidation
-    // (the fetch cache:'no-cache' idiom, undici #5504) and must not accept an
-    // age-0 entry, so it is excluded from the inclusive form via `> 0`. The
-    // `== null` guard also keeps 0 (falsy) from being read as "absent".
-    ((requestCacheControl['max-age'] == null ||
-      (requestCacheControl['max-age'] > 0 && ageSeconds <= requestCacheControl['max-age'])) &&
-      (requestCacheControl['min-fresh'] == null ||
-        entry.staleAt - now >= requestCacheControl['min-fresh'] * 1000))
-  const fresh = entry != null && now < entry.staleAt && requestAccepts
-
-  // Validation demanded regardless of freshness: the request's no-cache (or
-  // Pragma), or the stored response's unqualified no-cache (§5.2.2.4).
-  const mustRevalidate =
-    entry != null &&
-    (requestCacheControl['no-cache'] === true ||
-      entry.cacheControlDirectives?.['no-cache'] === true)
-
-  // RFC 9110 Section 13: Evaluate conditional request headers against cached
-  // entry — only against a FRESH entry that doesn't demand validation;
-  // answering 304 from a stale entry without validating would violate RFC
-  // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
-  // where the caller's own validators do the validation (a 304 flows through
-  // to the caller; a 200 replacement is stored by CacheHandler).
-  // typeof guards: duplicated conditional headers arrive as arrays — treat
-  // them as non-matching and bypass to origin rather than crashing.
-  const servableFromCache = entry != null && fresh && !mustRevalidate
-  if (servableFromCache && headers['if-none-match']) {
-    if (
-      typeof headers['if-none-match'] === 'string' &&
-      entry.etag &&
-      weakMatch(headers['if-none-match'], entry.etag)
-    ) {
-      return serveFromCache(
-        { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
-        opts,
-        handler,
-        write,
-        url,
-        lookupMs,
-      )
-    }
-    // Etag didn't match — bypass to origin.
-    entry = undefined
-  } else if (servableFromCache && headers['if-modified-since']) {
-    const lastModified = entry.headers?.['last-modified']
-    if (
-      typeof headers['if-modified-since'] === 'string' &&
-      lastModified &&
-      new Date(lastModified) <= new Date(headers['if-modified-since'])
-    ) {
-      return serveFromCache(
-        { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
-        opts,
-        handler,
-        write,
-        url,
-        lookupMs,
-      )
-    }
-    // No last-modified or modified since — bypass to origin.
-    entry = undefined
-  } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
-    entry = undefined
-  }
-
-  if (headers['if-match'] || headers['if-unmodified-since'] || headers['if-range']) {
-    // TODO (fix): evaluate these conditional headers against cached entry.
-    if (write !== null) {
-      traceLookup(write, opts, url, 'bypass', 'conditional', null, null, null, lookupMs)
-    }
-    return dispatch(opts, handler)
-  }
-
-  const cacheHandler = () =>
-    new CacheHandler(key, {
-      ...cacheOptsOf(opts),
-      store,
-      logger: opts.logger,
-      handler,
-    })
-
-  if (!entry) {
-    if (onlyIfCached) {
-      // RFC 9111 §5.2.1.7: no stored response usable without contacting the
-      // origin — 504.
-      return serveFromCache({ statusCode: 504 }, opts, handler)
-    }
-    // Request directives (no-cache, max-age, ...) constrain REUSE of a stored
-    // response, not storage of a fresh one (undici PR #5510): every miss path
-    // keeps the CacheHandler write-back so one client's freshness override
-    // doesn't disable caching of the URL for everyone. Only the request's
-    // no-store forbids storing.
-    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
-  }
-
-  if (fresh && !mustRevalidate) {
-    return serveFromCache(entry, opts, handler)
-  }
-
-  // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
-  // max-stale parses to Infinity: any staleness) — vetoed by the response's
-  // must-revalidate/proxy-revalidate (§5.2.2.2) and by the caller's own
-  // max-age/min-fresh bounds (requestAccepts).
-  if (
-    !mustRevalidate &&
-    requestAccepts &&
-    requestCacheControl['max-stale'] != null &&
-    !forbidsServingStale(entry) &&
-    now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
-  ) {
-    return serveFromCache(entry, opts, handler)
-  }
-
-  if (onlyIfCached) {
-    // Stale (or validation-demanding) entry and the origin is off-limits.
-    return serveFromCache({ statusCode: 504 }, opts, handler)
-  }
-
-  if (entry.statusCode === 206) {
-    // Range entries can't be revalidated as a whole representation — refetch.
-    return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
-  }
-
-  // RFC 5861 §3 stale-while-revalidate: serve the stale entry immediately and
-  // refresh in the background — unless validation is demanded, the response
-  // forbids serving stale, or the caller's own max-age/min-fresh bounds
-  // rejected the entry (they demand a validated/younger response NOW).
-  if (
-    !mustRevalidate &&
-    requestAccepts &&
-    !forbidsServingStale(entry) &&
-    typeof entry.cacheControlDirectives?.['stale-while-revalidate'] === 'number' &&
-    now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
-  ) {
-    try {
-      serveFromCache(entry, opts, handler)
-    } finally {
-      backgroundRefresh(dispatch, opts, key, store, entry)
-    }
-    return
-  }
-
-  // Synchronous revalidation (RFC 9111 §4.3): conditional request; 304
-  // freshens and serves the entry, an error within the stale-if-error window
-  // (RFC 5861 §4: response directive first, request directive fallback —
-  // vetoed by must-revalidate/proxy-revalidate) serves the stale entry, and
-  // anything else replaces it.
-  const staleIfError =
-    entry.cacheControlDirectives?.['stale-if-error'] ?? requestCacheControl['stale-if-error']
-  const allowStaleOnError =
-    !mustRevalidate &&
-    requestAccepts &&
-    !forbidsServingStale(entry) &&
-    typeof staleIfError === 'number' &&
-    staleIfError > 0 &&
-    now <= entry.staleAt + staleIfError * 1000
-
-  return dispatch(
-    { ...opts, headers: conditionalHeaders(headers, entry) },
-    new RevalidationHandler(key, entry, opts, {
-      store,
-      logger: opts.logger,
-      handler,
-      allowStaleOnError,
-      noStore: requestCacheControl['no-store'] === true,
-      cacheOpts: cacheOptsOf(opts),
-    }),
-  )
 }
 
 export function serveFromCache(entry, opts, handler) {

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -900,6 +900,11 @@ export default () => (dispatch) => (opts, handler) => {
   // entry the caller's own age bounds refused — otherwise an origin emitting
   // stale-while-revalidate would silently disable clients' max-age=0.
   const now = Date.now()
+  // Whole-second, non-negative age — the SAME value serveFromCache emits as the
+  // Age header. RFC 9111 directives are delta-seconds (integers), so evaluating
+  // max-age against a fractional age would reject an entry (e.g. 10.2s vs
+  // max-age=10) that the client sees as within bound via `Age: 10`.
+  const ageSeconds = entry == null ? 0 : Math.max(0, Math.floor((now - entry.cachedAt) / 1000))
   const requestAccepts =
     entry == null ||
     // Bounds are inclusive (RFC 9111 §5.2.1.1/§5.2.1.3): the client accepts an
@@ -912,8 +917,7 @@ export default () => (dispatch) => (opts, handler) => {
     // age-0 entry, so it is excluded from the inclusive form via `> 0`. The
     // `== null` guard also keeps 0 (falsy) from being read as "absent".
     ((requestCacheControl['max-age'] == null ||
-      (requestCacheControl['max-age'] > 0 &&
-        (now - entry.cachedAt) / 1000 <= requestCacheControl['max-age'])) &&
+      (requestCacheControl['max-age'] > 0 && ageSeconds <= requestCacheControl['max-age'])) &&
       (requestCacheControl['min-fresh'] == null ||
         entry.staleAt - now >= requestCacheControl['min-fresh'] * 1000))
   const fresh = entry != null && now < entry.staleAt && requestAccepts

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -261,7 +261,17 @@ export function parseVary(varyHeader, requestHeaders) {
  * selecting headers already match this request.
  */
 export function conditionalHeaders(headers, entry) {
-  const condHeaders = { ...headers }
+  // Null prototype, like every other header map this module builds (see
+  // makeKey): the request header names are caller-controlled, so a plain `{}`
+  // would expose Object.prototype (a `__proto__`/`constructor`/`toString`
+  // field name reading through the chain instead of as absent) once these
+  // headers flow back down the dispatch chain. Object.keys copies own fields
+  // only; values are request header strings/arrays, copied by reference (the
+  // shallow copy the previous spread also made).
+  const condHeaders = Object.create(null)
+  for (const name of Object.keys(headers)) {
+    condHeaders[name] = headers[name]
+  }
   if (entry.etag) {
     condHeaders['if-none-match'] = entry.etag
   }

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -11,6 +11,7 @@ import {
 import { isHopByHop } from './proxy.js'
 import { SqliteCacheStore } from '../sqlite-cache-store.js'
 import { RevalidationHandler, backgroundRefresh } from './cache-revalidation.js'
+import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 
 let DEFAULT_STORE = null
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
@@ -24,6 +25,29 @@ const REVALIDATION_RETENTION = 24 * 3600 // seconds
 // 1-year default, capped by maxEntryTTL below.
 const IMMUTABLE_LIFETIME = 31556952 // seconds
 const NOOP = () => {}
+
+/**
+ * The single `undici:cache` lookup-doc emitter (read path). `write` is the
+ * resolved trace fn (null when tracing is off), captured once per dispatch so
+ * a writer flipping mid-request can't split a dispatch across writers.
+ */
+function traceLookup(write, opts, url, result, reason, statusCode, ageSec, sizeBytes, lookupMs) {
+  traceSafe(
+    write,
+    {
+      id: opts.id ?? null,
+      method: opts.method ?? null,
+      url,
+      result,
+      reason,
+      statusCode,
+      ageSec,
+      sizeBytes,
+      lookupMs,
+    },
+    'undici:cache',
+  )
+}
 
 /**
  * Explicit (or opt-in heuristic) freshness lifetime in seconds, or null when
@@ -254,13 +278,6 @@ export class CacheHandler extends DecoratorHandler {
   #maxEntryTTL
   #heuristic
   #defaultTTL
-
-  // Trace plumbing captured once at the dispatch entry: the resolved write fn
-  // (null when tracing is off), the request id and the bounded url tag. One
-  // `undici:cache-store` doc is emitted per response at the storability
-  // outcome — no per-attempt emitted-flag is needed because every skip path
-  // leaves #value null (making the stored/overflow paths unreachable for the
-  // same attempt) and onConnect resets #value for retry re-entry.
   #write
   #id
   #url
@@ -307,8 +324,8 @@ export class CacheHandler extends DecoratorHandler {
   }
 
   // Storability declined at header time: emit the skip doc and pass the
-  // response through untouched. Keeps the many onHeaders early returns
-  // single-line; `reason` names the failed gate and must stay low-cardinality.
+  // response through untouched. `reason` names the failed gate and must stay
+  // low-cardinality.
   #skip(reason, statusCode, headers, resume) {
     this.#trace(statusCode, false, reason, null, null, null)
     return super.onHeaders(statusCode, headers, resume)
@@ -324,16 +341,10 @@ export class CacheHandler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, headers, resume) {
-    if (statusCode < 200) {
-      // Interim informational responses precede the real response (raw undici
-      // strips them, composed/mock dispatchers may forward them — same guard
-      // as redirect/response-verify): not a storability outcome, so no
-      // cache-store doc either — the final response emits the one doc.
-      return super.onHeaders(statusCode, headers, resume)
-    }
-
     if (statusCode !== 307 && statusCode !== 200 && statusCode !== 206) {
-      return this.#skip('status', statusCode, headers, resume)
+      // Not a cacheable status: pass through with no store doc (only cacheable
+      // statuses that then fail a gate emit a skip doc).
+      return super.onHeaders(statusCode, headers, resume)
     }
 
     // 'trailer' is the RFC 9110 field name; 'trailers' is kept for backwards
@@ -426,10 +437,11 @@ export class CacheHandler extends DecoratorHandler {
     // cacheControlDirectives.
 
     // parseVary returns null when the response can't be cached on Vary
-    // grounds (a non-string Vary header, or one containing '*').
+    // grounds (a non-string Vary header; the '*' form was already caught by the
+    // trailer/vary-star gate above).
     const vary = parseVary(headers.vary, this.#key.headers)
     if (vary == null) {
-      return super.onHeaders(statusCode, headers, resume)
+      return this.#skip('vary-invalid', statusCode, headers, resume)
     }
 
     const now = Date.now()
@@ -542,11 +554,12 @@ export class CacheHandler extends DecoratorHandler {
         // Handler state.
         size: 0,
       }
-    } else {
-      return this.#skip('too-large', statusCode, headers, resume)
+      return super.onHeaders(statusCode, headers, resume)
     }
 
-    return super.onHeaders(statusCode, headers, resume)
+    // Known too-large at header time (Content-Length exceeds maxEntrySize): the
+    // body is never buffered, so emit the skip doc now.
+    return this.#skip('too-large', statusCode, headers, resume)
   }
 
   onData(chunk) {
@@ -581,10 +594,9 @@ export class CacheHandler extends DecoratorHandler {
           this.#logger?.error({ err }, 'failed to set cache entry')
         }
       }
-      // stored reflects what actually happened: a throwing set() (e.g.
-      // 'database is locked' under write contention) persisted nothing, and
-      // dashboards keyed on `stored` must not count it. reason stays null —
-      // this is a store failure, not a storability gate; err carries the why.
+      // `stored` reflects what actually happened: a throwing set() (e.g.
+      // 'database is locked') persisted nothing. `reason` stays null — this is
+      // a store failure, not a storability gate; `err` carries the why.
       this.#trace(
         this.#value.statusCode,
         storeErr == null,
@@ -595,9 +607,10 @@ export class CacheHandler extends DecoratorHandler {
       )
       this.#value = null
     } else if (this.#value) {
-      // Unexpected trailers arriving at completion decline storability late —
-      // still one doc per response at the outcome.
+      // Unexpected trailers decline storability late — still one doc per
+      // response, at the outcome.
       this.#trace(this.#value.statusCode, false, 'trailer', null, null, null)
+      this.#value = null
     }
 
     super.onComplete(trailers)
@@ -842,6 +855,12 @@ export default ({ origins } = {}) => {
       return dispatch(opts, handler)
     }
 
+    // Capture-once per dispatch (log.js style): the same resolved fn drives the
+    // `undici:cache` lookup doc and is threaded into CacheHandler /
+    // InvalidationHandler / RevalidationHandler for the store/invalidate docs,
+    // so a writer flipping mid-request cannot split a dispatch across writers.
+    const write = traceWrite(opts.trace)
+
     if (opts.method !== 'GET' && opts.method !== 'HEAD') {
       // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
       // must not invalidate either. Every other method (POST/PUT/DELETE/...)
@@ -856,15 +875,26 @@ export default ({ origins } = {}) => {
         return dispatch(opts, handler)
       }
 
+      const invKey = makeKey(opts)
       return dispatch(
         opts,
-        new InvalidationHandler(makeKey(opts), { store, logger: opts.logger, handler }),
+        new InvalidationHandler(invKey, {
+          store,
+          logger: opts.logger,
+          handler,
+          write,
+          id: opts.id ?? null,
+          url: write !== null ? traceUrl(invKey) : null,
+        }),
       )
     }
 
     // TODO (fix): enable range requests
 
     const key = makeKey(opts)
+    // Bounded url tag shared by every doc this dispatch emits; the key (not raw
+    // opts) so the tag reflects the canonical path incl. the folded-in query.
+    const url = write !== null ? traceUrl(key) : null
 
     // All request-directive and conditional-header guards below MUST read from
     // the lowercased key.headers, not raw opts.headers — otherwise a caller
@@ -890,7 +920,20 @@ export default ({ origins } = {}) => {
     const onlyIfCached = requestCacheControl['only-if-cached'] === true
     const store = getStore(opts)
 
-    let entry = tryGetEntry(store, key, opts.logger)
+    // The lookup is timed only while tracing is on (performance.now() is not
+    // free); a store get that throws settles as a miss inside tryGetEntry.
+    // `missReason` tracks which gate cleared a returned entry so the eventual
+    // miss doc names it.
+    let missReason = 'none'
+    let lookupMs = null
+    let entry
+    if (write !== null) {
+      const lookupStart = performance.now()
+      entry = tryGetEntry(store, key, opts.logger)
+      lookupMs = Math.round(performance.now() - lookupStart)
+    } else {
+      entry = tryGetEntry(store, key, opts.logger)
+    }
 
     // RFC 9111 §3.5 serve-side authorization gate: a shared cache must not
     // reuse a stored response for a request with Authorization unless the
@@ -907,6 +950,7 @@ export default ({ origins } = {}) => {
         )
       ) {
         entry = undefined
+        missReason = 'auth'
       }
     }
 
@@ -970,10 +1014,14 @@ export default ({ origins } = {}) => {
           { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
           opts,
           handler,
+          write,
+          url,
+          lookupMs,
         )
       }
       // Etag didn't match — bypass to origin.
       entry = undefined
+      missReason = 'etag'
     } else if (servableFromCache && headers['if-modified-since']) {
       const lastModified = entry.headers?.['last-modified']
       if (
@@ -985,16 +1033,26 @@ export default ({ origins } = {}) => {
           { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
           opts,
           handler,
+          write,
+          url,
+          lookupMs,
         )
       }
       // No last-modified or modified since — bypass to origin.
       entry = undefined
+      missReason = 'modified'
     } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
+      // Stale (or validation-demanding) entry + caller conditionals: forward to
+      // origin so the caller's own validators do the validation.
       entry = undefined
+      missReason = 'conditional'
     }
 
     if (headers['if-match'] || headers['if-unmodified-since'] || headers['if-range']) {
       // TODO (fix): evaluate these conditional headers against cached entry.
+      if (write !== null) {
+        traceLookup(write, opts, url, 'bypass', 'conditional', null, null, null, lookupMs)
+      }
       return dispatch(opts, handler)
     }
 
@@ -1004,24 +1062,39 @@ export default ({ origins } = {}) => {
         store,
         logger: opts.logger,
         handler,
+        write,
+        id: opts.id ?? null,
+        url,
       })
 
     if (!entry) {
       if (onlyIfCached) {
         // RFC 9111 §5.2.1.7: no stored response usable without contacting the
-        // origin — 504.
-        return serveFromCache({ statusCode: 504 }, opts, handler)
+        // origin — 504. Not a hit: it is a miss the request forbade origin for.
+        return serveFromCache(
+          { statusCode: 504 },
+          opts,
+          handler,
+          write,
+          url,
+          lookupMs,
+          'miss',
+          'only-if-cached',
+        )
       }
       // Request directives (no-cache, max-age, ...) constrain REUSE of a stored
       // response, not storage of a fresh one (undici PR #5510): every miss path
       // keeps the CacheHandler write-back so one client's freshness override
       // doesn't disable caching of the URL for everyone. Only the request's
       // no-store forbids storing.
+      if (write !== null) {
+        traceLookup(write, opts, url, 'miss', missReason, null, null, null, lookupMs)
+      }
       return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
     }
 
     if (fresh && !mustRevalidate) {
-      return serveFromCache(entry, opts, handler)
+      return serveFromCache(entry, opts, handler, write, url, lookupMs)
     }
 
     // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
@@ -1035,16 +1108,28 @@ export default ({ origins } = {}) => {
       !forbidsServingStale(entry) &&
       now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
     ) {
-      return serveFromCache(entry, opts, handler)
+      return serveFromCache(entry, opts, handler, write, url, lookupMs)
     }
 
     if (onlyIfCached) {
       // Stale (or validation-demanding) entry and the origin is off-limits.
-      return serveFromCache({ statusCode: 504 }, opts, handler)
+      return serveFromCache(
+        { statusCode: 504 },
+        opts,
+        handler,
+        write,
+        url,
+        lookupMs,
+        'miss',
+        'only-if-cached',
+      )
     }
 
     if (entry.statusCode === 206) {
       // Range entries can't be revalidated as a whole representation — refetch.
+      if (write !== null) {
+        traceLookup(write, opts, url, 'miss', '206', null, null, null, lookupMs)
+      }
       return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
     }
 
@@ -1060,7 +1145,7 @@ export default ({ origins } = {}) => {
       now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
     ) {
       try {
-        serveFromCache(entry, opts, handler)
+        serveFromCache(entry, opts, handler, write, url, lookupMs)
       } finally {
         // RFC 9111 §5.2.1.5: a request no-store forbids storing ANY response to
         // it, and the background refresh's sole effect is to write the store —
@@ -1096,12 +1181,25 @@ export default ({ origins } = {}) => {
         allowStaleOnError,
         noStore: requestCacheControl['no-store'] === true,
         cacheOpts: cacheOptsOf(opts),
+        write,
+        id: opts.id ?? null,
+        url,
+        lookupMs,
       }),
     )
   }
 }
 
-export function serveFromCache(entry, opts, handler) {
+export function serveFromCache(
+  entry,
+  opts,
+  handler,
+  write = null,
+  url = null,
+  lookupMs = null,
+  result = 'hit',
+  reason = null,
+) {
   const { statusCode, trailers, body } = entry
 
   let headers = entry.headers
@@ -1118,11 +1216,8 @@ export function serveFromCache(entry, opts, handler) {
   }
 
   // Entry serves and conditional 304s are lookup hits; the only-if-cached
-  // synthetic 504 arrives as result 'miss' from the caller. Emitted before
-  // onConnect and outside the try/catch below so trace code sits strictly
-  // outside the handler-contract enforcement (traceSafe cannot throw, but
-  // keep it out of that window anyway). Synthetic entries have no cachedAt,
-  // so their ageSec stays null.
+  // synthetic 504 arrives as result 'miss' from the caller. Synthetic entries
+  // have no cachedAt, so their ageSec stays null. Emitted before onConnect.
   if (write !== null) {
     traceLookup(write, opts, url, result, reason, statusCode, age, body?.byteLength ?? 0, lookupMs)
   }

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -496,13 +496,13 @@ test('cache: authorization header allows caching when response has public direct
 // Response directives that prevent caching
 // ---------------------------------------------------------------------------
 
-test('cache: must-revalidate response directive prevents caching', async (t) => {
+test('cache: must-revalidate response is stored and served while fresh', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
-    // This cache does not yet revalidate, so responses that require it are
-    // not stored (a follow-up adds revalidation and stores these).
+    // must-revalidate only constrains STALE reuse (RFC 9111 §5.2.2.2); a
+    // fresh entry serves normally.
     res.writeHead(200, { 'cache-control': 's-maxage=60, must-revalidate' })
     res.end('body')
   })
@@ -520,10 +520,10 @@ test('cache: must-revalidate response directive prevents caching', async (t) => 
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'must-revalidate responses are not cached')
+  t.equal(hits, 1, 'must-revalidate response is served from cache while fresh')
 })
 
-test('cache: proxy-revalidate response directive prevents caching', async (t) => {
+test('cache: proxy-revalidate response is stored and served while fresh', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
@@ -545,14 +545,22 @@ test('cache: proxy-revalidate response directive prevents caching', async (t) =>
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'proxy-revalidate responses are not cached')
+  t.equal(hits, 1, 'proxy-revalidate response is served from cache while fresh')
 })
 
-test('cache: no-cache response directive prevents caching', async (t) => {
-  t.plan(1)
+test('cache: no-cache response directive forces origin validation on every reuse', async (t) => {
+  t.plan(2)
   let hits = 0
+  let conditional = 0
   const server = await startServer((req, res) => {
     hits++
+    // Unqualified no-cache: the response may be stored, but must be
+    // validated with the origin before every reuse (RFC 9111 §5.2.2.4). This
+    // origin never answers 304, so every request pays a full round-trip —
+    // but the second one must arrive as a conditional request.
+    if (req.headers['if-modified-since']) {
+      conditional++
+    }
     res.writeHead(200, { 'cache-control': 'max-age=60, no-cache' })
     res.end('body')
   })
@@ -570,7 +578,8 @@ test('cache: no-cache response directive prevents caching', async (t) => {
 
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'no-cache responses are not cached')
+  t.equal(hits, 2, 'every reuse goes to the origin')
+  t.equal(conditional, 1, 'the reuse validated instead of serving from cache')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/cache-origins.js
+++ b/test/cache-origins.js
@@ -1,0 +1,156 @@
+/* eslint-disable */
+// `origins` whitelist option (undici PR #4739): the cache interceptor only
+// caches (stores/serves/invalidates) requests whose origin is permitted by the
+// configured whitelist. A matching origin is cached (second request is a hit);
+// a non-matching origin bypasses the cache (second request hits the origin
+// again). Ported from undici's origins-option tests, adapted to the dispatch
+// API of this fork.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+async function startServer() {
+  let hits = 0
+  const server = createServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
+    res.end('body')
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  return {
+    server,
+    origin: `http://127.0.0.1:${server.address().port}`,
+    hits: () => hits,
+  }
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// Issues the same GET twice through a fresh store and reports how many times
+// the origin was contacted: 1 => the second was a cache hit (cached), 2 => the
+// cache was bypassed (not cached).
+async function originHitsFor(origins, { originOverride } = {}) {
+  const srv = await startServer()
+  try {
+    const store = new SqliteCacheStore({ location: ':memory:' })
+    const dispatch = compose(new undici.Agent(), interceptors.cache({ origins }))
+    // opts.origin drives both the interceptor's whitelist check and the key;
+    // an override lets a test exercise case-insensitivity while still routing
+    // to the live server (which the Agent reaches via the real origin).
+    const opts = {
+      origin: originOverride ?? srv.origin,
+      path: '/',
+      method: 'GET',
+      headers: {},
+      cache: { store },
+    }
+    await rawRequest(dispatch, opts)
+    await flush()
+    await rawRequest(dispatch, opts)
+    return srv.hits()
+  } finally {
+    srv.server.close()
+  }
+}
+
+test('origins: caches when the request origin matches a string entry', async (t) => {
+  t.plan(1)
+  const srv = await startServer()
+  t.teardown(() => srv.server.close())
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = compose(new undici.Agent(), interceptors.cache({ origins: [srv.origin] }))
+  const opts = { origin: srv.origin, path: '/', method: 'GET', headers: {}, cache: { store } }
+  await rawRequest(dispatch, opts)
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(srv.hits(), 1, 'second request served from cache')
+})
+
+test('origins: skips caching when the request origin does not match a string entry', async (t) => {
+  t.plan(1)
+  t.equal(await originHitsFor(['http://example.com']), 2, 'both requests hit the origin')
+})
+
+test('origins: caches when the request origin matches a RegExp entry', async (t) => {
+  t.plan(1)
+  t.equal(await originHitsFor([/127\.0\.0\.1/]), 1, 'RegExp match enables caching')
+})
+
+test('origins: skips caching when the request origin does not match a RegExp entry', async (t) => {
+  t.plan(1)
+  t.equal(await originHitsFor([/example\.com/]), 2, 'RegExp miss bypasses the cache')
+})
+
+test('origins: caches when the origin matches any entry in a mixed array', async (t) => {
+  t.plan(1)
+  t.equal(
+    await originHitsFor(['http://other.example', /127\.0\.0\.1/]),
+    1,
+    'any match enables caching',
+  )
+})
+
+test('origins: undefined caches every origin (default, backward compatible)', async (t) => {
+  t.plan(1)
+  t.equal(await originHitsFor(undefined), 1, 'no whitelist => caches as before')
+})
+
+test('origins: an empty array caches nothing', async (t) => {
+  t.plan(1)
+  t.equal(await originHitsFor([]), 2, 'empty whitelist matches no origin')
+})
+
+test('origins: string matching is case-insensitive', async (t) => {
+  t.plan(1)
+  const srv = await startServer()
+  t.teardown(() => srv.server.close())
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  // Whitelist the origin upper-cased; the request origin is lower-case.
+  const dispatch = compose(
+    new undici.Agent(),
+    interceptors.cache({ origins: [srv.origin.toUpperCase()] }),
+  )
+  const opts = { origin: srv.origin, path: '/', method: 'GET', headers: {}, cache: { store } }
+  await rawRequest(dispatch, opts)
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(srv.hits(), 1, 'case-insensitive string match enables caching')
+})
+
+test('origins: throws TypeError when not an array', async (t) => {
+  t.plan(2)
+  t.throws(() => interceptors.cache({ origins: 'http://example.com' }), TypeError)
+  t.throws(() => interceptors.cache({ origins: 123 }), TypeError)
+})
+
+test('origins: throws TypeError when an array entry is neither string nor RegExp', async (t) => {
+  t.plan(2)
+  t.throws(() => interceptors.cache({ origins: [123] }), TypeError)
+  t.throws(() => interceptors.cache({ origins: [{}] }), TypeError)
+})

--- a/test/cache-origins.js
+++ b/test/cache-origins.js
@@ -54,17 +54,15 @@ const flush = () => new Promise((resolve) => setImmediate(resolve))
 
 // Issues the same GET twice through a fresh store and reports how many times
 // the origin was contacted: 1 => the second was a cache hit (cached), 2 => the
-// cache was bypassed (not cached).
-async function originHitsFor(origins, { originOverride } = {}) {
+// cache was bypassed (not cached). `opts.origin` is the live server, so it
+// drives both the whitelist check and where the Agent connects.
+async function originHitsFor(origins) {
   const srv = await startServer()
   try {
     const store = new SqliteCacheStore({ location: ':memory:' })
     const dispatch = compose(new undici.Agent(), interceptors.cache({ origins }))
-    // opts.origin drives both the interceptor's whitelist check and the key;
-    // an override lets a test exercise case-insensitivity while still routing
-    // to the live server (which the Agent reaches via the real origin).
     const opts = {
-      origin: originOverride ?? srv.origin,
+      origin: srv.origin,
       path: '/',
       method: 'GET',
       headers: {},
@@ -161,4 +159,71 @@ test('origins: throws TypeError when an array entry is neither string nor RegExp
   t.plan(2)
   t.throws(() => interceptors.cache({ origins: [123] }), TypeError)
   t.throws(() => interceptors.cache({ origins: [{}] }), TypeError)
+})
+
+// ---------------------------------------------------------------------------
+// Cache keys on the LOGICAL origin, not the resolved IP: a downstream
+// (inner-of-cache) origin→IP rewrite — as the dns interceptor does, and as
+// DNS round-robin would vary per request — must not fragment the cache.
+// ---------------------------------------------------------------------------
+
+test('cache keys on the logical origin; a rotating downstream IP does not break caching', async (t) => {
+  t.plan(4)
+
+  // Base "network": serves a cacheable response and counts how often the ORIGIN
+  // was actually contacted (i.e. cache misses).
+  let originHits = 0
+  const base = (opts, handler) => {
+    originHits++
+    handler.onConnect(() => {})
+    handler.onHeaders(
+      200,
+      { 'content-type': 'text/plain', 'cache-control': 'max-age=60' },
+      () => {},
+    )
+    handler.onData(Buffer.from('payload'))
+    handler.onComplete({})
+    return true
+  }
+
+  // "dns round-robin", placed INNER of the cache (runs after it): rewrites the
+  // origin to a different IP on every call. If the cache keyed on the rewritten
+  // origin, every request would miss.
+  let rr = 0
+  const rotatingDns = (dispatch) => (opts, handler) =>
+    dispatch({ ...opts, origin: `http://10.0.0.${++rr}:80` }, handler)
+
+  // Record the origin the cache actually keys on.
+  const inner = new SqliteCacheStore({ location: ':memory:' })
+  const keyed = []
+  const store = {
+    maxEntrySize: inner.maxEntrySize,
+    get(key) {
+      keyed.push(key.origin)
+      return inner.get(key)
+    },
+    set(key, val) {
+      return inner.set(key, val)
+    },
+    delete(key) {
+      return inner.delete(key)
+    },
+  }
+
+  // cache OUTER of rotatingDns — the default-pipeline order (cache before dns).
+  const dispatch = compose(base, rotatingDns, interceptors.cache())
+  const opts = { origin: 'http://api.example.com', path: '/thing', method: 'GET', cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+
+  t.equal(second.body, 'payload', 'second request served from cache')
+  t.equal(originHits, 1, 'the rotating downstream IP did not cause a second origin hit')
+  t.same(
+    [...new Set(keyed)],
+    ['http://api.example.com'],
+    'cache keyed on the logical origin, never the rotating 10.0.0.x IP',
+  )
+  t.equal(rr, 1, 'the origin→IP rewrite ran once (miss only); the hit never reached it')
 })

--- a/test/cache-origins.js
+++ b/test/cache-origins.js
@@ -107,6 +107,14 @@ test('origins: skips caching when the request origin does not match a RegExp ent
   t.equal(await originHitsFor([/example\.com/]), 2, 'RegExp miss bypasses the cache')
 })
 
+test('origins: a global-flag RegExp matches consistently across requests (no lastIndex drift)', async (t) => {
+  t.plan(1)
+  // With a `g` flag, RegExp#test is stateful: without a lastIndex reset the
+  // second request would test from mid-string, fail to match, and bypass the
+  // cache — so this hits the origin twice unless matching is stateless.
+  t.equal(await originHitsFor([/127\.0\.0\.1/g]), 1, 'global RegExp still enables caching on reuse')
+})
+
 test('origins: caches when the origin matches any entry in a mixed array', async (t) => {
   t.plan(1)
   t.equal(

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -1255,6 +1255,41 @@ test('stale-while-revalidate: a failing background refresh is swallowed; the sta
   t.equal(store.get(key)?.etag, '"v1"', 'stale entry is retained after the refresh error')
 })
 
+test('stale-while-revalidate: a request no-store serves stale but suppresses the background refresh', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60, stale-while-revalidate=60', etag: '"v2"' })
+    res.end('refreshed')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const key = { origin: origin(server), method: 'GET', path: '/', headers: {} }
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'no-store' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body', 'stale entry still served to the no-store request')
+
+  // RFC 9111 §5.2.1.5: no response to a no-store request may be stored, so the
+  // background refresh must not run.
+  await flush()
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  t.equal(hits, 0, 'no background revalidation was issued')
+  t.equal(store.get(key)?.etag, '"v1"', 'stored entry was not overwritten')
+})
+
 test('freshening: a 304 that changes Vary recomputes the stored selector map (review)', async (t) => {
   t.plan(2)
   const server = await startServer((req, res) => {

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -366,6 +366,37 @@ test('stale-if-error: without the directive the 503 is passed through', async (t
   t.equal(res.body, 'boom')
 })
 
+test('stale-if-error: honors exactly RFC 5861 error statuses (501 passes through, 502 serves stale)', async (t) => {
+  t.plan(4)
+  // 501 (Not Implemented) is NOT a stale-if-error status per RFC 5861 §4
+  // (500/502/503/504 only); the old `>= 500 && <= 504` range wrongly caught it.
+  for (const { status, servesStale } of [
+    { status: 501, servesStale: false },
+    { status: 502, servesStale: true },
+  ]) {
+    const server = await startServer((req, res) => {
+      res.writeHead(status)
+      res.end('err')
+    })
+    t.teardown(server.close.bind(server))
+    const store = new SqliteCacheStore({ location: ':memory:' })
+    const dispatch = makeDispatch()
+    seedEntry(store, origin(server), {
+      etag: '"v1"',
+      cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+    })
+    const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+    const res = await rawRequest(dispatch, opts)
+    if (servesStale) {
+      t.equal(res.statusCode, 200, `${status} within the window serves the stale entry`)
+      t.equal(res.body, 'cached-body', `${status} served cached body`)
+    } else {
+      t.equal(res.statusCode, 501, `${status} is not an SIE error status — passed through`)
+      t.equal(res.body, 'err', `${status} delivered the origin response`)
+    }
+  }
+})
+
 test('stale-if-error: connection error before response serves the stale entry (#5513)', async (t) => {
   t.plan(2)
   // Port 1 (tcpmux) is privileged and never bound in practice — connecting

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -560,6 +560,39 @@ test('request no-cache: revalidates a fresh entry instead of serving it', async 
   t.equal(seen.length, 1, 'origin was consulted despite the entry being fresh')
 })
 
+test('request no-cache in the (nonstandard) qualified form still forces revalidation', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh entry — would be served without validation if the directive slipped.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  // `no-cache="set-cookie"` parses to an array (the qualified form has no
+  // request semantics per RFC, but must not be silently ignored). Any presence
+  // must force revalidation, not a blind fresh serve.
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'no-cache="set-cookie"' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body', 'validated body served')
+  t.equal(seen.length, 1, 'qualified request no-cache still revalidated (not served blindly)')
+})
+
 test('request no-cache on a cache miss still stores the response (write-back, #5510)', async (t) => {
   t.plan(2)
   let hits = 0

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -1025,3 +1025,181 @@ test('request no-store: revalidation replacement is delivered but not stored', a
   await rawRequest(dispatch, { ...base, headers: {} })
   t.equal(hits, 2, 'no-store replacement was not written to the cache')
 })
+
+// ---------------------------------------------------------------------------
+// Background-refresh in-flight guard: per-store and per-Vary-variant
+// (Copilot review #54, findings 1 & 2)
+// ---------------------------------------------------------------------------
+
+test('stale-while-revalidate: concurrent stale hits on one store coalesce into a single background refresh', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60, stale-while-revalidate=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  // Both fire in the same synchronous burst: the first adds the in-flight key,
+  // the second sees it and is coalesced before the first's refresh completes.
+  const [a, b] = await Promise.all([rawRequest(dispatch, opts), rawRequest(dispatch, opts)])
+  t.equal(a.body, 'cached-body', 'first stale hit served from cache')
+  t.equal(b.body, 'cached-body', 'second stale hit served from cache')
+
+  await waitFor(() => seen.length >= 1)
+  await flush()
+  t.equal(seen.length, 1, 'the two concurrent stale hits share one background refresh')
+})
+
+test('stale-while-revalidate: refreshes on different stores for the same URL do not block each other', async (t) => {
+  t.plan(1)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60, stale-while-revalidate=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const storeA = new SqliteCacheStore({ location: ':memory:' })
+  const storeB = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  for (const store of [storeA, storeB]) {
+    seedEntry(store, origin(server), {
+      etag: '"v1"',
+      cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+    })
+  }
+  const base = { origin: origin(server), path: '/', method: 'GET', headers: {} }
+
+  await Promise.all([
+    rawRequest(dispatch, { ...base, cache: { store: storeA } }),
+    rawRequest(dispatch, { ...base, cache: { store: storeB } }),
+  ])
+  // With a module-global guard keyed only by URL, storeB's refresh would be
+  // suppressed and this would hang at 1 until the waitFor deadline.
+  await waitFor(() => seen.length === 2)
+  t.equal(seen.length, 2, 'each store runs its own background refresh (no cross-store suppression)')
+})
+
+test('stale-while-revalidate: distinct Vary variants of one URL refresh independently', async (t) => {
+  t.plan(1)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers['accept-encoding'] ?? null)
+    res.writeHead(304, {
+      'cache-control': 'max-age=60, stale-while-revalidate=60',
+      vary: 'accept-encoding',
+    })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Two stored variants of the same URL, selected by Accept-Encoding.
+  for (const enc of ['gzip', 'br']) {
+    seedEntry(store, origin(server), {
+      headers: { vary: 'accept-encoding' },
+      cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+      etag: `"${enc}"`,
+    })
+    // seedEntry keys with headers:{}; overwrite the variant explicitly.
+    const buf = Buffer.from('cached-body')
+    const now = Date.now()
+    store.set(
+      { origin: origin(server), method: 'GET', path: '/', headers: { 'accept-encoding': enc } },
+      {
+        body: buf,
+        start: 0,
+        end: buf.byteLength,
+        statusCode: 200,
+        statusMessage: '',
+        headers: {},
+        cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+        etag: `"${enc}"`,
+        vary: { 'accept-encoding': enc },
+        cachedAt: now - 10e3,
+        staleAt: now - 5e3,
+        deleteAt: now + 3600e3,
+      },
+    )
+  }
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  await Promise.all([
+    rawRequest(dispatch, { ...base, headers: { 'accept-encoding': 'gzip' } }),
+    rawRequest(dispatch, { ...base, headers: { 'accept-encoding': 'br' } }),
+  ])
+  // The refresh key folds in the selected Vary variant, so the two variants do
+  // not share a single refresh slot.
+  await waitFor(() => seen.length === 2)
+  t.same(seen.sort(), ['br', 'gzip'], 'each Vary variant refreshed independently')
+})
+
+test('stale-while-revalidate: a failing background refresh is swallowed; the stale entry survives', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    // Kill the connection on the background conditional request.
+    res.destroy()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+  })
+  const key = { origin: origin(server), method: 'GET', path: '/', headers: {} }
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200, 'stale entry served immediately')
+  t.equal(res.body, 'cached-body', 'stale body served despite the doomed refresh')
+
+  // Let the background refresh run and fail; it must not throw or evict.
+  await waitFor(() => hits >= 1)
+  await flush()
+  t.equal(store.get(key)?.etag, '"v1"', 'stale entry is retained after the refresh error')
+})
+
+test('freshening: a 304 that changes Vary recomputes the stored selector map (review)', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(304, { 'cache-control': 'max-age=60', vary: 'accept-language' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Seeded entry has no Vary selectors.
+  seedEntry(store, origin(server), { etag: '"v1"', cacheControlDirectives: { 'max-age': 5 } })
+  const key = { origin: origin(server), method: 'GET', path: '/', headers: {} }
+  t.same(store.get(key)?.vary, {}, 'seeded entry starts with no Vary selectors')
+
+  await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  })
+  await flush()
+  // The 304 introduced `Vary: accept-language`; the freshened entry must adopt
+  // it (request had no Accept-Language, so the selector value is the null
+  // sentinel) rather than keeping the stale empty map.
+  t.same(store.get(key)?.vary, { 'accept-language': null }, "freshened entry adopts the 304's Vary")
+})

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -313,14 +313,16 @@ test('stale-if-error: origin 503 during revalidation serves the stale entry', as
 
 test('stale-if-error: serves stale without waiting for the 5xx body to drain', async (t) => {
   t.plan(2)
-  let bodyFullySent = false
+  let originAborted = false
   const server = await startServer((req, res) => {
     res.writeHead(503, { 'content-length': '1000000' })
     res.write(Buffer.alloc(16)) // headers + a little body, then hang
-    // Deliberately never end() — if the interceptor waited for the body to
-    // drain before serving stale, this request would hang until teardown.
+    // Deliberately never end(): the claimed body is 1 MB but only 16 bytes are
+    // sent. If the interceptor waited for the body to drain before serving
+    // stale, this request would hang until teardown. Instead it delivers stale
+    // and aborts the in-flight request, which closes this connection.
     res.on('close', () => {
-      bodyFullySent = false
+      originAborted = true
     })
   })
   t.teardown(server.close.bind(server))
@@ -335,7 +337,12 @@ test('stale-if-error: serves stale without waiting for the 5xx body to drain', a
 
   const res = await rawRequest(dispatch, opts)
   t.equal(res.body, 'cached-body', 'stale entry served promptly, before the 5xx body finished')
-  t.equal(bodyFullySent, false, 'origin never finished sending its body')
+  // The undelivered 1 MB body is never drained: the interceptor aborts the
+  // origin request right after serving stale, so the server observes the
+  // connection close. Wait deterministically rather than asserting a flag that
+  // could still be racing.
+  await waitFor(() => originAborted)
+  t.ok(originAborted, 'origin request was aborted, not drained to completion')
 })
 
 test('stale-if-error: without the directive the 503 is passed through', async (t) => {
@@ -605,6 +612,79 @@ test('request max-age=0: revalidates a fresh entry', async (t) => {
   })
   t.equal(res.body, 'cached-body')
   t.equal(seen.length, 1, 'max-age=0 demanded validation')
+})
+
+test('request max-age > 0: a fresh entry whose age is within the bound is served from cache', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
+    res.end('origin')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh entry, ~10s old.
+  seedEntry(store, origin(server), {
+    cachedAtOffset: -10e3,
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=30' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body', 'age (~10s) is within max-age=30, so the cached entry is served')
+  t.equal(hits, 0, 'origin was not contacted')
+})
+
+test('request min-fresh: satisfied entry is served, unsatisfied entry revalidates', async (t) => {
+  t.plan(4)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+  // Fresh for ~10 more seconds.
+  const seed = () =>
+    seedEntry(store, origin(server), {
+      etag: '"v1"',
+      cachedAtOffset: -5e3,
+      staleAtOffset: 10e3,
+      cacheControlDirectives: { 'max-age': 15 },
+    })
+
+  seed()
+  const served = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'min-fresh=5' },
+  })
+  t.equal(
+    served.body,
+    'cached-body',
+    'remaining freshness (~10s) >= min-fresh=5, served from cache',
+  )
+  t.equal(hits, 0, 'origin not contacted when min-fresh is satisfied')
+
+  seed()
+  const revalidated = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'min-fresh=20' },
+  })
+  t.equal(revalidated.statusCode, 200, 'min-fresh=20 not satisfied by ~10s remaining — revalidated')
+  t.equal(hits, 1, 'origin contacted when min-fresh exceeds remaining freshness')
 })
 
 test('request max-stale: serves a stale entry within the tolerance without origin contact', async (t) => {

--- a/test/cache-revalidation.js
+++ b/test/cache-revalidation.js
@@ -1,0 +1,1027 @@
+/* eslint-disable */
+// Stale-path behavior: origin revalidation (conditional requests, 304
+// freshening), stale-while-revalidate, stale-if-error, and local evaluation
+// of freshness-overriding request directives. Stale entries are seeded
+// directly into the store (no sleeps) so every test is deterministic.
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch() {
+  return compose(new undici.Agent(), interceptors.cache())
+}
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc, h) {
+        statusCode = sc
+        headers = h
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, headers, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+function origin(server) {
+  return `http://0.0.0.0:${server.address().port}`
+}
+
+// Seeds a (typically stale) entry the way CacheHandler would have stored it.
+function seedEntry(
+  store,
+  originStr,
+  {
+    path = '/',
+    method = 'GET',
+    body = 'cached-body',
+    headers = {},
+    cacheControlDirectives = {},
+    etag = '',
+    // Offsets relative to now, in ms.
+    cachedAtOffset = -10e3,
+    staleAtOffset = -5e3,
+    deleteAtOffset = 3600e3,
+  } = {},
+) {
+  const now = Date.now()
+  const buf = Buffer.from(body)
+  store.set(
+    { origin: originStr, method, path, headers: {} },
+    {
+      body: buf,
+      start: 0,
+      end: buf.byteLength,
+      statusCode: 200,
+      statusMessage: '',
+      headers,
+      cacheControlDirectives,
+      etag,
+      vary: {},
+      cachedAt: now + cachedAtOffset,
+      staleAt: now + staleAtOffset,
+      deleteAt: now + deleteAtOffset,
+    },
+  )
+}
+
+// Bounded poll — never waits forever (see global waiting guidelines).
+async function waitFor(cond, { timeout = 2000, interval = 10 } = {}) {
+  const deadline = Date.now() + timeout
+  while (!cond()) {
+    if (Date.now() > deadline) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval))
+  }
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+// ---------------------------------------------------------------------------
+// Conditional revalidation: 304 serves and freshens the stored entry
+// ---------------------------------------------------------------------------
+
+test('revalidation: stale entry with etag revalidates with if-none-match; 304 serves cached body', async (t) => {
+  t.plan(6)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { 'cache-control': 'max-age=5', 'last-modified': 'Sat, 04 Jul 2026 10:00:00 GMT' },
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.statusCode, 200, 'client sees 200, not the 304')
+  t.equal(first.body, 'cached-body', 'validated cached body is served')
+  t.equal(seen.length, 1, 'origin was asked once')
+  t.equal(seen[0]['if-none-match'], '"v1"', 'if-none-match carries the stored etag')
+  t.equal(
+    seen[0]['if-modified-since'],
+    'Sat, 04 Jul 2026 10:00:00 GMT',
+    'if-modified-since echoes the stored last-modified verbatim',
+  )
+
+  // The 304's max-age=60 freshened the entry: next request never hits origin.
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(seen.length, 1, 'freshened entry is served without contacting the origin')
+})
+
+test('revalidation: freshening resets the Age', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -100e3,
+    staleAtOffset: -95e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.ok(second.headers.age != null, 'age header present')
+  t.ok(Number(second.headers.age) <= 1, `age is reset after freshening (got ${second.headers.age})`)
+})
+
+test('revalidation: replacement 200 is delivered and stored', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('new-body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.body, 'new-body', 'replacement body is delivered')
+
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'new-body', 'replacement was stored')
+  t.equal(hits, 1, 'second request served from cache')
+})
+
+test('revalidation: entry without etag falls back to if-modified-since from cachedAt', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200)
+  t.equal(seen[0]['if-none-match'], undefined, 'no etag, no if-none-match')
+  t.ok(seen[0]['if-modified-since'].endsWith(' GMT'), 'if-modified-since derived from cachedAt')
+})
+
+// ---------------------------------------------------------------------------
+// Store-and-revalidate: response no-cache with a validator
+// ---------------------------------------------------------------------------
+
+test('revalidation: no-cache + etag response is stored and revalidated on every hit (#5515)', async (t) => {
+  t.plan(6)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match'] === '"v1"') {
+      conditional++
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200, { 'cache-control': 'no-cache', etag: '"v1"' })
+      res.end('validated-body')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.body, 'validated-body')
+  await flush()
+
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'validated-body', 'cached body served after 304 validation')
+  t.equal(hits, 2, 'every reuse revalidates with the origin')
+  t.equal(conditional, 1, 'second request was conditional')
+
+  // The freshened (post-304) entry must keep the no-cache semantics: a third
+  // request revalidates again from the entry the 304 re-stored.
+  await flush()
+  const third = await rawRequest(dispatch, opts)
+  t.equal(third.body, 'validated-body', 'freshened entry still serves the cached body')
+  t.equal(conditional, 2, 'the freshened entry is validated again, not served blindly')
+})
+
+test('revalidation: entry no-cache directive forces validation even while fresh', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh (staleAt in the future) but marked no-cache.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'no-cache': true, 'max-age': 70 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'fresh no-cache entry still validated with origin')
+})
+
+// ---------------------------------------------------------------------------
+// stale-if-error (RFC 5861 §4)
+// ---------------------------------------------------------------------------
+
+test('stale-if-error: origin 503 during revalidation serves the stale entry', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end('boom')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200, 'stale entry served instead of the 503')
+  t.equal(res.body, 'cached-body')
+})
+
+test('stale-if-error: serves stale without waiting for the 5xx body to drain', async (t) => {
+  t.plan(2)
+  let bodyFullySent = false
+  const server = await startServer((req, res) => {
+    res.writeHead(503, { 'content-length': '1000000' })
+    res.write(Buffer.alloc(16)) // headers + a little body, then hang
+    // Deliberately never end() — if the interceptor waited for the body to
+    // drain before serving stale, this request would hang until teardown.
+    res.on('close', () => {
+      bodyFullySent = false
+    })
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.body, 'cached-body', 'stale entry served promptly, before the 5xx body finished')
+  t.equal(bodyFullySent, false, 'origin never finished sending its body')
+})
+
+test('stale-if-error: without the directive the 503 is passed through', async (t) => {
+  t.plan(2)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end('boom')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 503, '503 replacement is delivered')
+  t.equal(res.body, 'boom')
+})
+
+test('stale-if-error: connection error before response serves the stale entry (#5513)', async (t) => {
+  t.plan(2)
+  // Port 1 (tcpmux) is privileged and never bound in practice — connecting
+  // yields a deterministic ECONNREFUSED without the port-reuse race of
+  // binding-then-closing a listener under parallel test load.
+  const originStr = 'http://127.0.0.1:1'
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, originStr, {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60 },
+  })
+  const opts = { origin: originStr, path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200, 'unreachable origin within stale-if-error serves stale')
+  t.equal(res.body, 'cached-body')
+})
+
+test('stale-if-error: request directive works as fallback window', async (t) => {
+  t.plan(1)
+  const server = await startServer((req, res) => {
+    res.writeHead(500)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'stale-if-error=60' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200, 'request stale-if-error honored on origin 5xx')
+})
+
+test('stale-if-error: must-revalidate vetoes serving stale (#5511)', async (t) => {
+  t.plan(1)
+  const server = await startServer((req, res) => {
+    res.writeHead(503)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-if-error': 60, 'must-revalidate': true },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 503, 'must-revalidate forbids the stale-if-error serve')
+})
+
+// ---------------------------------------------------------------------------
+// stale-while-revalidate (RFC 5861 §3)
+// ---------------------------------------------------------------------------
+
+test('stale-while-revalidate: stale entry within window is served immediately, refreshed in background', async (t) => {
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(200, { 'cache-control': 'max-age=60, stale-while-revalidate=60', etag: '"v2"' })
+    res.end('refreshed')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'stale-while-revalidate': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  t.equal(first.statusCode, 200)
+  t.equal(first.body, 'cached-body', 'stale body served without waiting for the origin')
+
+  await waitFor(() => seen.length === 1)
+  t.equal(seen[0]['if-none-match'], '"v1"', 'background refresh is a conditional request')
+
+  // Give the refresh time to store, then confirm the entry was replaced.
+  await waitFor(() => {
+    const entry = store.get({ origin: origin(server), method: 'GET', path: '/', headers: {} })
+    return entry?.etag === '"v2"'
+  })
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'refreshed', 'refreshed entry served afterwards')
+  t.equal(seen.length, 1, 'no additional origin hit for the refreshed entry')
+  t.end()
+})
+
+test('stale-while-revalidate: outside the window revalidates synchronously', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stale by 100s, swr window only 60s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -110e3,
+    staleAtOffset: -100e3,
+    cacheControlDirectives: { 'max-age': 10, 'stale-while-revalidate': 60 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.body, 'cached-body', '304 validated the entry')
+  t.equal(seen.length, 1, 'origin consulted before serving (synchronous revalidation)')
+})
+
+// ---------------------------------------------------------------------------
+// Request directives evaluated locally
+// ---------------------------------------------------------------------------
+
+test('request no-cache: revalidates a fresh entry instead of serving it', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'no-cache' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200)
+  t.equal(res.body, 'cached-body', 'validated body served')
+  t.equal(seen.length, 1, 'origin was consulted despite the entry being fresh')
+})
+
+test('request no-cache on a cache miss still stores the response (write-back, #5510)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'no-cache' } })
+  t.equal(hits, 1)
+  await flush()
+
+  // The no-cache fetch must not have disabled caching for everyone else.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 1, 'plain request is served from the entry stored by the no-cache fetch')
+})
+
+test('request max-age=0 forces validation and exceeded max-age keeps write-back (undici #5504)', async (t) => {
+  t.plan(4)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match']) {
+      conditional++
+    }
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('hello')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  // The exact #5504 repro shape: populate, then request with max-age=0
+  // (what fetch cache:'no-cache' sends) — must NOT be a silent cache hit.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-age=0' } })
+  t.equal(hits, 2, 'max-age=0 contacted the origin (not a falsy-dropped directive)')
+  t.equal(conditional, 1, 'and did so with a conditional request')
+
+  // Secondary #5504 claim: the response fetched because of the max-age bypass
+  // must still update the store — the next plain request is a cache hit.
+  await flush()
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'replacement was stored (write-back preserved)')
+  t.pass('write-back verified')
+})
+
+test('request max-age=0: revalidates a fresh entry', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    staleAtOffset: 60e3,
+    cacheControlDirectives: { 'max-age': 70 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=0' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'max-age=0 demanded validation')
+})
+
+test('request max-stale: serves a stale entry within the tolerance without origin contact', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stale by 5s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  const res = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'max-stale=30' },
+  })
+  t.equal(res.body, 'cached-body', 'stale-by-5s entry served under max-stale=30')
+  t.equal(hits, 0, 'origin not contacted')
+
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-stale=2' } })
+  t.equal(hits, 1, 'staleness beyond max-stale=2 revalidates')
+})
+
+test('request bare max-stale accepts any staleness', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -1000e3,
+    staleAtOffset: -995e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-stale' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(hits, 0, 'bare max-stale served an arbitrarily stale entry')
+})
+
+test('request max-stale: must-revalidate vetoes serving stale', async (t) => {
+  t.plan(1)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(1)
+    res.writeHead(304)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5, 'must-revalidate': true },
+  })
+
+  await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-stale=300' },
+    cache: { store },
+  })
+  t.equal(seen.length, 1, 'must-revalidate entry validated despite max-stale')
+})
+
+test('only-if-cached: stale entry without max-stale returns 504', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'only-if-cached' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 504, 'stale entry is not usable for only-if-cached')
+  t.equal(hits, 0, 'origin never contacted')
+})
+
+test('caller conditionals against a stale entry are forwarded to the origin', async (t) => {
+  t.plan(3)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    if (req.headers['if-none-match'] === '"v1"') {
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200)
+      res.end('fresh')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'if-none-match': '"v1"' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 304, "origin's 304 flows to the caller")
+  t.equal(seen.length, 1, 'stale entry did not answer the conditional locally')
+  t.equal(seen[0]['if-none-match'], '"v1"', "caller's own validator was forwarded")
+})
+
+// ---------------------------------------------------------------------------
+// Review regressions: request bounds vs stale-serving windows, 304 freshening
+// edge cases, aborts, HEAD
+// ---------------------------------------------------------------------------
+
+test('request max-age is not nullified by max-stale (review)', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=3600' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Origin-fresh entry (staleAt far in the future) aged 300s.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -300e3,
+    staleAtOffset: 3300e3,
+    cacheControlDirectives: { 'max-age': 3600 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=10, max-stale=600' },
+    cache: { store },
+  })
+  t.equal(res.statusCode, 200)
+  t.equal(seen.length, 1, 'entry older than the request max-age was validated, not served blindly')
+})
+
+test('request max-age=0 is not nullified by response stale-while-revalidate (review)', async (t) => {
+  t.plan(2)
+  const seen = []
+  const server = await startServer((req, res) => {
+    seen.push(req.headers)
+    res.writeHead(304, { 'cache-control': 'max-age=60, stale-while-revalidate=300' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Fresh entry aged 30s with a wide SWR window.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cachedAtOffset: -30e3,
+    staleAtOffset: 30e3,
+    cacheControlDirectives: { 'max-age': 60, 'stale-while-revalidate': 300 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'max-age=0' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body')
+  t.equal(seen.length, 1, 'max-age=0 validated synchronously despite the SWR window')
+})
+
+test('freshening: 304 without a Date header restarts the freshness clock (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.sendDate = false
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  // Stored 300s ago with the origin's original Date header.
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { date: new Date(Date.now() - 300e3).toUTCString() },
+    cachedAtOffset: -300e3,
+    staleAtOffset: -295e3,
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'the 304 granted 60s of freshness — second request never hit the origin')
+
+  const entry = store.get({ origin: origin(server), method: 'GET', path: '/', headers: {} })
+  t.ok(entry.staleAt > Date.now(), 'freshened entry is actually fresh')
+})
+
+test('freshening: 304 headers are merged with store-time exclusions (set-cookie, content-length) (review)', async (t) => {
+  t.plan(4)
+  const server = await startServer((req, res) => {
+    res.writeHead(304, {
+      'cache-control': 'max-age=60',
+      'set-cookie': 'session=leak',
+      'content-length': '9999',
+      'x-fresh': 'merged',
+    })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    headers: { 'x-old': 'kept' },
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.headers['set-cookie'], undefined, '304 Set-Cookie never reaches the shared entry')
+  t.equal(res.headers['x-fresh'], 'merged', 'new 304 fields are merged in')
+  t.equal(res.headers['x-old'], 'kept', 'stored fields survive the merge')
+  t.equal(res.body, 'cached-body', 'stored body served (304 content-length ignored)')
+})
+
+test('revalidation: HEAD entry freshens and serves an empty body (review)', async (t) => {
+  t.plan(3)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(304, { 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const now = Date.now()
+  store.set(
+    { origin: origin(server), method: 'HEAD', path: '/', headers: {} },
+    {
+      body: null,
+      start: 0,
+      end: 0,
+      statusCode: 200,
+      statusMessage: '',
+      headers: { 'content-length': '5' },
+      cacheControlDirectives: { 'max-age': 5 },
+      etag: '"v1"',
+      vary: {},
+      cachedAt: now - 10e3,
+      staleAt: now - 5e3,
+      deleteAt: now + 3600e3,
+    },
+  )
+  const opts = { origin: origin(server), path: '/', method: 'HEAD', headers: {}, cache: { store } }
+
+  const res = await rawRequest(dispatch, opts)
+  t.equal(res.statusCode, 200)
+  t.equal(res.body, '', 'HEAD serves no body')
+
+  await flush()
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'freshened HEAD entry served without another origin hit')
+})
+
+test('only-if-cached combined with max-stale serves a stale entry (review)', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200)
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const res = await rawRequest(dispatch, {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { 'cache-control': 'only-if-cached, max-stale=30' },
+    cache: { store },
+  })
+  t.equal(res.body, 'cached-body', 'max-stale makes the stale entry usable for only-if-cached')
+  t.equal(hits, 0, 'origin never contacted')
+})
+
+test('abort during revalidation cancels the in-flight conditional request (review)', async (t) => {
+  t.plan(2)
+  let sawRequest = false
+  const server = await startServer((req, res) => {
+    sawRequest = true
+    // Never answer — only an abort can end this request.
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } },
+      {
+        onConnect(abort) {
+          // Abort as soon as the handle exists — during the conditional flight.
+          setTimeout(() => abort(new Error('user-abort')), 20)
+        },
+        onHeaders() {
+          reject(new Error('should not receive headers'))
+          return true
+        },
+        onData() {
+          return true
+        },
+        onComplete() {
+          reject(new Error('should not complete'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+  t.equal(err.message, 'user-abort', "the user's abort reason surfaces via onError")
+  t.ok(sawRequest, 'the conditional request had reached the origin')
+})
+
+test('request no-store: revalidation replacement is delivered but not stored', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60', etag: '"v2"' })
+    res.end('replacement')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  seedEntry(store, origin(server), {
+    etag: '"v1"',
+    cacheControlDirectives: { 'max-age': 5 },
+  })
+  const base = { origin: origin(server), path: '/', method: 'GET', cache: { store } }
+
+  const res = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'no-store' },
+  })
+  t.equal(res.body, 'replacement')
+  await flush()
+
+  // The stale seeded entry is still there (superseded only on store), and the
+  // replacement must not have been written: a plain request revalidates again.
+  await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(hits, 2, 'no-store replacement was not written to the cache')
+})

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -122,6 +122,37 @@ test('storability: invalid Expires (0) means already expired — not cached', as
   t.equal(hits, 2, 'Expires: 0 is treated as already expired (RFC 9111 §5.3)')
 })
 
+test('storability: past Expires with etag is stored for revalidation', async (t) => {
+  t.plan(2)
+  let hits = 0
+  let conditional = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match'] === '"e"') {
+      conditional++
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200, {
+        expires: new Date(Date.now() - 60e3).toUTCString(),
+        etag: '"e"',
+      })
+      res.end('body')
+    }
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  const first = await rawRequest(dispatch, opts)
+  await flush()
+  const second = await rawRequest(dispatch, opts)
+  t.equal(second.body, 'body', 'validated body served')
+  t.equal(conditional, 1, 'second request revalidated instead of refetching')
+})
+
 // ---------------------------------------------------------------------------
 // Corrected initial age (RFC 9111 §4.2.3)
 // ---------------------------------------------------------------------------
@@ -272,6 +303,31 @@ test('authorization: s-maxage permits shared-cache storage and reuse (#4911)', a
   await rawRequest(dispatch, opts)
   await rawRequest(dispatch, opts)
   t.equal(hits, 1, 's-maxage response cached and served for authorized requests')
+})
+
+test('authorization: must-revalidate permits storage for authorized requests', async (t) => {
+  t.plan(1)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60, must-revalidate' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const opts = {
+    origin: origin(server),
+    path: '/',
+    method: 'GET',
+    headers: { authorization: 'Bearer secret' },
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'must-revalidate response cached while fresh for authorized requests')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -91,12 +91,12 @@ test('cache: request max-age=0 bypasses cache lookup', async (t) => {
 })
 
 // ---------------------------------------------------------------------------
-// 'min-fresh' / 'max-stale' are not recognised by cache-control-parser, so the
-// old directive checks were dead code and the cache served entries anyway.
+// 'min-fresh' / 'max-stale' are evaluated locally against the entry's
+// freshness (RFC 9111 §5.2.1.3 / §5.2.1.2) instead of bypassing the cache.
 // ---------------------------------------------------------------------------
 
-test('cache: request min-fresh bypasses cache lookup', async (t) => {
-  t.plan(1)
+test('cache: request min-fresh is evaluated against the entry freshness', async (t) => {
+  t.plan(2)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
@@ -115,11 +115,16 @@ test('cache: request min-fresh bypasses cache lookup', async (t) => {
   }
 
   await rawRequest(dispatch, { ...base, headers: {} })
+  // ~60s of freshness left — comfortably more than 30s.
   await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'min-fresh=30' } })
-  t.equal(hits, 2, 'min-fresh must go to the origin until the directive is supported')
+  t.equal(hits, 1, 'entry fresh for longer than min-fresh is served from cache')
+
+  // Demands more remaining freshness than the entry can have — origin.
+  await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'min-fresh=120' } })
+  t.equal(hits, 2, 'entry with less remaining freshness than min-fresh goes to origin')
 })
 
-test('cache: request max-stale bypasses cache lookup', async (t) => {
+test('cache: request max-stale still serves a fresh entry', async (t) => {
   t.plan(1)
   let hits = 0
   const server = await startServer((req, res) => {
@@ -140,7 +145,7 @@ test('cache: request max-stale bypasses cache lookup', async (t) => {
 
   await rawRequest(dispatch, { ...base, headers: {} })
   await rawRequest(dispatch, { ...base, headers: { 'cache-control': 'max-stale=30' } })
-  t.equal(hits, 2, 'max-stale must go to the origin until the directive is supported')
+  t.equal(hits, 1, 'a fresh entry satisfies a max-stale request')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/trace-cache.js
+++ b/test/trace-cache.js
@@ -313,3 +313,38 @@ test('trace-cache: forwarded 1xx emits no cache-store doc', async (t) => {
   t.equal(stores[0].statusCode, 200)
   t.equal(stores[0].stored, true)
 })
+
+// ---------------------------------------------------------------------------
+// non-cacheable FINAL status → cache-store skipped with reason 'status'
+// (interim 1xx stays silent; regression guard for the trace port on rebase)
+// ---------------------------------------------------------------------------
+
+test('trace-cache: non-cacheable status emits a skipped cache-store doc (reason status)', async (t) => {
+  const server = await startServer((req, res) => {
+    res.writeHead(404, { 'cache-control': 'max-age=60' })
+    res.end('missing')
+  })
+  t.teardown(server.close.bind(server))
+
+  const writer = makeWriter()
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  // request() throws on the 404 (response-error interceptor); the cache-store
+  // doc is emitted synchronously in CacheHandler.onHeaders before the error
+  // propagates, so it's already recorded.
+  await request(origin, {
+    trace: writer,
+    cache: { store },
+    dispatcher: makeDispatcher(t),
+  }).then(
+    ({ body }) => body.dump(),
+    () => {},
+  )
+
+  const stores = writer.docs.filter((doc) => doc.op === 'undici:cache-store')
+  t.equal(stores.length, 1, 'the non-cacheable status still emits one skip doc')
+  t.equal(stores[0].statusCode, 404)
+  t.equal(stores[0].stored, false)
+  t.equal(stores[0].reason, 'status')
+})


### PR DESCRIPTION
Second of two stacked PRs splitting the cache overhaul (was #52). **Stacked on #53** — review/merge that first; the diff here is purely the revalidation machinery on top of the freshness/store foundation.

> Base is `feat/cache-rest` (#53). GitHub will retarget this to `main` once #53 merges; the diff shown is against #53.

## What's here
Retains entries past freshness (the `staleAt`/`deleteAt` split from #53's schema) and revalidates them with conditional requests instead of refetching in full.

- **`RevalidationHandler`**: `if-none-match` from the stored etag, `if-modified-since` echoing the stored `Last-Modified` **verbatim** (nginx `if_modified_since exact` compat, undici PR #5512). A 304 merges headers, restarts the freshness clock (RFC 9110 §6.6.1 receipt-time `Date` when the 304 omits one) and re-stores; other statuses replace the entry. User callbacks defer until the decision, with an eager connect so caller aborts cancel the in-flight conditional request.
- **stale-while-revalidate** (RFC 5861 §3): serve stale immediately, refresh in the background (per-key in-flight guard; opts cloned without `body`/`signal`).
- **stale-if-error** (RFC 5861 §4): serve stale on origin 5xx (aborting the error body early) and pre-response connection errors (undici PR #5513); response directive first, request fallback; vetoed by `must-revalidate`/`proxy-revalidate` (undici PR #5511).
- **Store-and-revalidate**: `must-revalidate`/`proxy-revalidate`/unqualified `no-cache` responses are now stored and validated before reuse; zero-TTL responses with a validator are kept for revalidation (undici PR #5515).
- **Request directives evaluated locally**: `max-age` (incl. `=0`, the `fetch cache:'no-cache'` idiom — undici #5504), `min-fresh`, `max-stale`, `no-cache`, `only-if-cached`; the caller's age bounds also gate every stale-serving path so an origin's SWR can't nullify a client's `max-age=0`.
- `computeEntryTimes` gains the retention buffer (2× freshness, extended by SWR/SIE windows and validator retention) so stale entries survive for revalidation.

## Notes
- Incorporates the Copilot finding from #52 (stale-if-error aborts the 5xx body early instead of draining it).
- Tests: new `test/cache-revalidation.js` (85 assertions) plus the request-directive reworks; all green.
- Together, #53 + this PR reproduce the exact tree that was reviewed as #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Added since review
- **`origins` whitelist option** (undici PR #4739): `cache({ origins: ['\''host'\'', /regex/] })` restricts which request origins are cached (string case-insensitive / RegExp; non-matching origins bypass the cache). New `test/cache-origins.js`. This is additional user-facing API surface beyond the revalidation work — flagged here per review.
- **Rebased onto `main`** (base retargeted from the merged `feat/cache-rest`) and **re-applied the #55 trace instrumentation** into the rewritten + split cache modules (`test/trace-cache.js` passes unchanged).
- Conformance-suite adoption is tracked separately in #56.
