### PR TITLE
fix(retry): decline unvalidated pos=0 full-200 restart to prevent cache poisoning (#69)

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -303,21 +303,28 @@ class Handler extends DecoratorHandler {
       // from the first attempt (and, behind a cache, already used to build the
       // stored entry: its status, cache-control/TTL, Date and validators). That
       // splice is only sound when this response is the SAME representation as
-      // the first, and the one proof of that is the strong-etag if-match the
-      // resume carried: a compliant origin answers a changed representation
-      // with 412, so a 2xx here must still echo that same strong etag. At pos 0
-      // without a strong etag we sent no validator (the `this.#pos && !this.#etag`
-      // resume guard is falsy at pos 0), so a full 200 could be a different or
-      // updated representation. Accepting it would let a cache persist attempt
-      // 1's headers, cache-control/TTL and validators paired with attempt 2's
-      // body and replay that splice for the first response's freshness
-      // lifetime — ignoring attempt 2's own (possibly shorter or no-store)
-      // caching. Require a strong etag that this response echoes; otherwise
-      // decline via the graceful #maybeError path (an assert here would throw
-      // out of this parser callback and hang the stream). At pos > 0 the resume
-      // guard already guarantees a strong #etag, so this only tightens pos 0.
+      // the first. A compliant origin answers a changed representation to the
+      // resume's if-match with 412 — but HTTP does not oblige a 2xx to carry an
+      // etag at all, even when if-match was evaluated. So rather than trust the
+      // origin, impose a stricter CLIENT-SIDE acceptance rule: only splice when
+      // this response echoes the same strong etag the resume validated against;
+      // a 2xx that changed or dropped the etag is declined. At pos 0 without a
+      // strong etag we sent no validator (the `this.#pos && !this.#etag` resume
+      // guard is falsy at pos 0), so a full 200 could be a different or updated
+      // representation — accepting it would let a cache persist attempt 1's
+      // headers, cache-control/TTL and validators paired with attempt 2's body
+      // and replay that splice for the first response's freshness lifetime,
+      // ignoring attempt 2's own (possibly shorter or no-store) caching. Decline
+      // via the graceful #maybeError path with a descriptive reason (an assert
+      // here would throw out of this parser callback and hang the stream). At
+      // pos > 0 the resume guard already guarantees a strong #etag, so this only
+      // tightens pos 0.
       if (typeof this.#etag !== 'string' || this.#etag !== headers.etag) {
-        this.#maybeError(null)
+        this.#maybeError(
+          new Error(
+            'Response retry failed: resumed response did not echo the strong etag required to splice it onto the already-forwarded headers',
+          ),
+        )
         return false
       }
 

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -298,29 +298,37 @@ class Handler extends DecoratorHandler {
     } else if (statusCode === 206 || (this.#pos === 0 && statusCode === 200)) {
       assert(this.#etag != null || !this.#pos)
 
-      if (this.#pos > 0 && this.#etag !== headers.etag) {
+      // A resume — a 206 range, or a full 200 from a server that ignored the
+      // resume Range at pos 0 — is spliced onto the headers ALREADY forwarded
+      // from the first attempt (and, behind a cache, already used to build the
+      // stored entry: its status, cache-control/TTL, Date and validators). That
+      // splice is only sound when this response is the SAME representation as
+      // the first, and the one proof of that is the strong-etag if-match the
+      // resume carried: a compliant origin answers a changed representation
+      // with 412, so a 2xx here must still echo that same strong etag. At pos 0
+      // without a strong etag we sent no validator (the `this.#pos && !this.#etag`
+      // resume guard is falsy at pos 0), so a full 200 could be a different or
+      // updated representation. Accepting it would let a cache persist attempt
+      // 1's headers, cache-control/TTL and validators paired with attempt 2's
+      // body and replay that splice for the first response's freshness
+      // lifetime — ignoring attempt 2's own (possibly shorter or no-store)
+      // caching. Require a strong etag that this response echoes; otherwise
+      // decline via the graceful #maybeError path (an assert here would throw
+      // out of this parser callback and hang the stream). At pos > 0 the resume
+      // guard already guarantees a strong #etag, so this only tightens pos 0.
+      if (typeof this.#etag !== 'string' || this.#etag !== headers.etag) {
         this.#maybeError(null)
         return false
       }
 
       if (this.#pos === 0 && statusCode === 200) {
-        // We asked for a byte range to resume, but no bytes had been forwarded
-        // to the consumer yet, so a server that ignored Range and replied with
-        // the full 200 is acceptable — forward it from the start. (RFC 9110
-        // permits ignoring Range; if-match still guards against changed
-        // content via a 412.) Without this, a legal full 200 retry was
-        // rejected with "Response retry failed".
-        //
-        // The server restarted the response from scratch, so the previous
-        // attempt's resume metadata no longer describes what we're receiving:
-        // refresh #end/#etag from THIS response's headers, otherwise a second
-        // failure would resume against the stale content-length/etag.
+        // The server restarted the response from scratch, so the first
+        // attempt's content-length no longer describes what we're receiving:
+        // refresh #end from THIS response so a second failure resumes against
+        // the right length. #etag is unchanged — we just confirmed it equals
+        // this response's (strong) etag.
         const contentLength = headers['content-length'] ? Number(headers['content-length']) : null
         this.#end = Number.isFinite(contentLength) ? contentLength : null
-        // Same guard as the first-response path: only strong (non-weak),
-        // scalar etags are safe to use for resume validation.
-        this.#etag =
-          typeof headers.etag === 'string' && !headers.etag.startsWith('W/') ? headers.etag : null
         this.#resume = resume
         return true
       }

--- a/test/issue-69-retry-restart-cache-poisoning.js
+++ b/test/issue-69-retry-restart-cache-poisoning.js
@@ -1,0 +1,76 @@
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { test } from 'tap'
+import undici from '@nxtedition/undici'
+import { request } from '../lib/index.js'
+
+// Regression test for issue #69.
+//
+// When a cacheable 200 delivers its headers but the connection dies before any
+// body byte, responseRetry resumes with `range: bytes=0-`. Because headers were
+// already forwarded, onConnect is not re-driven, so the CacheHandler keeps the
+// entry it built from attempt 1's headers (the cache interceptor sits OUTSIDE
+// responseRetry in the default chain, so it observes the retry layer's spliced
+// output). If the pos=0 restart branch then accepted a full 200 from attempt 2
+// without a validator, the cache would persist attempt 1's headers,
+// cache-control/TTL, Date and validators paired with attempt 2's BODY — and
+// replay that splice to every client for attempt 1's freshness lifetime,
+// ignoring attempt 2's own (here: no-store) directive.
+//
+// The fix declines the unvalidated restart, so the poisoned entry is never
+// stored: the first request fails and a later request fetches the origin fresh.
+//
+// request() wraps the dispatcher with the full default interceptor chain
+// (cache + responseRetry included), so `cache: true` + `retry` exercise exactly
+// the production ordering — no manual compose() needed.
+
+test('issue #69: unvalidated pos=0 full-200 restart does not poison the cache', async (t) => {
+  t.plan(4)
+
+  let attempts = 0
+  const server = createServer((req, res) => {
+    attempts++
+    if (attempts === 1) {
+      // Cacheable, long-lived, NO strong etag — headers only, then die before
+      // any body byte so the resume starts at pos 0 with no validator to send.
+      res.writeHead(200, { 'content-length': '5', 'cache-control': 'max-age=3600' })
+      res.flushHeaders()
+      setTimeout(() => res.destroy(), 50)
+    } else if (attempts === 2) {
+      // The resume: a server that ignored Range and restarted the full 200 with
+      // a DIFFERENT body and a no-store directive. Accepting this would splice
+      // "WORLD" onto attempt 1's max-age=3600 headers and cache it for an hour.
+      res.writeHead(200, { 'content-length': '5', 'cache-control': 'no-store' })
+      res.end('WORLD')
+    } else {
+      // Reached only if the poisoned entry was NOT stored: a fresh origin fetch.
+      res.writeHead(200, { 'content-length': '5', 'cache-control': 'max-age=3600' })
+      res.end('hello')
+    }
+  })
+  t.teardown(server.close.bind(server))
+  server.listen(0)
+  await once(server, 'listening')
+
+  const url = `http://0.0.0.0:${server.address().port}`
+  const dispatcher = new undici.Agent()
+  t.teardown(() => dispatcher.close())
+
+  // First request: the unvalidated restart must be declined, not delivered.
+  const first = await request(url, { dispatcher, cache: true, retry: () => true })
+  await t.rejects(
+    first.body.text(),
+    /Response retry failed/,
+    'the unvalidated restart is declined instead of spliced',
+  )
+
+  // Second request: if the cache had been poisoned it would serve "WORLD" with
+  // max-age=3600 without hitting the origin. Instead it must miss and fetch the
+  // origin fresh.
+  const second = await request(url, { dispatcher, cache: true, retry: () => true })
+  const text = await second.body.text()
+
+  t.equal(text, 'hello', 'second request is served the fresh origin body, not the spliced one')
+  t.not(text, 'WORLD', 'attempt 2 body was never cached against attempt 1 headers')
+  t.equal(attempts, 3, 'initial + declined resume + a fresh origin fetch (no cache hit)')
+})

--- a/test/review-bugfixes-4-retry-resume-edge.js
+++ b/test/review-bugfixes-4-retry-resume-edge.js
@@ -14,20 +14,23 @@ import { compose, interceptors, request } from '../lib/index.js'
 // 2. Flat [name, value, ...] array request headers (legal for direct
 //    dispatch()/compose() users) must be normalized before the resume
 //    re-dispatch — not spread into garbage '0'/'1' header names.
-// 3. When a resume at pos 0 is answered with a full 200 (server ignored
-//    Range), the NEW response's etag/content-length must replace the stale
-//    resume metadata for any subsequent resume.
+// 3. A resume at pos 0 answered with a full 200 whose strong etag DIFFERS from
+//    the if-match the resume carried must be declined, not spliced: its body
+//    describes a different representation than the first-attempt headers that
+//    were already forwarded downstream (and, behind a cache, already stored)
+//    — see issue #69.
 // 4. When a resume attempt is answered with an unexpected status (e.g. 503),
 //    the surfaced error must describe THAT response — not only the stale
 //    error from the previous failure.
 // 5. A pos 0 resume with no usable etag (e.g. the server sent a weak etag,
-//    which is discarded) must not send an if-match header at all — a null
-//    etag would go on the wire as an invalid empty `if-match:` value.
-// 6. An if-match written by a PREVIOUS resume attempt must not leak into the
-//    next resume once #etag has been cleared (full-200 restart with a weak
-//    etag) — the re-dispatch spreads the reassigned opts.headers, so the
-//    stale validator persists unless it is deleted before the conditional
-//    re-set.
+//    which is discarded) sends no if-match — so a full-200 restart cannot be
+//    proven to match the already-forwarded headers and must be declined rather
+//    than spliced (issue #69). The resume request itself still omits if-match
+//    (a null etag would go on the wire as an invalid empty `if-match:` value).
+// 6. A full-200 restart that echoes the SAME strong etag as the resume's
+//    if-match is provably the same representation, so it is accepted and a
+//    subsequent failure resumes from where the restart left off, still
+//    validating against that etag.
 
 // ---------------------------------------------------------------------------
 // Bug 1: non-positive content-length + error between headers and complete.
@@ -183,37 +186,34 @@ test('retry: flat-array request headers are normalized on range resume re-dispat
 })
 
 // ---------------------------------------------------------------------------
-// Bug 3: full-200 restart of a resume must refresh #end/#etag from the NEW
-// response, so a second failure resumes against the new representation.
-// verify: false because the consumer intentionally receives more bytes than
-// the first response's content-length announced (the restart is longer).
+// Bug 3 (issue #69): a full-200 restart of a resume whose strong etag DIFFERS
+// from the if-match carried must be declined, not spliced. The first attempt's
+// headers were already forwarded downstream (and, behind a cache, used to build
+// the stored entry); splicing a body from a different representation onto them
+// would persist the first attempt's headers/cache-control/TTL/validators with
+// the second attempt's body.
 // ---------------------------------------------------------------------------
 
-test('retry: full-200 restart refreshes resume metadata (new etag/content-length)', async (t) => {
-  t.plan(4)
+test('retry: full-200 restart with a changed etag is declined, not spliced', async (t) => {
+  t.plan(3)
 
   let attempts = 0
   const server = createServer((req, res) => {
     attempts++
     if (attempts === 1) {
       // Headers only — no body bytes forwarded — then die, so the resume
-      // starts at pos 0.
+      // starts at pos 0 holding the strong etag "v1".
       res.writeHead(200, { 'content-length': '10', etag: '"v1"' })
       res.flushHeaders()
       setTimeout(() => res.destroy(), 50)
-    } else if (attempts === 2) {
-      t.equal(req.headers['if-match'], '"v1"', 'first resume validates against the old etag')
-      // Server ignores Range and restarts from scratch with a NEW etag and a
-      // NEW (longer) content-length, then dies mid-body.
-      res.writeHead(200, { 'content-length': '20', etag: '"v2"' })
-      res.write('AAAAA')
-      setTimeout(() => res.destroy(), 50)
     } else {
-      // The second resume must be based on the restarted response's metadata.
-      t.equal(req.headers['if-match'], '"v2"', 'second resume validates against the NEW etag')
-      t.equal(req.headers.range, 'bytes=5-19', 'second resume range uses the NEW content-length')
-      res.writeHead(206, { 'content-range': 'bytes 5-19/20', 'content-length': '15', etag: '"v2"' })
-      res.end('BBBBBBBBBBBBBBB')
+      t.equal(req.headers['if-match'], '"v1"', 'resume validates against the first etag')
+      // A compliant origin answers if-match against a CHANGED representation
+      // with 412; this one ignores it and restarts a full 200 with a DIFFERENT
+      // strong etag. Splicing that body onto the already-forwarded first-attempt
+      // headers must be declined.
+      res.writeHead(200, { 'content-length': '10', etag: '"v2"' })
+      res.end('helloworld')
     }
   })
   t.teardown(server.close.bind(server))
@@ -222,10 +222,13 @@ test('retry: full-200 restart refreshes resume metadata (new etag/content-length
 
   const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
     retry: () => true,
-    verify: false,
   })
-  const text = await body.text()
-  t.equal(text, 'AAAAA' + 'BBBBBBBBBBBBBBB', 'restarted body is forwarded seamlessly')
+  await t.rejects(
+    body.text(),
+    /Response retry failed/,
+    'the mismatched restart is declined instead of spliced',
+  )
+  t.equal(attempts, 2, 'initial attempt + one declined resume attempt')
 })
 
 // ---------------------------------------------------------------------------
@@ -272,13 +275,15 @@ test('retry: resume attempt answered with 503 surfaces the 503, not the stale pr
 })
 
 // ---------------------------------------------------------------------------
-// Bug 5: pos 0 resume without a usable etag must not send if-match.
-// A weak etag is discarded by the retry handler (not byte-comparable), so the
-// resume re-dispatch holds no etag — writing it unconditionally sends an
-// invalid empty `if-match:` header on the wire.
+// Bug 5 (issue #69): a pos 0 resume without a usable etag sends no if-match, so
+// a full-200 restart cannot be proven to be the same representation as the
+// already-forwarded headers — it must be declined rather than spliced. The
+// resume request itself still omits if-match (a weak etag is discarded by the
+// retry handler, and a null etag would go on the wire as an invalid empty
+// `if-match:` value).
 // ---------------------------------------------------------------------------
 
-test('retry: pos 0 resume without a usable etag omits the if-match header', async (t) => {
+test('retry: pos 0 restart without a usable etag is declined (and sends no if-match)', async (t) => {
   t.plan(4)
 
   let attempts = 0
@@ -291,8 +296,10 @@ test('retry: pos 0 resume without a usable etag omits the if-match header', asyn
       res.flushHeaders()
       setTimeout(() => res.destroy(), 50)
     } else {
-      t.notOk('if-match' in req.headers, 'no if-match header on the wire')
+      t.notOk('if-match' in req.headers, 'no if-match header on the wire (nothing to validate)')
       t.equal(req.headers.range, 'bytes=0-4', 'resume still requests the full range')
+      // No validator was sent, so this full 200 cannot be proven to match the
+      // already-forwarded first-attempt headers — it must be declined.
       res.writeHead(200, { 'content-length': '5' })
       res.end('hello')
     }
@@ -304,20 +311,22 @@ test('retry: pos 0 resume without a usable etag omits the if-match header', asyn
   const { body } = await request(`http://0.0.0.0:${server.address().port}`, {
     retry: () => true,
   })
-  const text = await body.text()
-  t.equal(text, 'hello', 'body delivered after the etag-less pos 0 resume')
-  t.equal(attempts, 2, 'initial attempt + one resume attempt')
+  await t.rejects(
+    body.text(),
+    /Response retry failed/,
+    'the unvalidated restart is declined instead of spliced',
+  )
+  t.equal(attempts, 2, 'initial attempt + one declined resume attempt')
 })
 
 // ---------------------------------------------------------------------------
-// Bug 6: a stale if-match from a previous resume attempt must not leak into
-// the next resume after #etag was cleared. The resume re-dispatch REASSIGNS
-// this.#opts with the if-match merged into headers; the next resume spreads
-// those headers, so the old validator survives unless deleted before the
-// conditional re-set.
+// Bug 6 (issue #69): a full-200 restart that echoes the SAME strong etag as the
+// resume's if-match is provably the same representation, so it is accepted; a
+// subsequent failure then resumes from where the restart left off, still
+// validating against that etag.
 // ---------------------------------------------------------------------------
 
-test('retry: stale if-match from a previous resume is not sent once the etag is cleared', async (t) => {
+test('retry: full-200 restart echoing the same strong etag is accepted and resumes', async (t) => {
   t.plan(5)
 
   let attempts = 0
@@ -331,18 +340,18 @@ test('retry: stale if-match from a previous resume is not sent once the etag is 
       setTimeout(() => res.destroy(), 50)
     } else if (attempts === 2) {
       t.equal(req.headers['if-match'], '"v1"', 'first resume validates against the held etag')
-      // Full-200 restart with a WEAK etag → the retry handler clears #etag.
-      // Die again before any body byte, forcing a second pos 0 resume.
-      res.writeHead(200, { 'content-length': '10', etag: 'W/"v2"' })
-      res.flushHeaders()
+      // Server ignored Range and restarted the full 200, but echoes the SAME
+      // strong etag → provably the same representation, so the restart is
+      // accepted. Forward a few bytes then die, forcing a second resume that
+      // must continue from the restart offset.
+      res.writeHead(200, { 'content-length': '10', etag: '"v1"' })
+      res.write('hello')
       setTimeout(() => res.destroy(), 50)
     } else {
-      // No usable etag is held any more — the stale "v1" validator from the
-      // first resume must NOT be replayed on the wire.
-      t.notOk('if-match' in req.headers, 'stale if-match is not carried into the second resume')
-      t.equal(req.headers.range, 'bytes=0-9', 'second resume still requests the full range')
-      res.writeHead(200, { 'content-length': '10' })
-      res.end('helloworld')
+      t.equal(req.headers['if-match'], '"v1"', 'second resume still validates against "v1"')
+      t.equal(req.headers.range, 'bytes=5-9', 'second resume continues from the restart offset')
+      res.writeHead(206, { 'content-range': 'bytes 5-9/10', 'content-length': '5', etag: '"v1"' })
+      res.end('world')
     }
   })
   t.teardown(server.close.bind(server))
@@ -353,6 +362,6 @@ test('retry: stale if-match from a previous resume is not sent once the etag is 
     retry: () => true,
   })
   const text = await body.text()
-  t.equal(text, 'helloworld', 'body delivered after the second resume')
+  t.equal(text, 'helloworld', 'the accepted restart body is forwarded seamlessly')
   t.equal(attempts, 3, 'initial attempt + two resume attempts')
 })


### PR DESCRIPTION
Fixes #69.

## Problem

When a cacheable `200` delivers its headers but the connection dies before any body byte, `responseRetry` resumes with `range: bytes=0-`. Because `#headersSent` is already true, `onConnect` is not re-driven ([response-retry.js](../blob/main/lib/interceptor/response-retry.js#L185-L207)), so a `CacheHandler` downstream never resets its entry — it keeps buffering against **attempt 1's headers**.

The `pos=0` restart branch then accepted a full `200` from attempt 2 without forwarding its headers upstream, and — when attempt 1 had no strong etag — without any `if-match` on the wire (`this.#pos && !this.#etag` is falsy at pos 0). Attempt 2's **body** got spliced onto attempt 1's headers, `cache-control`/TTL, `Date` and validators. A cache then replayed that splice to every client for attempt 1's freshness lifetime, ignoring attempt 2's own (possibly shorter or `no-store`) caching.

## Fix

A resume splice onto already-forwarded headers is only sound when the response is provably the **same representation**. The one proof is a strong-etag `if-match` the resume carried: a compliant origin answers a changed representation with `412`, so a `2xx` must echo that same strong etag. Require it — otherwise decline via the existing `#maybeError` path.

At `pos > 0` the resume guard already guarantees a strong `#etag`, so this only tightens the `pos 0` / full-`200` restart case.

## Behavior change

- A `pos=0` full-`200` restart with **no usable etag** (attempt 1 had none / weak) is now **declined** instead of spliced+served.
- A restart whose **strong etag differs** from the `if-match` sent is **declined**.
- A restart that **echoes the same strong etag** is still accepted and resumes normally.

## Tests

- Reworked the three restart cases in `test/review-bugfixes-4-retry-resume-edge.js` (Bugs 3/5/6) to assert the new safe behavior.
- Added `test/issue-69-retry-restart-cache-poisoning.js`: an end-to-end regression through the default chain (cache outside retry) proving the unvalidated restart is declined and never stored, so a later request fetches the origin fresh rather than being served attempt 2's body against attempt 1's `max-age`.

All retry + cache suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)