### PR TITLE
fix: require @nxtedition/undici >= 11.1.9 (fork-private global-dispatcher symbol)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@nxtedition/scheduler": "^4.1.1",
     "@nxtedition/trace": "^1.0.0",
-    "@nxtedition/undici": "^11.1.4",
+    "@nxtedition/undici": "^11.1.9",
     "fast-querystring": "^1.1.2",
     "http-errors": "^2.0.1",
     "xxhash-wasm": "^1.1.0"


### PR DESCRIPTION
Companion to #57 (see "Bugs found & fixed" there, item 3).

Node ≥ 26.3 bundles undici v8, which claims the same `Symbol.for('undici.globalDispatcher.2')` global-dispatcher slot that `@nxtedition/undici` used through 11.1.6. Any `fetch()` running before the fork's module init (tap's runtime, any app touching global fetch) parks node's built-in Agent in the shared slot — and every pipeline `request()` then fails with `invalid onRequestStart method`. With a pre-11.1.7 install, 161 tests fail on `main` under node 26.3.

The fork already fixed this in `nxtedition/undici@dea4176a` ("fix(global): use our own symbol for globalDispatcher", released in **11.1.7**) by moving to `Symbol.for('nxtedition.globalDispatcher.1')`. Since this repo commits no lockfile, the `package.json` range is the installable floor — this PR raises it to `^11.1.9` so no resolution below the symbol fix is possible.

Verified in a clean worktree on plain `main` + 11.1.9: the collision repro (fetch first, then `request()`) passes, and the previously-failing files (`test/query.js`, `test/request.js`, `test/signal.js`, …) all pass in isolation; the full suite matches main's baseline.

#57 additionally keeps a defense-in-depth guard in `request()`/`getGlobalDispatcher()` for installs still resolving 11.1.4–11.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)