### PR TITLE
fix(cache): serve stored fresh 200 when caller conditional cannot produce a 304

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -229,7 +229,8 @@ export default ({ origins } = {}) => {
     // where the caller's own validators do the validation (a 304 flows through
     // to the caller; a 200 replacement is stored by CacheHandler).
     // typeof guards: duplicated conditional headers arrive as arrays — treat
-    // them as non-matching and bypass to origin rather than crashing.
+    // them as non-matching and serve the stored representation rather than
+    // crashing.
     const servableFromCache = entry != null && fresh && !mustRevalidate
     if (servableFromCache && headers['if-none-match']) {
       if (
@@ -246,9 +247,9 @@ export default ({ origins } = {}) => {
           lookupMs,
         )
       }
-      // Etag didn't match — bypass to origin.
-      entry = undefined
-      missReason = 'etag'
+      // If-None-Match didn't match (RFC 9110 §13.1.2): "proceed as normal".
+      // The entry is fresh, so serve the stored 200 below (fall through)
+      // instead of paying an origin round-trip for content the cache holds.
     } else if (servableFromCache && headers['if-modified-since']) {
       const lastModified = entry.headers?.['last-modified']
       if (
@@ -265,9 +266,9 @@ export default ({ origins } = {}) => {
           lookupMs,
         )
       }
-      // No last-modified or modified since — bypass to origin.
-      entry = undefined
-      missReason = 'modified'
+      // Modified since the caller's validator (or no comparable last-modified):
+      // RFC 9110 §13.1.3 — proceed as normal. The entry is fresh, so serve the
+      // stored 200 below (fall through) instead of refetching from the origin.
     } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
       // Stale (or validation-demanding) entry + caller conditionals: forward to
       // origin so the caller's own validators do the validation.

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -2081,8 +2081,8 @@ test('cache: If-None-Match with weak etag comparison returns 304', async (t) => 
   t.equal(hits, 1, 'server not contacted')
 })
 
-test('cache: If-None-Match with non-matching etag bypasses to origin', async (t) => {
-  t.plan(1)
+test('cache: If-None-Match with non-matching etag serves the stored 200', async (t) => {
+  t.plan(3)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
@@ -2107,12 +2107,15 @@ test('cache: If-None-Match with non-matching etag bypasses to origin', async (t)
 
   await rawRequest(dispatch, base)
 
-  // Non-matching etag should bypass cache and hit origin.
-  await rawRequest(dispatch, {
+  // RFC 9110 §13.1.2: a non-matching If-None-Match means "proceed as normal".
+  // The entry is fresh, so serve the stored 200 without contacting the origin.
+  const result = await rawRequestWithBody(dispatch, {
     ...base,
     headers: { 'if-none-match': '"different"' },
   })
-  t.equal(hits, 2, 'non-matching etag bypasses to origin')
+  t.equal(result.statusCode, 200, 'non-matching etag serves stored 200')
+  t.equal(result.body, 'ok', 'stored body is served')
+  t.equal(hits, 1, 'origin not contacted for fresh entry')
 })
 
 test('cache: If-None-Match with wildcard * returns 304', async (t) => {
@@ -2183,8 +2186,8 @@ test('cache: If-Modified-Since returns 304 when resource not modified', async (t
   t.equal(hits, 1, 'server not contacted')
 })
 
-test('cache: If-Modified-Since bypasses to origin when resource was modified', async (t) => {
-  t.plan(1)
+test('cache: If-Modified-Since serves the stored 200 when resource was modified', async (t) => {
+  t.plan(3)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
@@ -2209,10 +2212,14 @@ test('cache: If-Modified-Since bypasses to origin when resource was modified', a
 
   await rawRequest(dispatch, base)
 
-  // If-Modified-Since is before Last-Modified — modified since then.
-  await rawRequest(dispatch, {
+  // If-Modified-Since is before Last-Modified — modified since then. RFC 9110
+  // §13.1.3: proceed as normal. The entry is fresh, so serve the stored 200
+  // without contacting the origin.
+  const result = await rawRequestWithBody(dispatch, {
     ...base,
     headers: { 'if-modified-since': 'Wed, 01 Jan 2025 00:00:00 GMT' },
   })
-  t.equal(hits, 2, 'modified resource bypasses to origin')
+  t.equal(result.statusCode, 200, 'modified resource serves stored 200')
+  t.equal(result.body, 'ok', 'stored body is served')
+  t.equal(hits, 1, 'origin not contacted for fresh entry')
 })


### PR DESCRIPTION
## Summary

Fixes #68.

When a fresh cached entry exists and the caller sends a conditional that the cache cannot answer with a 304 — a non-matching `if-none-match`, or an `if-modified-since` older than the stored `last-modified` — the interceptor previously cleared the entry and refetched from the origin (`missReason = 'etag' | 'modified'`).

Per RFC 9110 §13.1.2 / §13.1.3, a non-matching conditional means **"proceed as normal"**. Since the entry is fresh, the correct and cheaper behavior is to serve the stored 200 rather than pay an origin round-trip for content the cache already holds fresh.

## Changes

- `lib/interceptor/cache/index.js`: the two conditional branches now fall through to the normal fresh-serve path instead of clearing the entry. The `etag` / `modified` miss reasons are removed. Stale (or validation-demanding) entries with caller conditionals still forward to the origin unchanged.
- `test/cache-advanced.js`: the two tests that asserted the old bypass-to-origin behavior now assert the stored 200 is served (`statusCode: 200`, correct body, origin not contacted).

## Verification

All cache suites pass in isolation: `cache-advanced` (92), `cache-revalidation` (105), `trace-cache` (85), `cache-fuzz` (4), `cache-coverage-interceptor` (114), `cache-storability` (62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)