### PR TITLE
fix(cache): honor a matching validator in a multi-line If-None-Match

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -228,16 +228,19 @@ export default ({ origins } = {}) => {
     // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
     // where the caller's own validators do the validation (a 304 flows through
     // to the caller; a 200 replacement is stored by CacheHandler).
-    // typeof guards: duplicated conditional headers arrive as arrays — treat
-    // them as non-matching and serve the stored representation rather than
-    // crashing.
+    // Duplicated conditional headers arrive as arrays. RFC 9110 §5.3: multiple
+    // field lines of the same name are equivalent to one comma-joined value, so
+    // an If-None-Match spread across lines is joined before matching (weakMatch
+    // already splits on commas) — a matching validator still yields a 304
+    // rather than falling through to the full 200. A duplicated If-Modified-Since
+    // is malformed (it is a single-value field), so a non-string value is left
+    // to fall through and serve the stored 200 ("proceed as normal").
     const servableFromCache = entry != null && fresh && !mustRevalidate
     if (servableFromCache && headers['if-none-match']) {
-      if (
-        typeof headers['if-none-match'] === 'string' &&
-        entry.etag &&
-        weakMatch(headers['if-none-match'], entry.etag)
-      ) {
+      const ifNoneMatch = Array.isArray(headers['if-none-match'])
+        ? headers['if-none-match'].join(',')
+        : headers['if-none-match']
+      if (typeof ifNoneMatch === 'string' && entry.etag && weakMatch(ifNoneMatch, entry.etag)) {
         return serveFromCache(
           { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
           opts,

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -2151,6 +2151,43 @@ test('cache: If-None-Match with wildcard * returns 304', async (t) => {
   t.equal(result.statusCode, 304, 'wildcard If-None-Match returns 304')
 })
 
+test('cache: multi-line If-None-Match with a matching etag returns 304', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60',
+      'content-type': 'text/plain',
+      etag: '"abc123"',
+    })
+    res.end('ok')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, base)
+
+  // Duplicated If-None-Match lines arrive as an array. RFC 9110 §5.3: they are
+  // equivalent to one comma-joined list, so a matching validator among them
+  // still yields a 304 rather than serving the full 200.
+  const result = await rawRequestWithBody(dispatch, {
+    ...base,
+    headers: { 'if-none-match': ['"other"', '"abc123"'] },
+  })
+  t.equal(result.statusCode, 304, 'matching etag among multiple lines returns 304')
+  t.equal(hits, 1, 'origin not contacted')
+})
+
 test('cache: If-Modified-Since returns 304 when resource not modified', async (t) => {
   t.plan(2)
   let hits = 0


### PR DESCRIPTION
## Summary

Follow-up to #78 (already merged), addressing a valid Copilot finding against `main`.

When #78 introduced "serve the stored fresh 200 on a non-matching conditional" ([#68](https://github.com/nxtedition/nxt-undici/issues/68)), a duplicated `If-None-Match` — which arrives as an **array** — would fall through and serve the full 200 even when one of the header lines **matched** the stored etag.

Per RFC 9110 §5.3, multiple field lines of the same name are equivalent to a single comma-joined value, and `weakMatch` already splits on commas. So the array is now joined before matching — a matching validator among the lines correctly yields a `304` again.

A duplicated `If-Modified-Since` is malformed (single-value field); per RFC the recipient should ignore it and proceed as normal, so it is left to fall through and serve the stored 200.

## Changes

- `lib/interceptor/cache/index.js`: normalize an array-valued `If-None-Match` to a comma-joined string before `weakMatch`.
- `test/cache-advanced.js`: regression test — a multi-line `If-None-Match` containing the matching etag returns `304` and does not contact the origin.

## Verification

`test/cache-advanced.js`: 94 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)