### PR TITLE
fix(cache): restore lost multi-line If-None-Match fix and align stale tests (follow-up to #78)

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -228,16 +228,19 @@ export default ({ origins } = {}) => {
     // 9111 §4.3.2. Stale + caller conditionals forward to the origin below,
     // where the caller's own validators do the validation (a 304 flows through
     // to the caller; a 200 replacement is stored by CacheHandler).
-    // typeof guards: duplicated conditional headers arrive as arrays — treat
-    // them as non-matching and serve the stored representation rather than
-    // crashing.
+    // Duplicated conditional headers arrive as arrays. RFC 9110 §5.3: multiple
+    // field lines of the same name are equivalent to one comma-joined value, so
+    // an If-None-Match spread across lines is joined before matching (weakMatch
+    // already splits on commas) — a matching validator still yields a 304
+    // rather than falling through to the full 200. A duplicated If-Modified-Since
+    // is malformed (it is a single-value field), so a non-string value is left
+    // to fall through and serve the stored 200 ("proceed as normal").
     const servableFromCache = entry != null && fresh && !mustRevalidate
     if (servableFromCache && headers['if-none-match']) {
-      if (
-        typeof headers['if-none-match'] === 'string' &&
-        entry.etag &&
-        weakMatch(headers['if-none-match'], entry.etag)
-      ) {
+      const ifNoneMatch = Array.isArray(headers['if-none-match'])
+        ? headers['if-none-match'].join(',')
+        : headers['if-none-match']
+      if (typeof ifNoneMatch === 'string' && entry.etag && weakMatch(ifNoneMatch, entry.etag)) {
         return serveFromCache(
           { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
           opts,

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -2151,6 +2151,43 @@ test('cache: If-None-Match with wildcard * returns 304', async (t) => {
   t.equal(result.statusCode, 304, 'wildcard If-None-Match returns 304')
 })
 
+test('cache: multi-line If-None-Match with a matching etag returns 304', async (t) => {
+  t.plan(2)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, {
+      'cache-control': 's-maxage=60',
+      'content-type': 'text/plain',
+      etag: '"abc123"',
+    })
+    res.end('ok')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, base)
+
+  // Duplicated If-None-Match lines arrive as an array. RFC 9110 §5.3: they are
+  // equivalent to one comma-joined list, so a matching validator among them
+  // still yields a 304 rather than serving the full 200.
+  const result = await rawRequestWithBody(dispatch, {
+    ...base,
+    headers: { 'if-none-match': ['"other"', '"abc123"'] },
+  })
+  t.equal(result.statusCode, 304, 'matching etag among multiple lines returns 304')
+  t.equal(hits, 1, 'origin not contacted')
+})
+
 test('cache: If-Modified-Since returns 304 when resource not modified', async (t) => {
   t.plan(2)
   let hits = 0

--- a/test/review-bugfixes-4-cache-header-case.js
+++ b/test/review-bugfixes-4-cache-header-case.js
@@ -121,8 +121,9 @@ test('cache: capitalized Cache-Control: no-store prevents storing the response',
 
 // ---------------------------------------------------------------------------
 // A capitalized If-None-Match must be evaluated against the cached etag, same
-// as the lowercase form: matching etag → 304 from cache, non-matching etag →
-// bypass to origin.
+// as the lowercase form: matching etag → 304 from cache, non-matching etag on
+// a fresh entry → serve the stored 200 from cache (RFC 9110 §13.1.2 "proceed
+// as normal"; the entry is fresh, so no origin round-trip is needed — see #68).
 // ---------------------------------------------------------------------------
 
 test('cache: capitalized If-None-Match behaves like lowercase', async (t) => {
@@ -157,10 +158,15 @@ test('cache: capitalized If-None-Match behaves like lowercase', async (t) => {
   t.equal(matched.statusCode, 304, 'matching If-None-Match yields 304')
   t.equal(hits, 1, '304 is served from cache without contacting origin')
 
-  // Non-matching etag → bypass to origin.
+  // Non-matching etag on a fresh entry → serve the stored 200 from cache,
+  // no origin hit (RFC 9110 §13.1.2 "proceed as normal", see #68).
   const missed = await rawRequest(dispatch, { ...base, headers: { 'If-None-Match': '"other"' } })
   t.equal(missed.statusCode, 200, 'non-matching If-None-Match yields the full response')
-  t.equal(hits, 2, 'non-matching If-None-Match bypasses the cache to origin')
+  t.equal(
+    hits,
+    1,
+    'non-matching If-None-Match serves the fresh stored 200 without contacting origin',
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -335,11 +335,15 @@ test('cache: HEAD response with Content-Range is not cached and emits no error l
 
 // ---------------------------------------------------------------------------
 // Duplicated conditional headers arrive as arrays; the old code called
-// String.prototype.split on them and threw synchronously inside dispatch.
+// String.prototype.split on them and threw synchronously inside dispatch. Per
+// RFC 9110 §5.3 multiple field lines are equivalent to one comma-joined value,
+// so the array is joined before matching (see #68): a matching validator among
+// the lines yields a 304, and a non-matching list falls through to the stored
+// fresh 200 — neither crashes, neither contacts the origin.
 // ---------------------------------------------------------------------------
 
-test('cache: If-None-Match as array does not crash and bypasses to origin', async (t) => {
-  t.plan(3)
+test('cache: If-None-Match as array is treated as one list, does not crash', async (t) => {
+  t.plan(5)
   let hits = 0
   const server = await startServer((req, res) => {
     hits++
@@ -360,12 +364,21 @@ test('cache: If-None-Match as array does not crash and bypasses to origin', asyn
   await rawRequest(dispatch, { ...base, headers: {} })
   t.equal(hits, 1)
 
-  const res = await rawRequest(dispatch, {
+  // A matching validator among the array lines yields a 304 from cache.
+  const matched = await rawRequest(dispatch, {
     ...base,
     headers: { 'if-none-match': ['"abc"', '"def"'] },
   })
-  t.equal(res.statusCode, 200, 'array conditional bypasses to origin instead of throwing')
-  t.equal(hits, 2)
+  t.equal(matched.statusCode, 304, 'matching etag among multiple lines returns 304')
+  t.equal(hits, 1, 'matching array validator is served from cache without contacting origin')
+
+  // A non-matching array on a fresh entry falls through to the stored 200.
+  const missed = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'if-none-match': ['"nope"', '"def"'] },
+  })
+  t.equal(missed.statusCode, 200, 'non-matching array serves the fresh stored 200')
+  t.equal(hits, 1, 'non-matching array does not contact the origin')
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #78 (merged). Two things regressed on `main` after that merge:

1. **A committed fix never reached `main`.** The multi-line `If-None-Match`
   normalization (commit `511e3ec`, made in response to Copilot's review on #78)
   was pushed to the PR branch *after* the merge, so it was lost. Without it, a
   duplicated `If-None-Match` header (which arrives as an array) fails the
   `typeof === 'string'` guard and falls through to the full `200` even when one
   of the lines matches the stored etag — instead of the `304` it should return.

2. **Two regression tests still assert the pre-#78 behavior** and now fail
   deterministically on `main` (not the parallel-run flakiness seen elsewhere):
   - `test/review-bugfixes-4-cache-header-case.js` expected a non-matching
     `If-None-Match` on a fresh entry to increment origin hits 1 → 2.
   - `test/review-bugfixes-cache-2.js` expected an array-valued `If-None-Match`
     to bypass to the origin.

   Both now serve the fresh stored `200` (or a `304`) with a single origin hit,
   consistent with #78's intentional RFC 9110 §13.1.2/§13.1.3 fall-through.

## Changes

- **`lib/interceptor/cache/index.js`** (restored from `511e3ec`): join a
  duplicated (array) `If-None-Match` into one comma value before matching per
  RFC 9110 §5.3 (`weakMatch` already splits on commas), so a matching validator
  among the lines yields a `304`. A duplicated `If-Modified-Since` is malformed
  (single-value field) and continues to fall through to the stored `200`.
- **`test/cache-advanced.js`** (restored from `511e3ec`): regression test for a
  matching etag in a multi-line `If-None-Match` returning `304`.
- **`test/review-bugfixes-4-cache-header-case.js`**: non-matching `If-None-Match`
  on a fresh entry now asserts the stored `200` with one origin hit.
- **`test/review-bugfixes-cache-2.js`**: reworked the array case into a
  list-aware test — a matching validator among the lines returns `304`, a
  non-matching list falls through to the stored `200`, neither contacts origin.

## Verification

Passing in isolation: `review-bugfixes-4-cache-header-case` (12),
`review-bugfixes-cache-2` (25), `cache-advanced` (94), `cache-revalidation`
(110), `trace-cache` (85), `cache-fuzz` (4), `cache-coverage-interceptor` (114),
`cache-storability` (63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)