### PR TITLE
feat(retry): exponential backoff with jitter and configurable maxDelay

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -117,6 +117,11 @@ export interface DispatchOptions {
 
 export interface RetryOptions {
   count?: number
+  /** Cap on the exponential backoff between attempts, in milliseconds
+   *  (default 10_000). The first retry is always immediate; subsequent waits
+   *  are 1s·2^(n−1) capped here, with 50–100% jitter applied. Does not affect
+   *  a server-provided retry-after (clamped to 60s separately). */
+  maxDelay?: number
   retry?: RetryFn
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -118,9 +118,10 @@ export interface DispatchOptions {
 export interface RetryOptions {
   count?: number
   /** Cap on the exponential backoff between attempts, in milliseconds
-   *  (default 10_000). The first retry is always immediate; subsequent waits
-   *  are 1s·2^(n−1) capped here, with 50–100% jitter applied. Does not affect
-   *  a server-provided retry-after (clamped to 60s separately). */
+   *  (default 60_000; clamped to the ~2^31−1 ms timer max). The first retry is
+   *  always immediate; subsequent waits are 1s·2^(n−1) capped here, with
+   *  50–100% jitter applied. Does not affect a server-provided retry-after
+   *  (clamped to 60s separately). */
   maxDelay?: number
   retry?: RetryFn
 }

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -116,6 +116,21 @@ function sleep(delay, signal) {
   })
 }
 
+// Exponential backoff with equal jitter. The first retry is immediate — a
+// failure on a reused socket (ECONNRESET/EPIPE on a stale keep-alive
+// connection) almost always succeeds on a fresh connection, and callers rely
+// on that being invisible. From there 1s·2^(n−1) capped at maxDelay, of which
+// a random 50–100% is used so a fleet that failed against the same upstream
+// at the same moment does not retry in lockstep against it while it recovers.
+// Exported for tests.
+export function backoffDelay(retryCount, maxDelay) {
+  if (retryCount <= 0) {
+    return 0
+  }
+  const delay = Math.min(2 ** (retryCount - 1) * 1e3, maxDelay)
+  return delay / 2 + Math.random() * (delay / 2)
+}
+
 class Handler extends DecoratorHandler {
   #dispatch
   #opts
@@ -623,6 +638,9 @@ class Handler extends DecoratorHandler {
       return false
     }
 
+    const maxDelay =
+      Number.isFinite(retryOpts?.maxDelay) && retryOpts.maxDelay >= 0 ? retryOpts.maxDelay : 10e3
+
     const statusCode =
       err?.statusCode ?? err?.status ?? err?.$metadata?.httpStatusCode ?? this.#statusCode
     const headers = err?.headers ?? this.#headers
@@ -641,7 +659,7 @@ class Handler extends DecoratorHandler {
             // value and avoids the 32-bit timer overflow that makes huge delays
             // fire immediately.
             Math.min(retryAfter, 60e3)
-          : Math.min(10e3, retryCount * 1e3)
+          : backoffDelay(retryCount, maxDelay)
       this.#opts.logger?.debug({ statusCode, retryAfter, delay, retryCount }, 'retry delay')
       traceRetry(this.#opts, retryCount, delay, err ?? statusCode)
       return this.#backoff(delay, opts)
@@ -664,14 +682,14 @@ class Handler extends DecoratorHandler {
         'UND_ERR_SOCKET',
       ].includes(err.code)
     ) {
-      const delay = Math.min(10e3, retryCount * 1e3)
+      const delay = backoffDelay(retryCount, maxDelay)
       this.#opts.logger?.debug({ err, retryCount }, 'retry delay')
       traceRetry(this.#opts, retryCount, delay, err)
       return this.#backoff(delay, opts)
     }
 
     if (err?.message && ['other side closed'].includes(err.message)) {
-      const delay = Math.min(10e3, retryCount * 1e3)
+      const delay = backoffDelay(retryCount, maxDelay)
       this.#opts.logger?.debug({ err, retryCount }, 'retry delay')
       traceRetry(this.#opts, retryCount, delay, err)
       return this.#backoff(delay, opts)

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -127,7 +127,10 @@ export function backoffDelay(retryCount, maxDelay) {
   if (retryCount <= 0) {
     return 0
   }
-  const delay = Math.min(2 ** (retryCount - 1) * 1e3, maxDelay)
+  // Also clamp to the platform timer max: setTimeout overflows 32 bits and
+  // fires immediately for larger delays (same guard as the retry-after clamp),
+  // so a huge user-provided maxDelay must not produce instant retries.
+  const delay = Math.min(2 ** (retryCount - 1) * 1e3, maxDelay, 2 ** 31 - 1)
   return delay / 2 + Math.random() * (delay / 2)
 }
 
@@ -638,8 +641,12 @@ class Handler extends DecoratorHandler {
       return false
     }
 
+    // Default cap 60s — the exponential curve then spans the full default
+    // 8-retry budget (0, 1, 2, 4, 8, 16, 32, 60s ≈ 2min total), enough to ride
+    // out a container reschedule or rolling redeploy of an upstream. Matches
+    // the retry-after clamp below.
     const maxDelay =
-      Number.isFinite(retryOpts?.maxDelay) && retryOpts.maxDelay >= 0 ? retryOpts.maxDelay : 10e3
+      Number.isFinite(retryOpts?.maxDelay) && retryOpts.maxDelay >= 0 ? retryOpts.maxDelay : 60e3
 
     const statusCode =
       err?.statusCode ?? err?.status ?? err?.$metadata?.httpStatusCode ?? this.#statusCode

--- a/test/retry-backoff.js
+++ b/test/retry-backoff.js
@@ -1,0 +1,140 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+import { backoffDelay } from '../lib/interceptor/response-retry.js'
+
+// ---------------------------------------------------------------------------
+// backoffDelay unit: exponential curve, equal jitter, cap
+// ---------------------------------------------------------------------------
+
+test('backoffDelay: first retry is immediate', (t) => {
+  t.equal(backoffDelay(0, 10e3), 0)
+  t.equal(backoffDelay(-1, 10e3), 0)
+  t.end()
+})
+
+test('backoffDelay: exponential with 50-100% jitter', (t) => {
+  // [retryCount, maxDelay, base after cap]
+  const cases = [
+    [1, 10e3, 1e3],
+    [2, 10e3, 2e3],
+    [4, 10e3, 8e3],
+    // capped: 2^(n-1)s exceeds maxDelay
+    [5, 10e3, 10e3],
+    [8, 10e3, 10e3],
+    // custom cap engages between the exponential steps
+    [6, 30e3, 30e3],
+    // 2^large overflows to Infinity — cap must still bound it
+    [2000, 10e3, 10e3],
+  ]
+  for (const [retryCount, maxDelay, base] of cases) {
+    for (let i = 0; i < 20; i++) {
+      const delay = backoffDelay(retryCount, maxDelay)
+      if (!(delay >= base / 2 && delay < base)) {
+        t.fail(
+          `backoffDelay(${retryCount}, ${maxDelay}) = ${delay}, expected [${base / 2}, ${base})`,
+        )
+      }
+    }
+  }
+  t.equal(backoffDelay(3, 0), 0, 'maxDelay 0 clamps to no wait')
+  t.pass('all sampled delays within [base/2, base)')
+  t.end()
+})
+
+// ---------------------------------------------------------------------------
+// retry.maxDelay plumbs through to the connection-error backoff
+// ---------------------------------------------------------------------------
+
+test('retry: maxDelay caps the backoff between connection-error attempts', async (t) => {
+  let callCount = 0
+  const mockDispatch = (opts, handler) => {
+    callCount++
+    handler.onConnect(() => {})
+    if (callCount <= 2) {
+      const err = new Error('connect ECONNREFUSED 127.0.0.1:1')
+      err.code = 'ECONNREFUSED'
+      handler.onError(err)
+    } else {
+      handler.onHeaders(200, {}, () => {})
+      handler.onData(Buffer.from('ok'))
+      handler.onComplete({})
+    }
+    return true
+  }
+  const dispatch = compose(mockDispatch, interceptors.responseRetry())
+
+  const start = Date.now()
+  const result = await new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(
+      { method: 'GET', path: '/', origin: 'http://x', retry: { count: 3, maxDelay: 20 } },
+      {
+        onConnect() {},
+        onHeaders(sc) {
+          statusCode = sc
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(statusCode)
+        },
+        onError: reject,
+      },
+    )
+  })
+  const elapsed = Date.now() - start
+
+  t.equal(result, 200)
+  t.equal(callCount, 3)
+  // The second retry (retryCount 1) waits 500-1000ms under the default 10s
+  // cap; with maxDelay 20 both waits must stay within [0, 20]ms + timer slop.
+  t.ok(elapsed < 500, `elapsed ${elapsed}ms`)
+})
+
+// ---------------------------------------------------------------------------
+// retry.maxDelay also applies to the status-code backoff (no retry-after)
+// ---------------------------------------------------------------------------
+
+test('retry: maxDelay caps the backoff for 503 without retry-after', async (t) => {
+  let callCount = 0
+  const mockDispatch = (opts, handler) => {
+    callCount++
+    handler.onConnect(() => {})
+    if (callCount <= 2) {
+      const err = new Error('service unavailable')
+      err.statusCode = 503
+      handler.onError(err)
+    } else {
+      handler.onHeaders(200, {}, () => {})
+      handler.onData(Buffer.from('ok'))
+      handler.onComplete({})
+    }
+    return true
+  }
+  const dispatch = compose(mockDispatch, interceptors.responseRetry())
+
+  const start = Date.now()
+  const result = await new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(
+      { method: 'GET', path: '/', origin: 'http://x', retry: { count: 3, maxDelay: 20 } },
+      {
+        onConnect() {},
+        onHeaders(sc) {
+          statusCode = sc
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(statusCode)
+        },
+        onError: reject,
+      },
+    )
+  })
+  const elapsed = Date.now() - start
+
+  t.equal(result, 200)
+  t.equal(callCount, 3)
+  t.ok(elapsed < 500, `elapsed ${elapsed}ms`)
+})

--- a/test/retry-backoff.js
+++ b/test/retry-backoff.js
@@ -25,6 +25,10 @@ test('backoffDelay: exponential with 50-100% jitter', (t) => {
     [6, 30e3, 30e3],
     // 2^large overflows to Infinity — cap must still bound it
     [2000, 10e3, 10e3],
+    // a huge maxDelay is clamped to the ~2^31-1 ms timer max — setTimeout
+    // would otherwise overflow and fire immediately
+    [40, 2 ** 40, 2 ** 31 - 1],
+    [2000, Number.MAX_SAFE_INTEGER, 2 ** 31 - 1],
   ]
   for (const [retryCount, maxDelay, base] of cases) {
     for (let i = 0; i < 20; i++) {
@@ -86,8 +90,8 @@ test('retry: maxDelay caps the backoff between connection-error attempts', async
 
   t.equal(result, 200)
   t.equal(callCount, 3)
-  // The second retry (retryCount 1) waits 500-1000ms under the default 10s
-  // cap; with maxDelay 20 both waits must stay within [0, 20]ms + timer slop.
+  // The second retry (retryCount 1) waits 500-1000ms under the default cap;
+  // with maxDelay 20 both waits must stay within [0, 20]ms + timer slop.
   t.ok(elapsed < 500, `elapsed ${elapsed}ms`)
 })
 


### PR DESCRIPTION
## Problem

The retry backoff is linear — `min(10s, retryCount × 1s)` — so the default 8 retries wait only **~28s total**. That survives a momentary blip but not a container reschedule (~10–60s) or a rolling redeploy of an upstream. It also has **no jitter**: when an upstream drops, every client that failed at the same moment retries in lockstep, hammering the service exactly while it recovers.

(Motivating case: a tv2k image render whose input fetch to storage failed with `EHOSTUNREACH` — all 8 retries burned inside ~28s while storage was unreachable, and the failure was persisted permanently in the render state record.)

## Change

- New `backoffDelay(retryCount, maxDelay)`: the **first retry stays immediate** (a failure on a reused keep-alive socket almost always succeeds on a fresh connection — callers rely on that being invisible), then exponential `1s·2^(n−1)` capped at `maxDelay`, of which a random **50–100%** is used (equal jitter) to desynchronize fleets.
- Applied to all three delay sites: the connection-error code path, the `"other side closed"` path, and the 420/429/502/503/504 path when no `retry-after` header is present. A server-provided `retry-after` is honored unchanged (still clamped to 60s).
- New **`retry.maxDelay`** option, default **60s** — the exponential then spans the full default 8-retry budget, and the cap matches the existing `retry-after` clamp. The computed delay is also clamped to the ~2³¹−1 ms platform timer max so a huge finite `maxDelay` cannot overflow `setTimeout` and fire immediately.
- Typed + documented in `index.d.ts`.

## Delay sequences (worst case, before jitter)

| retry # | before | after (default, cap 60s) |
|---|---|---|
| 1 | 0 | 0 |
| 2 | 1s | 1s |
| 3 | 2s | 2s |
| 4 | 3s | 4s |
| 5 | 4s | 8s |
| 6 | 5s | 16s |
| 7 | 6s | 32s |
| 8 | 7s | 60s |
| **total** | **28s** | **~123s** (~92s expected with jitter) |

Callers wanting the old tighter behavior can pass `retry: { maxDelay: 10e3 }`; callers wanting longer windows raise `count`.

## Tests

New `test/retry-backoff.js`:
- unit tests for the curve, jitter bounds `[base/2, base)`, cap behavior, `2^large → Infinity` overflow, the timer-max clamp, and `maxDelay: 0`
- integration tests proving `maxDelay` plumbs through both the connection-error and 503 (no `retry-after`) backoff paths

Full suite: 2313 pass / 4 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)