### PR TITLE
feat(cache): trace background SWR refresh store writes (#75)

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -383,7 +383,10 @@ export default ({ origins } = {}) => {
         // it, and the background refresh's sole effect is to write the store —
         // so skip it entirely (issuing a fetch we couldn't store is pure waste).
         if (!requestCacheControl['no-store']) {
-          backgroundRefresh(dispatch, opts, key, store, entry)
+          // Thread the trace context (write/url captured once above) so the
+          // refresh's store writes emit `undici:cache-store` docs; the stale
+          // serve just above already emitted this dispatch's lookup doc.
+          backgroundRefresh(dispatch, opts, key, store, entry, write, url)
         }
       }
       return

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -1,4 +1,5 @@
 import { parseCacheControl } from '../../utils.js'
+import { traceSafe, traceErr } from '../../trace.js'
 import { isHopByHop } from '../proxy.js'
 import { CacheHandler } from './cache-handler.js'
 import {
@@ -75,6 +76,7 @@ export class RevalidationHandler {
   #id
   #url
   #lookupMs
+  #background
   /** @type {null | 'pass' | 'validated' | 'stale'} */
   #mode = null
   /** @type {CacheHandler | import('../../utils.js').DecoratorHandler | object | null} */
@@ -91,7 +93,19 @@ export class RevalidationHandler {
     key,
     entry,
     opts,
-    { store, logger, handler, allowStaleOnError, noStore, cacheOpts, write, id, url, lookupMs },
+    {
+      store,
+      logger,
+      handler,
+      allowStaleOnError,
+      noStore,
+      cacheOpts,
+      write,
+      id,
+      url,
+      lookupMs,
+      background,
+    },
   ) {
     this.#key = key
     this.#entry = entry
@@ -102,13 +116,46 @@ export class RevalidationHandler {
     this.#userHandler = handler
     this.#allowStaleOnError = allowStaleOnError
     this.#noStore = noStore ?? false
-    // Trace context (null when tracing is off / for background refresh): the
-    // eventual serveFromCache and pass-mode CacheHandler emit their docs with
-    // it, so a synchronous revalidation traces like any other lookup/store.
+    // Trace context (null when tracing is off): the eventual serveFromCache and
+    // pass-mode CacheHandler emit their docs with it, so a synchronous
+    // revalidation traces like any other lookup/store.
     this.#write = write ?? null
     this.#id = id ?? null
     this.#url = url ?? null
     this.#lookupMs = lookupMs ?? null
+    // A background stale-while-revalidate refresh (RFC 5861 §3): the triggering
+    // dispatch already emitted its `undici:cache` lookup doc at the stale serve,
+    // so this refresh emits only `undici:cache-store` docs for its store writes
+    // (freshen / replacement) and suppresses lookup docs — a second lookup doc
+    // sharing the triggering id would double-count the hit.
+    this.#background = background ?? false
+  }
+
+  // The `undici:cache-store` emitter for the freshen store write — the same
+  // shape and op CacheHandler uses for the pass-mode replacement, so a 304
+  // refresh is as visible as a full replacement. `err` is the raw store error
+  // (or null); tagging is deferred so no string work happens with tracing off.
+  #traceStore(statusCode, stored, sizeBytes, ttlSec, err) {
+    if (this.#write !== null) {
+      traceSafe(
+        this.#write,
+        {
+          id: this.#id,
+          method: this.#key.method ?? null,
+          url: this.#url,
+          statusCode,
+          stored,
+          // A freshen re-store is never declined by a storability gate (the
+          // stored entry already passed them); reason stays null like a
+          // successful CacheHandler store.
+          reason: null,
+          sizeBytes,
+          ttlSec,
+          err: err != null ? traceErr(err) : null,
+        },
+        'undici:cache-store',
+      )
+    }
   }
 
   onConnect(abort) {
@@ -160,8 +207,9 @@ export class RevalidationHandler {
     // the stored entry did not survive validation — a miss. It must be
     // emitted here because delivery routes through the CacheHandler (or the
     // raw user handler under request no-store), neither of which emits a
-    // lookup doc — only #deliver's serveFromCache terminals do.
-    if (this.#write !== null) {
+    // lookup doc — only #deliver's serveFromCache terminals do. Suppressed for
+    // a background refresh, whose lookup was already recorded at the stale serve.
+    if (this.#write !== null && !this.#background) {
       traceLookup(
         this.#write,
         this.#opts,
@@ -237,8 +285,9 @@ export class RevalidationHandler {
     if (this.#userAborted) {
       // Terminal without a serveFromCache: emit the dispatch's lookup doc
       // here so revalidation outcomes never vanish from the undici:cache
-      // stream (one lookup doc per dispatch).
-      if (this.#write !== null) {
+      // stream (one lookup doc per dispatch). Suppressed for a background
+      // refresh (its lookup was recorded at the stale serve).
+      if (this.#write !== null && !this.#background) {
         traceLookup(
           this.#write,
           this.#opts,
@@ -257,7 +306,10 @@ export class RevalidationHandler {
         entry,
         this.#opts,
         this.#userHandler,
-        this.#write,
+        // A background refresh emits no lookup doc; the freshen store write is
+        // traced by #freshen's own #traceStore, so serveFromCache's delivery to
+        // the silent handler must not add one here.
+        this.#background ? null : this.#write,
         this.#url,
         this.#lookupMs,
         'hit',
@@ -277,8 +329,9 @@ export class RevalidationHandler {
       // the outcome is visible. onError routes a user abort here too (the
       // abort is the probable cause of the error), so distinguish it from a
       // genuine origin/revalidation failure — matching the 'aborted' reason
-      // the #deliver abort arm uses.
-      if (this.#write !== null) {
+      // the #deliver abort arm uses. Suppressed for a background refresh (no
+      // lookup doc; a failed refresh stored nothing, so no store doc either).
+      if (this.#write !== null && !this.#background) {
         traceLookup(
           this.#write,
           this.#opts,
@@ -514,6 +567,7 @@ export class RevalidationHandler {
       // RFC 9111 §5.2.1.5: a request no-store forbids storing any part of
       // this request's response — serve the freshened value, don't write it.
       if (!this.#noStore) {
+        let storeErr = null
         try {
           // The store gets a private copy of the bytes: `freshened` is also
           // the entry delivered to the user handler, and a consumer mutating
@@ -524,12 +578,26 @@ export class RevalidationHandler {
             body: freshened.body ? Buffer.from(freshened.body) : freshened.body,
           })
         } catch (err) {
+          storeErr = err
           if (err.message === 'database is locked') {
             this.#logger?.debug({ err }, 'failed to freshen cache entry')
           } else {
             this.#logger?.error({ err }, 'failed to freshen cache entry')
           }
         }
+        // The 304-freshen store write's `undici:cache-store` doc — the
+        // counterpart to the pass-mode replacement's CacheHandler doc, so a
+        // refresh's store outcome is visible whether the origin answered 304 or
+        // with a full replacement (chiefly for background refreshes, which emit
+        // no lookup doc). `stored` reflects what actually happened: a throwing
+        // set() persisted nothing.
+        this.#traceStore(
+          freshened.statusCode,
+          storeErr == null,
+          freshened.body ? freshened.body.byteLength : 0,
+          Math.round((freshened.staleAt - freshened.cachedAt) / 1000),
+          storeErr,
+        )
       }
 
       return freshened
@@ -558,8 +626,14 @@ export function fastFailoverRetry(retry) {
  * Fire-and-forget background refresh for stale-while-revalidate (RFC 5861
  * §3): the caller was already served the stale entry; only the store observes
  * the outcome. Re-enters the dispatch chain below the cache interceptor.
+ *
+ * `write`/`url` are the triggering dispatch's trace context (both null when
+ * tracing is off), captured at serve time in index.js and threaded through so
+ * the refresh's store writes emit `undici:cache-store` docs carrying the
+ * triggering request's id (opts.id). Lookup docs are NOT re-emitted — the
+ * triggering dispatch already recorded its stale-while-revalidate hit.
  */
-export function backgroundRefresh(dispatch, opts, key, store, entry) {
+export function backgroundRefresh(dispatch, opts, key, store, entry, write = null, url = null) {
   let inflight = backgroundRefreshes.get(store)
   if (inflight == null) {
     inflight = new Set()
@@ -615,6 +689,10 @@ export function backgroundRefresh(dispatch, opts, key, store, entry) {
         allowStaleOnError: false,
         noStore: false,
         cacheOpts: cacheOptsOf(opts),
+        write,
+        id: opts.id ?? null,
+        url,
+        background: true,
       }),
     )
   } catch (err) {

--- a/test/trace-cache.js
+++ b/test/trace-cache.js
@@ -348,3 +348,204 @@ test('trace-cache: non-cacheable status emits a skipped cache-store doc (reason 
   t.equal(stores[0].stored, false)
   t.equal(stores[0].reason, 'status')
 })
+
+// ---------------------------------------------------------------------------
+// background stale-while-revalidate refresh: the stale serve emits the one
+// lookup doc; the fire-and-forget refresh emits the cache-store doc for its
+// store write, tagged with the triggering request's id — no second lookup doc.
+// ---------------------------------------------------------------------------
+
+const settle = () => new Promise((r) => setImmediate(r))
+
+// Poll for a condition with a bounded deadline so a never-firing background
+// refresh fails the test instead of hanging it.
+async function waitFor(predicate, { timeout = 2000, label = 'condition' } = {}) {
+  const deadline = Date.now() + timeout
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`)
+    }
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+
+function seedStale(store, origin, { directives, etag = '' } = {}) {
+  const now = Date.now()
+  const body = Buffer.from('stale-body')
+  const headers = { 'cache-control': 'max-age=5, stale-while-revalidate=600' }
+  if (etag) {
+    headers.etag = etag
+  }
+  store.set(
+    { origin, method: 'GET', path: '/', headers: {} },
+    {
+      body,
+      start: 0,
+      end: body.length,
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers,
+      cacheControlDirectives: directives ?? { 'max-age': 5, 'stale-while-revalidate': 600 },
+      etag,
+      vary: {},
+      cachedAt: now - 10e3,
+      staleAt: now - 5e3,
+      deleteAt: now + 3600e3,
+    },
+  )
+}
+
+test('trace-cache: background SWR refresh (replacement) emits a store doc, no extra lookup', async (t) => {
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
+    res.end('fresh-body')
+  })
+  t.teardown(server.close.bind(server))
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  seedStale(store, origin)
+  await settle()
+
+  const writer = makeWriter()
+  const res = await request(origin, {
+    trace: writer,
+    cache: { store },
+    dispatcher: makeDispatcher(t),
+  })
+  t.equal(await res.body.text(), 'stale-body', 'the stale entry is served immediately')
+
+  await waitFor(() => writer.docs.some((doc) => doc.op === 'undici:cache-store'), {
+    label: 'background refresh store doc',
+  })
+  t.equal(hits, 1, 'the background refresh contacted the origin')
+
+  const lookups = writer.docs.filter((doc) => doc.op === 'undici:cache')
+  t.equal(lookups.length, 1, 'only the stale serve emits a lookup doc — the refresh emits none')
+  t.equal(lookups[0].result, 'hit')
+  t.equal(lookups[0].reason, 'stale-while-revalidate')
+
+  const stores = writer.docs.filter((doc) => doc.op === 'undici:cache-store')
+  t.equal(stores.length, 1, 'the background refresh emits one store doc for the replacement')
+
+  const [stored] = stores
+  t.equal(stored.id, lookups[0].id, 'the store doc carries the triggering request id')
+  t.equal(stored.method, 'GET')
+  t.equal(stored.url, `${origin}/`)
+  t.equal(stored.statusCode, 200)
+  t.equal(stored.stored, true)
+  t.equal(stored.reason, null)
+  t.equal(stored.sizeBytes, 'fresh-body'.length)
+  t.equal(stored.ttlSec, 60)
+  t.equal(stored.err, null)
+})
+
+// ---------------------------------------------------------------------------
+// background SWR refresh answered by a 304 → the freshen store write is visible
+// as a cache-store doc, mirroring the replacement path above.
+// ---------------------------------------------------------------------------
+
+test('trace-cache: background SWR refresh (304 freshen) emits a store doc', async (t) => {
+  let conditional = false
+  const server = await startServer((req, res) => {
+    conditional = req.headers['if-none-match'] === '"v1"'
+    res.writeHead(304, { etag: '"v1"', 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  seedStale(store, origin, { etag: '"v1"' })
+  await settle()
+
+  const writer = makeWriter()
+  const res = await request(origin, {
+    trace: writer,
+    cache: { store },
+    dispatcher: makeDispatcher(t),
+  })
+  t.equal(await res.body.text(), 'stale-body')
+
+  await waitFor(() => writer.docs.some((doc) => doc.op === 'undici:cache-store'), {
+    label: 'background 304 freshen store doc',
+  })
+  t.ok(conditional, 'the refresh sent a conditional request')
+
+  const lookups = writer.docs.filter((doc) => doc.op === 'undici:cache')
+  t.equal(lookups.length, 1, 'the refresh adds no lookup doc')
+  t.equal(lookups[0].reason, 'stale-while-revalidate')
+
+  const stores = writer.docs.filter((doc) => doc.op === 'undici:cache-store')
+  t.equal(stores.length, 1, 'the 304-freshen store write emits one store doc')
+  t.equal(stores[0].id, lookups[0].id)
+  t.equal(stores[0].statusCode, 200, 'the freshened entry keeps its stored status')
+  t.equal(stores[0].stored, true)
+  t.equal(stores[0].reason, null)
+  t.equal(stores[0].sizeBytes, 'stale-body'.length)
+  t.equal(stores[0].err, null)
+})
+
+// ---------------------------------------------------------------------------
+// synchronous 304 revalidation now emits a freshen cache-store doc alongside
+// its lookup doc, matching the full-replacement path (which stores via
+// CacheHandler). Regression guard for the freshen store-doc gap.
+// ---------------------------------------------------------------------------
+
+test('trace-cache: synchronous 304 freshen emits a cache-store doc', async (t) => {
+  const server = await startServer((req, res) => {
+    res.writeHead(304, { etag: '"v1"', 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  // A plain stale entry (no stale-while-revalidate) forces synchronous
+  // revalidation rather than a background refresh.
+  const now = Date.now()
+  const body = Buffer.from('stale-body')
+  store.set(
+    { origin, method: 'GET', path: '/', headers: {} },
+    {
+      body,
+      start: 0,
+      end: body.length,
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers: { etag: '"v1"', 'cache-control': 'max-age=5' },
+      cacheControlDirectives: { 'max-age': 5 },
+      etag: '"v1"',
+      vary: {},
+      cachedAt: now - 10e3,
+      staleAt: now - 5e3,
+      deleteAt: now + 3600e3,
+    },
+  )
+  await settle()
+
+  const writer = makeWriter()
+  const res = await request(origin, {
+    trace: writer,
+    cache: { store },
+    dispatcher: makeDispatcher(t),
+  })
+  t.equal(await res.body.text(), 'stale-body')
+
+  const lookups = writer.docs.filter((doc) => doc.op === 'undici:cache')
+  t.equal(lookups.length, 1)
+  t.equal(lookups[0].result, 'hit')
+  t.equal(lookups[0].reason, 'revalidated')
+
+  const stores = writer.docs.filter((doc) => doc.op === 'undici:cache-store')
+  t.equal(stores.length, 1, 'the freshen store write is now traced')
+  t.equal(stores[0].id, lookups[0].id)
+  t.equal(stores[0].statusCode, 200)
+  t.equal(stores[0].stored, true)
+  t.equal(stores[0].reason, null)
+})


### PR DESCRIPTION
Fixes #75.

## Problem

A stale-while-revalidate background refresh constructed its `RevalidationHandler` without any trace context (`write`/`id`/`url`), so the store writes it performed — a 304 freshen or a full replacement — emitted no `undici:cache-store` docs. Background refresh activity and its outcomes were invisible to tracing, even though the synchronous revalidation path traces fully.

## Fix

- **Thread the trace context** from the triggering dispatch into `backgroundRefresh` → `RevalidationHandler`. `write`/`url` are captured once at serve time in `index.js`; the id comes from `opts.id`. Store docs carry the triggering request's id, per the issue's low-cardinality guidance.
- **Replacement path**: the pass-mode `CacheHandler` already emits a store doc once it has the trace context — no extra work needed.
- **304 freshen path**: `#freshen` now emits a store doc for its re-store, closing a gap that also affected the synchronous path. A 304 refresh is now as visible as a full replacement, matching `CacheHandler`'s doc shape (`stored` reflects a throwing `set()`).
- **No double-counted lookups**: a new `background` flag suppresses `undici:cache` lookup docs in the refresh handler. The triggering dispatch already recorded its `stale-while-revalidate` hit; a second lookup doc sharing the same id would inflate hit counts. A failed background refresh stores nothing, so it emits no doc at all.

## Tests

Added to `test/trace-cache.js`:
- background SWR refresh (replacement) emits one store doc tagged with the triggering id, and **no** extra lookup doc;
- background SWR refresh answered by a 304 emits a freshen store doc;
- synchronous 304 freshen now emits a store doc (regression guard for the freshen gap).

Background-refresh waits are bounded by a polling deadline so a never-firing refresh fails rather than hangs.

Full cache + trace suites pass in isolation; the 3 pre-existing failures (Vary arrays, If-None-Match array bypass) are unrelated and reproduce on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)