### PR TITLE
fix(sqlite-store): free stale schema before migration

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -172,42 +172,6 @@ export class SqliteCacheStore {
       PRAGMA mmap_size = ${maxSize};
       PRAGMA max_page_count = ${Math.ceil(maxSize / pageSize)};
       PRAGMA optimize;
-
-      CREATE TABLE IF NOT EXISTS cacheInterceptorV${VERSION} (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        url TEXT NOT NULL,
-        method TEXT NOT NULL,
-        start INTEGER NOT NULL,
-        end INTEGER NOT NULL,
-        staleAt INTEGER NOT NULL,
-        deleteAt INTEGER NOT NULL,
-        statusCode INTEGER NOT NULL,
-        statusMessage TEXT NOT NULL,
-        headers TEXT NULL,
-        cacheControlDirectives TEXT NULL,
-        etag TEXT NULL,
-        vary TEXT NULL,
-        cachedAt INTEGER NOT NULL,
-        -- body is deliberately the LAST column: the lookup filters candidate
-        -- rows on start/deleteAt and vary, and any column stored after a
-        -- large blob would force SQLite to walk the blob's overflow pages
-        -- just to test a row it may then reject.
-        body BLOB NULL
-      );
-
-      -- (url, method) with the implicit rowid tail satisfies the lookup's
-      -- ORDER BY id DESC via a backward index scan, so .get() truly stops at
-      -- the newest candidate. Adding more columns (the old start/deleteAt
-      -- suffix) breaks that ordering and forces a temp B-tree sort that
-      -- materializes every candidate row — blobs included — per lookup.
-      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method);
-      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
-      -- Covers the supersede-on-flush DELETEs (#supersedeFullQuery /
-      -- #supersede206Query), whose predicate is url+method+vary (+statusCode,
-      -- and start/end for 206) — so a re-cache supersedes via an index seek
-      -- instead of scanning every row for a hot url+method with many Vary
-      -- variants or partial windows.
-      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_supersedeQuery ON cacheInterceptorV${VERSION}(url, method, vary, statusCode, start, end);
     `),
     )
 
@@ -250,10 +214,56 @@ export class SqliteCacheStore {
         }
       }
     } catch (err) {
-      // A failed cleanup must not brick construction — the current version's
-      // table still works, the stale one just keeps occupying pages.
+      // Best effort for databases that already have the current schema. When
+      // migrating a database with no free pages, the cleanup is required to
+      // make room for the new schema and the schema creation below will
+      // surface the failure instead of leaving a half-constructed store.
       process.emitWarning(err)
     }
+
+    // Create the current schema only after stale tables have returned their
+    // pages to SQLite's freelist. Doing this first can make a version bump
+    // permanently fail with SQLITE_FULL when the old cache consumed every
+    // page: CREATE TABLE needs space before the later cleanup can run.
+    this.#withBusyRetry(() =>
+      this.#db.exec(`
+      CREATE TABLE IF NOT EXISTS cacheInterceptorV${VERSION} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url TEXT NOT NULL,
+        method TEXT NOT NULL,
+        start INTEGER NOT NULL,
+        end INTEGER NOT NULL,
+        staleAt INTEGER NOT NULL,
+        deleteAt INTEGER NOT NULL,
+        statusCode INTEGER NOT NULL,
+        statusMessage TEXT NOT NULL,
+        headers TEXT NULL,
+        cacheControlDirectives TEXT NULL,
+        etag TEXT NULL,
+        vary TEXT NULL,
+        cachedAt INTEGER NOT NULL,
+        -- body is deliberately the LAST column: the lookup filters candidate
+        -- rows on start/deleteAt and vary, and any column stored after a
+        -- large blob would force SQLite to walk the blob's overflow pages
+        -- just to test a row it may then reject.
+        body BLOB NULL
+      );
+
+      -- (url, method) with the implicit rowid tail satisfies the lookup's
+      -- ORDER BY id DESC via a backward index scan, so .get() truly stops at
+      -- the newest candidate. Adding more columns (the old start/deleteAt
+      -- suffix) breaks that ordering and forces a temp B-tree sort that
+      -- materializes every candidate row — blobs included — per lookup.
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method);
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
+      -- Covers the supersede-on-flush DELETEs (#supersedeFullQuery /
+      -- #supersede206Query), whose predicate is url+method+vary (+statusCode,
+      -- and start/end for 206) — so a re-cache supersedes via an index seek
+      -- instead of scanning every row for a hot url+method with many Vary
+      -- variants or partial windows.
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_supersedeQuery ON cacheInterceptorV${VERSION}(url, method, vary, statusCode, start, end);
+    `),
+    )
 
     this.#getValuesQuery = this.#db.prepare(`
       SELECT

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -5,6 +5,8 @@
 //   materialized every candidate row's body blob per get), and the body blob
 //   must be the last column so candidate filtering never walks its overflow
 //   pages.
+// - schema migration must drop a full stale-version table before trying to
+//   allocate the current table and indexes.
 // - the constructor must survive SQLITE_BUSY from another process's write
 //   transaction during a multi-process cold start on a shared DB file.
 // - max_page_count must derive from the file's actual page size, not a
@@ -141,6 +143,55 @@ test('schema v12: no temp B-tree sort on lookup; body blob is the last column', 
     plan.some((r) => /TEMP B-TREE/i.test(r.detail)),
     `no temp b-tree in plan: ${plan.map((r) => r.detail).join(' | ')}`,
   )
+  t.end()
+})
+
+test('schema migration frees a full stale database before creating the current schema', async (t) => {
+  const dbPath = tmpDb(t, 'full-schema-migration')
+  const maxPages = 96
+  const pageSize = 1024
+
+  const seed = new DatabaseSync(dbPath)
+  seed.exec(`
+    PRAGMA page_size = ${pageSize};
+    VACUUM;
+    PRAGMA journal_mode = DELETE;
+    PRAGMA max_page_count = ${maxPages};
+    CREATE TABLE cacheInterceptorV11 (id INTEGER PRIMARY KEY, body BLOB);
+  `)
+  const insert = seed.prepare('INSERT INTO cacheInterceptorV11(body) VALUES (?)')
+  let fullError
+  while (fullError === undefined) {
+    try {
+      insert.run(Buffer.alloc(700))
+    } catch (err) {
+      fullError = err
+    }
+  }
+  t.equal(fullError.errcode, 13, 'fixture consumed every database page')
+  t.equal(seed.prepare('PRAGMA page_count').get().page_count, maxPages)
+  t.equal(seed.prepare('PRAGMA freelist_count').get().freelist_count, 0)
+  seed.close()
+
+  // Before the fix, CREATE TABLE V12 ran first and threw SQLITE_FULL, so the
+  // stale-table cleanup below it was unreachable on every later construction.
+  const store = new SqliteCacheStore({ location: dbPath, maxSize: maxPages * pageSize })
+  t.teardown(() => store.close())
+  store.set(makeKey(), makeValue())
+  await flush()
+  t.equal(store.get(makeKey())?.body?.toString(), 'hello', 'migrated store is usable')
+  store.close()
+
+  const inspect = new DatabaseSync(dbPath, { readOnly: true })
+  t.teardown(() => inspect.close())
+  const cacheTables = inspect
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
+    )
+    .all()
+    .map(({ name }) => name)
+    .filter((name) => /^cacheInterceptorV\d+$/.test(name))
+  t.same(cacheTables, ['cacheInterceptorV12'], 'stale schema was replaced')
   t.end()
 })
 


### PR DESCRIPTION
Follow-up to merged PR #62.

## Problem

Schema v12 creates the current table and indexes before dropping tables from older cache schema versions. If the old cache consumed every page allowed by `max_page_count`, `CREATE TABLE cacheInterceptorV12` needs another page and throws `SQLITE_FULL`. The cleanup that would free the old pages is later in the constructor and can never run, so every future construction fails.

The regression fixture fills a v11 database to exactly 96 of 96 pages with an empty freelist and reproduces the permanent constructor failure.

## Fix

Apply the connection pragmas first, drop stale cache-version tables so their pages enter the freelist, then create the current schema and indexes. Cleanup remains best-effort for databases that already contain the current schema; during a full migration, schema creation correctly surfaces any cleanup failure.

## Tests

Added a full-database migration regression that verifies:

- the fixture actually reaches `SQLITE_FULL`;
- construction succeeds;
- the migrated store can write and read; and
- only the v12 cache table remains.

Validation: ESLint; SQLite migration, cache-store, and error-contract suites, 187 assertions passing.
