### PR TITLE
feat(cache): normalize equivalent target URIs in the cache key (#73)

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -13,7 +13,7 @@ import { conditionalHeaders, weakMatch } from './headers.js'
 import { InvalidationHandler } from './invalidation-handler.js'
 import { RevalidationHandler, backgroundRefresh, fastFailoverRetry } from './revalidation.js'
 import { serveFromCache, traceLookup } from './serve.js'
-import { cacheOptsOf, getStore, makeKey, tryGetEntry } from './store.js'
+import { cacheOptsOf, getStore, makeKey, normalizeOrigin, tryGetEntry } from './store.js'
 
 /**
  * Validates the optional `origins` whitelist (undici PR #4739): undefined (the
@@ -39,12 +39,20 @@ function assertCacheOrigins(origins, name) {
  * Whether the request origin is permitted by the whitelist. String entries
  * match the whole origin case-insensitively; RegExp entries are tested against
  * it. An empty array matches nothing (caches no origin).
+ *
+ * The origin is canonicalized (normalizeOrigin — RFC 9110 §4.2.3) before both
+ * comparisons, mirroring makeKey: without this, a request that keys identically
+ * to an allowed one (e.g. `new URL('https://example.com')` -> `.../` , or the
+ * default-port `https://example.com:443`) could still be judged "not allowed"
+ * and bypass the cache — policy gating and keying MUST share one equivalence
+ * class. String entries are normalized too so a whitelisted `:443`/URL-object
+ * spelling matches; RegExps test against the canonical form.
  */
 function originAllowed(origin, origins) {
-  const requestOrigin = `${origin}`.toLowerCase()
+  const requestOrigin = normalizeOrigin(`${origin}`).toLowerCase()
   for (const allowed of origins) {
     if (typeof allowed === 'string') {
-      if (allowed.toLowerCase() === requestOrigin) {
+      if (normalizeOrigin(allowed).toLowerCase() === requestOrigin) {
         return true
       }
     } else {

--- a/lib/interceptor/cache/store.js
+++ b/lib/interceptor/cache/store.js
@@ -30,17 +30,22 @@ export function getStore(opts) {
  * there rather than collapsing distinct origins onto the literal string
  * `'null'`. Applied once in makeKey so the get and set paths key identically
  * (and traceUrl, fed the key, tags the canonical origin too).
+ *
+ * Always returns a string: the input is coerced up front so the fallback path
+ * (unparseable / opaque origin) can't hand a URL object or other non-string
+ * back to callers doing string operations on the result.
  */
 export function normalizeOrigin(origin) {
+  const raw = String(origin)
   try {
-    const normalized = new URL(origin).origin
+    const normalized = new URL(raw).origin
     if (normalized && normalized !== 'null') {
       return normalized
     }
   } catch {
     // Not a parseable absolute URL — key on the caller's value verbatim.
   }
-  return origin
+  return raw
 }
 
 export function tryGetEntry(store, key, logger) {

--- a/lib/interceptor/cache/store.js
+++ b/lib/interceptor/cache/store.js
@@ -31,7 +31,7 @@ export function getStore(opts) {
  * `'null'`. Applied once in makeKey so the get and set paths key identically
  * (and traceUrl, fed the key, tags the canonical origin too).
  */
-function normalizeOrigin(origin) {
+export function normalizeOrigin(origin) {
   try {
     const normalized = new URL(origin).origin
     if (normalized && normalized !== 'null') {

--- a/lib/interceptor/cache/store.js
+++ b/lib/interceptor/cache/store.js
@@ -12,6 +12,37 @@ export function getStore(opts) {
   return opts.cache.store ?? (DEFAULT_STORE ??= new SqliteCacheStore({ location: ':memory:' }))
 }
 
+/**
+ * RFC 9110 §4.2.3 origin normalization: equivalent target URIs must share one
+ * cache key. `makeCacheKey` stringifies `opts.origin` verbatim, so the SAME
+ * logical origin fragments into distinct entries — costing hits and duplicating
+ * storage — when callers vary the scheme/host case, spell out the default port,
+ * or pass a URL object (whose `toString()` appends a trailing `/`) vs a bare
+ * string:
+ *
+ *   https://example.com  ==  https://example.com:443  ==  HTTPS://EXAMPLE.COM
+ *   new URL('https://example.com')  ->  'https://example.com/'
+ *
+ * `URL#origin` collapses all of these: it lowercases the scheme and host and
+ * elides the scheme's default port, yielding a canonical `scheme://host[:port]`
+ * with no trailing slash or userinfo. Non-special schemes (and anything
+ * unparseable) expose a `'null'` opaque origin — keep the caller's raw value
+ * there rather than collapsing distinct origins onto the literal string
+ * `'null'`. Applied once in makeKey so the get and set paths key identically
+ * (and traceUrl, fed the key, tags the canonical origin too).
+ */
+function normalizeOrigin(origin) {
+  try {
+    const normalized = new URL(origin).origin
+    if (normalized && normalized !== 'null') {
+      return normalized
+    }
+  } catch {
+    // Not a parseable absolute URL — key on the caller's value verbatim.
+  }
+  return origin
+}
+
 export function tryGetEntry(store, key, logger) {
   try {
     return store.get(key)
@@ -56,6 +87,14 @@ export function makeKey(opts) {
       ? { ...opts, headers: parseHeaders(opts.headers, Object.create(null)) }
       : opts,
   )
+
+  // Canonicalize equivalent target URIs onto one key (RFC 9110 §4.2.3): scheme
+  // /host case and default ports must not fragment the cache. `key.origin` is
+  // the stringified origin makeCacheKey produced, so this normalizes both the
+  // get and set paths identically.
+  if (typeof key.origin === 'string') {
+    key.origin = normalizeOrigin(key.origin)
+  }
 
   // makeCacheKey preserves request header names verbatim. Vary selector names
   // are lowercased (in CacheHandler and matchesValue), so lowercase the key's

--- a/test/cache-coverage-interceptor.js
+++ b/test/cache-coverage-interceptor.js
@@ -734,14 +734,22 @@ test('cache: makeKey canonicalizes equivalent origins onto one key', async (t) =
     'https://Example.Com:443',
     new URL('https://example.com'),
   ]
+  // One shared store for every variant: fragmentation is a property of the
+  // WHOLE key (origin + method + path + headers), not just the origin, so
+  // strictSame every produced key against the first — a mismatch in any field
+  // is what splits equivalent URIs into separate entries.
+  const store = makeRecordingStore()
   for (const origin of equivalents) {
-    const store = makeRecordingStore()
     driveOrigin(origin, store)
-    t.equal(store.sets.length, 1, `entry stored for ${origin}`)
-    t.equal(
-      store.sets[0].key.origin,
-      'https://example.com',
-      `origin ${origin} normalized to https://example.com`,
+  }
+  t.equal(store.sets.length, equivalents.length, 'every variant produced a store set')
+  const first = store.sets[0].key
+  t.equal(first.origin, 'https://example.com', 'origin normalized to https://example.com')
+  for (let i = 1; i < store.sets.length; i++) {
+    t.strictSame(
+      store.sets[i].key,
+      first,
+      `key for ${equivalents[i]} is identical to ${equivalents[0]}`,
     )
   }
 })

--- a/test/cache-coverage-interceptor.js
+++ b/test/cache-coverage-interceptor.js
@@ -706,6 +706,61 @@ test('cache: opts.query with an empty path folds onto "/"', async (t) => {
 })
 
 // ---------------------------------------------------------------------------
+// makeKey: origin normalization (RFC 9110 §4.2.3)
+// ---------------------------------------------------------------------------
+
+// Fake dispatch that always "misses" through to a recording store, so the
+// stored key.origin exposes exactly what makeKey canonicalized on both the get
+// (store.get) and set (store.set) paths — they share one makeKey, so equal set
+// keys imply equal get keys.
+function driveOrigin(origin, store) {
+  const wrapped = interceptors.cache()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'cache-control': 'max-age=60' }, () => {})
+    handler.onData(Buffer.from('x'))
+    handler.onComplete(null)
+    return true
+  })
+  wrapped({ origin, path: '/', method: 'GET', headers: {}, cache: { store } }, makeInnerHandler())
+}
+
+test('cache: makeKey canonicalizes equivalent origins onto one key', async (t) => {
+  // Every spelling of the same target URI must key identically: default port
+  // spelled out, scheme/host case, and a URL object (toString appends "/").
+  const equivalents = [
+    'https://example.com',
+    'https://example.com:443',
+    'HTTPS://EXAMPLE.COM',
+    'https://Example.Com:443',
+    new URL('https://example.com'),
+  ]
+  for (const origin of equivalents) {
+    const store = makeRecordingStore()
+    driveOrigin(origin, store)
+    t.equal(store.sets.length, 1, `entry stored for ${origin}`)
+    t.equal(
+      store.sets[0].key.origin,
+      'https://example.com',
+      `origin ${origin} normalized to https://example.com`,
+    )
+  }
+})
+
+test('cache: makeKey preserves non-default ports and distinct hosts', async (t) => {
+  const cases = [
+    ['https://example.com:8443', 'https://example.com:8443'],
+    ['http://example.com:8080', 'http://example.com:8080'],
+    // http default port elided, but https on the same host stays distinct.
+    ['http://example.com:80', 'http://example.com'],
+  ]
+  for (const [origin, expected] of cases) {
+    const store = makeRecordingStore()
+    driveOrigin(origin, store)
+    t.equal(store.sets[0].key.origin, expected, `${origin} -> ${expected}`)
+  }
+})
+
+// ---------------------------------------------------------------------------
 // Trace-gated read-path branches
 // ---------------------------------------------------------------------------
 

--- a/test/cache-coverage-interceptor.js
+++ b/test/cache-coverage-interceptor.js
@@ -760,12 +760,21 @@ test('cache: makeKey preserves non-default ports and distinct hosts', async (t) 
     ['http://example.com:8080', 'http://example.com:8080'],
     // http default port elided, but https on the same host stays distinct.
     ['http://example.com:80', 'http://example.com'],
+    // Distinct hosts must not collapse onto one key.
+    ['https://other.example.com', 'https://other.example.com'],
   ]
   for (const [origin, expected] of cases) {
     const store = makeRecordingStore()
     driveOrigin(origin, store)
     t.equal(store.sets[0].key.origin, expected, `${origin} -> ${expected}`)
   }
+
+  // Two different hosts produce two different keys (no fragmentation is fine;
+  // COLLISION would be a poisoning bug).
+  const store = makeRecordingStore()
+  driveOrigin('https://a.example.com', store)
+  driveOrigin('https://b.example.com', store)
+  t.not(store.sets[0].key.origin, store.sets[1].key.origin, 'distinct hosts key distinctly')
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`makeKey` stringified `opts.origin` verbatim, so equivalent target URIs (RFC 9110 §4.2.3) fragmented into distinct cache entries — costing avoidable misses (hit-rate loss) and duplicating storage:

- `https://example.com` vs `https://example.com:443` vs `HTTPS://EXAMPLE.COM`
- object-vs-string origin call shapes that stringify differently (`new URL('https://example.com')` → `'https://example.com/'`)

This canonicalizes `key.origin` **once** in `makeKey` via `URL#origin`, which lowercases the scheme/host and elides the scheme's default port, yielding a canonical `scheme://host[:port]` with no trailing slash or userinfo.

## Details

- Applied on the single shared key builder, so the **get and set** paths key identically (the invariant the issue flagged).
- `traceUrl` is fed the key, so the `url` trace tag tags the canonical origin in lockstep — no divergence between cache docs and `undici:request` docs.
- Non-special / unparseable origins expose a `'null'` opaque origin; these fall back to the caller's raw value rather than collapsing distinct origins onto the literal string `'null'`.
- Non-default ports (`:8443`, `:8080`) and cross-scheme hosts stay distinct.

## Tests

Added to `test/cache-coverage-interceptor.js`:
- equivalent spellings (default port, scheme/host case, URL object) all canonicalize onto `https://example.com`
- non-default ports and `http` default-port elision preserved as distinct keys

Full `cache-coverage-interceptor.js` (127) and `trace-cache.js` (85) suites pass.

Fixes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)