### PR TITLE
fix(retry): validate strong ETags before resuming

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -17,6 +17,32 @@ const MAX_ERROR_BODY_SIZE = 256 * 1024
 
 function noop() {}
 
+// RFC 9110 §8.8.3: a strong entity-tag is a quoted opaque-tag without the
+// case-sensitive W/ prefix. Validate the complete grammar before putting a
+// server-provided value into If-Match; merely rejecting strings that start
+// with W/ would misclassify malformed values such as `bogus`, `w/"tag"`
+// or quoted strings containing spaces/control characters as strong validators.
+function isStrongEtag(value) {
+  if (
+    typeof value !== 'string' ||
+    value.length < 2 ||
+    value.charCodeAt(0) !== 0x22 ||
+    value.charCodeAt(value.length - 1) !== 0x22
+  ) {
+    return false
+  }
+
+  // etagc = %x21 / %x23-7E / obs-text (%x80-FF). DQUOTE (%x22),
+  // whitespace, controls and Unicode outside the HTTP byte range are invalid.
+  for (let i = 1; i < value.length - 1; i++) {
+    const code = value.charCodeAt(i)
+    if (code !== 0x21 && !(code >= 0x23 && code <= 0x7e) && !(code >= 0x80 && code <= 0xff)) {
+      return false
+    }
+  }
+  return true
+}
+
 // Emit an `undici:retry` trace doc at the point a retry is actually scheduled.
 // Cold path only — a retry already implies a failed attempt — so resolving the
 // writer per emission (same resolution as the trace interceptor: explicit
@@ -279,12 +305,11 @@ class Handler extends DecoratorHandler {
         return super.onHeaders(statusCode, headers, resume)
       }
 
-      // A duplicated etag response header arrives as an array, which has no
-      // startsWith and cannot be used for resumption — treat it as absent.
-      // Weak etags are not useful for comparison nor cache
-      // for instance not safe to assume if the response is byte-per-byte
-      // equal
-      if (this.#etag != null && (typeof this.#etag !== 'string' || this.#etag.startsWith('W/'))) {
+      // Only a syntactically valid strong entity-tag can prove that a resumed
+      // body belongs to the representation whose headers were already sent.
+      // Duplicated, weak and malformed values are treated as absent and never
+      // copied into If-Match.
+      if (!isStrongEtag(this.#etag)) {
         this.#etag = null
       }
 

--- a/test/issue-69-retry-restart-cache-poisoning.js
+++ b/test/issue-69-retry-restart-cache-poisoning.js
@@ -74,3 +74,57 @@ test('issue #69: unvalidated pos=0 full-200 restart does not poison the cache', 
   t.not(text, 'WORLD', 'attempt 2 body was never cached against attempt 1 headers')
   t.equal(attempts, 3, 'initial + declined resume + a fresh origin fetch (no cache hit)')
 })
+
+test('issue #69: malformed etag cannot validate a restart or poison the cache', async (t) => {
+  t.plan(5)
+
+  let attempts = 0
+  const server = createServer((req, res) => {
+    attempts++
+    if (attempts === 1) {
+      // An unquoted value is not an entity-tag. It must not be retained as a
+      // strong validator or copied into the resume's If-Match request.
+      res.writeHead(200, {
+        'content-length': '5',
+        'cache-control': 'max-age=3600',
+        etag: 'bogus',
+      })
+      res.flushHeaders()
+      setTimeout(() => res.destroy(), 50)
+    } else if (attempts === 2) {
+      t.notOk('if-match' in req.headers, 'malformed etag is not sent as If-Match')
+      // Echoing the same malformed text must not satisfy the splice gate. If
+      // accepted, WORLD would inherit attempt 1's one-hour freshness despite
+      // this response explicitly being no-store.
+      res.writeHead(200, {
+        'content-length': '5',
+        'cache-control': 'no-store',
+        etag: 'bogus',
+      })
+      res.end('WORLD')
+    } else {
+      res.writeHead(200, { 'content-length': '5', 'cache-control': 'max-age=3600' })
+      res.end('hello')
+    }
+  })
+  t.teardown(server.close.bind(server))
+  server.listen(0)
+  await once(server, 'listening')
+
+  const url = `http://0.0.0.0:${server.address().port}`
+  const dispatcher = new undici.Agent()
+  t.teardown(() => dispatcher.close())
+
+  const first = await request(url, { dispatcher, cache: true, retry: () => true })
+  await t.rejects(
+    first.body.text(),
+    /Response retry failed/,
+    'the malformed-etag restart is declined instead of spliced',
+  )
+
+  const second = await request(url, { dispatcher, cache: true, retry: () => true })
+  const text = await second.body.text()
+  t.equal(text, 'hello', 'later request fetches the fresh origin body')
+  t.not(text, 'WORLD', 'the restarted body was not stored with attempt 1 headers')
+  t.equal(attempts, 3, 'initial + declined resume + fresh origin fetch')
+})


### PR DESCRIPTION
Follow-up to #80.

## Problem

The resume layer rejected array-valued and uppercase weak ETags, but treated every other string as a strong validator. A malformed value such as unquoted `bogus` was retained, sent in `If-Match`, and accepted when the retry response echoed it.

That leaves issue #69 reproducible: attempt 2 can supply a different body with `Cache-Control: no-store`, while the cache stores it under attempt 1 headers and its long freshness lifetime.

## Fix

Validate the full RFC 9110 entity-tag grammar before retaining a response ETag for byte-range resume. Only a quoted strong opaque-tag is eligible; weak, duplicated, unquoted, whitespace/control-containing, and otherwise malformed values are treated as absent and never sent in `If-Match`.

## Tests

The end-to-end cache-poisoning suite now covers a malformed echoed ETag. It proves that:

- the malformed value is not sent as `If-Match`;
- the unsafe restart is declined;
- attempt 2 is not cached under attempt 1 headers; and
- a later request reaches the origin.

Validation: ESLint; 11 retry-focused suites (all passing); post-rebase targeted suites, 119 assertions passing.
