### PR TITLE
fix(sqlite-store): fail hard on corrupt or incompatible databases

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -185,8 +185,19 @@ export class SqliteCacheStore {
       assertCompatibleSchema(this.#db)
     } catch (err) {
       // Construction failed: close the handle, preserve the database byte for
-      // byte, and surface the original corruption/incompatibility error.
-      this.#db.close()
+      // byte, and surface the original corruption/incompatibility error. If
+      // close() also throws, don't let it mask the original — suppress it into
+      // a SuppressedError so both are retained, with the schema error as the
+      // primary `.error`.
+      try {
+        this.#db.close()
+      } catch (closeErr) {
+        throw new SuppressedError(
+          err,
+          closeErr,
+          'Failed to close database after schema validation error',
+        )
+      }
       throw err
     }
 

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -3,6 +3,38 @@ import { parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
 const VERSION = 12
+const CACHE_TABLE = `cacheInterceptorV${VERSION}`
+
+class SqliteCacheSchemaError extends Error {
+  code = 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH'
+
+  constructor(tables) {
+    super(
+      `SqliteCacheStore: incompatible cache schema; expected ${CACHE_TABLE}, found ${tables.join(', ')}`,
+    )
+    this.name = 'SqliteCacheSchemaError'
+  }
+}
+
+// Cache files are never migrated or destructively repaired in place. A table
+// from any other cache schema version means the file belongs to an incompatible
+// package version; fail before creating the current table or changing data.
+// Errors reading sqlite_master (including SQLITE_NOTADB/SQLITE_CORRUPT) are
+// likewise allowed to propagate unchanged.
+function assertCompatibleSchema(db) {
+  const incompatible = db
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
+    )
+    .all()
+    .map(({ name }) => name)
+    .filter((name) => /^cacheInterceptorV\d+$/.test(name) && name !== CACHE_TABLE)
+    .sort()
+
+  if (incompatible.length > 0) {
+    throw new SqliteCacheSchemaError(incompatible)
+  }
+}
 
 // Synchronous bounded sleep for the constructor's SQLITE_BUSY retry (the
 // constructor has no event loop to yield to). Atomics.wait on a throwaway
@@ -149,6 +181,15 @@ export class SqliteCacheStore {
       timeout: this.#dbTimeout,
     })
 
+    try {
+      assertCompatibleSchema(this.#db)
+    } catch (err) {
+      // Construction failed: close the handle, preserve the database byte for
+      // byte, and surface the original corruption/incompatibility error.
+      this.#db.close()
+      throw err
+    }
+
     const maxSize = opts?.maxSize ?? 256 * 1024 * 1024
     // page_size is a persistent property fixed when the file's first page is
     // written; a pre-existing DB may not use 4096. max_page_count is the one
@@ -210,50 +251,6 @@ export class SqliteCacheStore {
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_supersedeQuery ON cacheInterceptorV${VERSION}(url, method, vary, statusCode, start, end);
     `),
     )
-
-    // Drop tables left behind by previous schema versions. gc(), clear() and
-    // the SQLITE_FULL eviction only ever touch the current version's table, so
-    // after a VERSION bump the old table's pages would otherwise stay allocated
-    // to its b-tree forever while max_page_count caps the whole file — new
-    // inserts hit SQLITE_FULL almost immediately and eviction frees nothing.
-    // Dropping returns the pages to SQLite's freelist, which subsequent inserts
-    // reuse, so no VACUUM is needed. SQLite drops the table's indexes and its
-    // sqlite_sequence row along with it.
-    try {
-      // LIKE is only a coarse pre-filter; the regexp restricts matches to
-      // digit-only version suffixes so user tables sharing the prefix (e.g.
-      // "cacheInterceptorVBackup") in a shared database file are never dropped.
-      const staleTables = this.#db
-        .prepare(
-          `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
-        )
-        .all()
-        .filter(
-          ({ name }) =>
-            /^cacheInterceptorV\d+$/.test(name) && name !== `cacheInterceptorV${VERSION}`,
-        )
-      if (staleTables.length > 0) {
-        this.#db.exec('BEGIN')
-        try {
-          for (const { name } of staleTables) {
-            // name comes from sqlite_master; quote it defensively anyway.
-            this.#db.exec(`DROP TABLE IF EXISTS "${String(name).replaceAll('"', '""')}"`)
-          }
-          this.#db.exec('COMMIT')
-        } catch (err) {
-          try {
-            this.#db.exec('ROLLBACK')
-          } catch {
-            // already rolled back automatically
-          }
-          throw err
-        }
-      }
-    } catch (err) {
-      // A failed cleanup must not brick construction — the current version's
-      // table still works, the stale one just keeps occupying pages.
-      process.emitWarning(err)
-    }
 
     this.#getValuesQuery = this.#db.prepare(`
       SELECT

--- a/test/cache-coverage-sqlite-store.js
+++ b/test/cache-coverage-sqlite-store.js
@@ -1,7 +1,6 @@
-/* eslint-disable */
 // Coverage tests for lib/sqlite-cache-store.js — targets the paths the
 // existing suites leave uncovered: broadcast registry pruning of dead
-// WeakRefs, stale-table drop failure handling, gc()/clear() error paths,
+// WeakRefs, schema compatibility failures, gc()/clear() error paths,
 // delete() (batch + DB invalidation), within-batch coalescing, flush
 // supersede semantics, flush time-budget slicing, SQLITE_FULL / non-FULL
 // flush errors, findValue full-scan + sort comparator arms, matchesValue
@@ -115,11 +114,11 @@ test('constructor honors opts.db.timeout and maxSize with a file-backed db', asy
 })
 
 // ---------------------------------------------------------------------------
-// Stale-table dropping at construction
+// Schema compatibility preflight
 // ---------------------------------------------------------------------------
 
-test('old-version tables are dropped, prefix-sharing user tables kept', async (t) => {
-  const dbPath = tmpDb(t, 'stale-drop-ok')
+test('old-version tables fail hard, prefix-sharing user tables are kept', (t) => {
+  const dbPath = tmpDb(t, 'schema-mismatch')
 
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
@@ -129,9 +128,14 @@ test('old-version tables are dropped, prefix-sharing user tables kept', async (t
   `)
   seed.close()
 
-  const store = new SqliteCacheStore({ location: dbPath })
-  store.set(makeKey({ path: '/after-drop' }), makeValue())
-  store.close()
+  let error
+  try {
+    new SqliteCacheStore({ location: dbPath })
+    t.fail('construction should reject an incompatible cache schema')
+  } catch (err) {
+    error = err
+  }
+  t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
 
   const check = new DatabaseSync(dbPath, { readOnly: true })
   t.teardown(() => check.close())
@@ -139,113 +143,47 @@ test('old-version tables are dropped, prefix-sharing user tables kept', async (t
     .prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`)
     .all()
     .map((r) => r.name)
-  t.notOk(tables.includes('cacheInterceptorV1'), 'stale digit-version table dropped')
+  t.ok(tables.includes('cacheInterceptorV1'), 'incompatible cache table preserved')
   t.ok(tables.includes('cacheInterceptorVKeep'), 'non-digit-suffix table preserved')
+  t.strictSame(
+    tables.filter((name) => /^cacheInterceptorV\d+$/.test(name)),
+    ['cacheInterceptorV1'],
+    'constructor did not create the current table',
+  )
   t.end()
 })
 
-test('failed stale-table drop rolls back, warns, and does not brick construction', async (t) => {
-  const dbPath = tmpDb(t, 'stale-drop-fail')
-
-  const seed = new DatabaseSync(dbPath)
-  seed.exec(`CREATE TABLE cacheInterceptorV1 (id INTEGER PRIMARY KEY, url TEXT);`)
-  seed.close()
-
+test('schema inspection errors propagate without warning-and-continue', async (t) => {
+  const dbPath = tmpDb(t, 'schema-read-fail')
   const warnings = collectWarnings(t)
-
   const AnyDB = /** @type {any} */ (DatabaseSync)
-  const origExec = AnyDB.prototype.exec
-  AnyDB.prototype.exec = function (sql) {
-    if (/^DROP TABLE/.test(sql)) {
-      throw new Error('synthetic drop failure')
+  const origPrepare = AnyDB.prototype.prepare
+  const synthetic = Object.assign(new Error('synthetic schema read failure'), { errcode: 11 })
+  AnyDB.prototype.prepare = function (sql) {
+    if (/FROM sqlite_master/.test(sql)) {
+      throw synthetic
     }
-    return origExec.call(this, sql)
+    return origPrepare.call(this, sql)
   }
 
-  let store
+  let error
   try {
-    store = new SqliteCacheStore({ location: dbPath })
+    new SqliteCacheStore({ location: dbPath })
+    t.fail('construction should propagate schema inspection errors')
+  } catch (err) {
+    error = err
   } finally {
-    AnyDB.prototype.exec = origExec
+    AnyDB.prototype.prepare = origPrepare
   }
-  // Guarded: the test closes the store itself before inspecting the file.
-  t.teardown(() => {
-    try {
-      store.close()
-    } catch (err) {
-      if (err?.code !== 'ERR_INVALID_STATE') throw err
-    }
-  })
-
   await flush()
-  t.ok(
-    warnings.some((w) => /synthetic drop failure/.test(w.message)),
-    'cleanup failure surfaced as a process warning',
-  )
-
-  // The store is fully functional despite the failed cleanup.
-  store.set(makeKey({ path: '/survives' }), makeValue())
-  await flush()
-  t.ok(store.get(makeKey({ path: '/survives' })), 'store works after failed cleanup')
-
-  // The stale table is still there (transaction rolled back).
-  store.close()
-  const check = new DatabaseSync(dbPath, { readOnly: true })
-  t.teardown(() => check.close())
-  const tables = check
-    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`)
-    .all()
-    .map((r) => r.name)
-  t.ok(tables.includes('cacheInterceptorV1'), 'stale table kept after rollback')
+  t.equal(error, synthetic, 'the original corruption-style error is rethrown')
+  t.equal(warnings.length, 0, 'constructor does not downgrade the failure to a warning')
   t.end()
 })
 
 // ---------------------------------------------------------------------------
 // gc() / clear() error paths
 // ---------------------------------------------------------------------------
-
-test('stale-table drop failure where ROLLBACK also fails still only warns', async (t) => {
-  const dbPath = tmpDb(t, 'stale-drop-rollback-fail')
-
-  const seed = new DatabaseSync(dbPath)
-  seed.exec(`CREATE TABLE cacheInterceptorV2 (id INTEGER PRIMARY KEY);`)
-  seed.close()
-
-  const warnings = collectWarnings(t)
-
-  const AnyDB = /** @type {any} */ (DatabaseSync)
-  const origExec = AnyDB.prototype.exec
-  AnyDB.prototype.exec = function (sql) {
-    if (/^DROP TABLE/.test(sql)) {
-      throw new Error('synthetic drop failure')
-    }
-    if (sql === 'ROLLBACK') {
-      // Roll back for real (so the connection stays usable), then report
-      // failure — mimics "no transaction is active" after an auto-rollback.
-      origExec.call(this, sql)
-      throw new Error('synthetic rollback failure')
-    }
-    return origExec.call(this, sql)
-  }
-
-  let store
-  try {
-    store = new SqliteCacheStore({ location: dbPath })
-  } finally {
-    AnyDB.prototype.exec = origExec
-  }
-  t.teardown(() => store.close())
-
-  await flush()
-  t.ok(
-    warnings.some((w) => /synthetic drop failure/.test(w.message)),
-    'original drop error (not the rollback error) is the warning',
-  )
-  store.set(makeKey({ path: '/still-works' }), makeValue())
-  await flush()
-  t.ok(store.get(makeKey({ path: '/still-works' })), 'store functional despite double failure')
-  t.end()
-})
 
 test('gc() SQL failure emits warnings from both catch and finally-catch', async (t) => {
   const store = new SqliteCacheStore()

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -127,3 +127,33 @@ test('corrupt database fails hard and is not replaced', (t) => {
   t.strictSame(fs.readFileSync(dbPath), original, 'corrupt file is preserved byte-for-byte')
   t.end()
 })
+
+test('a close() failure during schema-error cleanup does not mask the original error', (t) => {
+  const dbPath = tmpDb(t, 'schema-close-fail')
+  const seed = new DatabaseSync(dbPath)
+  seed.exec('CREATE TABLE cacheInterceptorV99999 (id INTEGER PRIMARY KEY);')
+  seed.close()
+
+  // Force close() to throw only while the constructor is cleaning up after the
+  // schema check fails, so both errors race to propagate out of the catch.
+  const realClose = DatabaseSync.prototype.close
+  const closeErr = new Error('close boom')
+  DatabaseSync.prototype.close = function () {
+    throw closeErr
+  }
+
+  let error
+  try {
+    new SqliteCacheStore({ location: dbPath })
+    t.fail('construction should reject an incompatible cache schema')
+  } catch (err) {
+    error = err
+  } finally {
+    DatabaseSync.prototype.close = realClose
+  }
+
+  t.equal(error?.name, 'SuppressedError', 'both failures are retained in a SuppressedError')
+  t.equal(error?.error?.name, 'SqliteCacheSchemaError', 'the schema error stays the primary .error')
+  t.equal(error?.suppressed, closeErr, 'the close() failure is retained as .suppressed')
+  t.end()
+})

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -1,9 +1,6 @@
-/* eslint-disable */
-// Regression tests: stale cacheInterceptorV{N} tables from older schema
-// versions must be dropped on startup. gc()/clear()/eviction only touch the
-// current version's table, so without the cleanup a VERSION bump on a
-// max_page_count-capped file leaves the old table's pages allocated forever
-// and new inserts starve with SQLITE_FULL.
+// SQLite cache files are intentionally never migrated or destructively
+// repaired. A different cache schema version or corrupt database is an
+// operator-visible startup failure, and the file must remain untouched.
 import { test } from 'tap'
 import os from 'node:os'
 import path from 'node:path'
@@ -11,34 +8,13 @@ import fs from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
-function makeKey(overrides = {}) {
-  return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
-}
-
-function makeValue(overrides = {}) {
-  const now = Date.now()
-  return {
-    body: Buffer.from('hello'),
-    start: 0,
-    end: 5,
-    statusCode: 200,
-    statusMessage: 'OK',
-    cachedAt: now,
-    staleAt: now + 3600e3,
-    deleteAt: now + 7200e3,
-    ...overrides,
-  }
-}
-
-const flush = () => new Promise((resolve) => setImmediate(resolve))
-
 function tmpDb(t, prefix) {
   const dbPath = path.join(
     os.tmpdir(),
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
+    for (const ext of ['', '-wal', '-shm', '-journal']) {
       try {
         fs.unlinkSync(dbPath + ext)
       } catch {}
@@ -47,95 +23,107 @@ function tmpDb(t, prefix) {
   return dbPath
 }
 
-test('old-version cacheInterceptorV{N} tables are dropped on startup', async (t) => {
-  const dbPath = tmpDb(t, 'stale-tables')
+function tableNames(db) {
+  return db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+    .all()
+    .map(({ name }) => name)
+}
 
-  // Seed the file with tables from two other schema versions, each with rows
-  // and an index — as left behind by a real VERSION bump. Version numbers are
-  // huge so they can never collide with the store's current VERSION, plus a
-  // non-digit-suffix table that only shares the prefix and must survive.
+test('incompatible cache schema versions fail without modifying the database', (t) => {
+  const dbPath = tmpDb(t, 'schema-mismatch')
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
     CREATE TABLE cacheInterceptorV99998 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       url TEXT NOT NULL,
-      body BLOB NULL
+      body BLOB
     );
-    CREATE INDEX idx_cacheInterceptorV99998_url ON cacheInterceptorV99998(url);
-    INSERT INTO cacheInterceptorV99998 (url, body) VALUES ('https://old.example.com/a', x'deadbeef');
+    INSERT INTO cacheInterceptorV99998 (url, body)
+      VALUES ('https://old.example.com/a', x'deadbeef');
     CREATE TABLE cacheInterceptorV99999 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       url TEXT NOT NULL,
-      body BLOB NULL
+      body BLOB
     );
-    CREATE INDEX idx_cacheInterceptorV99999_url ON cacheInterceptorV99999(url);
-    INSERT INTO cacheInterceptorV99999 (url, body) VALUES ('https://old.example.com/b', x'deadbeef');
+    INSERT INTO cacheInterceptorV99999 (url, body)
+      VALUES ('https://old.example.com/b', x'cafebabe');
+    CREATE TABLE userData (k TEXT PRIMARY KEY, v TEXT);
+    INSERT INTO userData (k, v) VALUES ('keep', 'me');
+  `)
+  seed.close()
+
+  let error
+  try {
+    new SqliteCacheStore({ location: dbPath })
+    t.fail('construction should reject an incompatible cache schema')
+  } catch (err) {
+    error = err
+  }
+  t.equal(error?.name, 'SqliteCacheSchemaError')
+  t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
+  t.match(error?.message, /cacheInterceptorV99998, cacheInterceptorV99999/)
+
+  const check = new DatabaseSync(dbPath, { readOnly: true })
+  t.teardown(() => check.close())
+  const numericCacheTables = tableNames(check).filter((name) => /^cacheInterceptorV\d+$/.test(name))
+  t.strictSame(
+    numericCacheTables,
+    ['cacheInterceptorV99998', 'cacheInterceptorV99999'],
+    'no current table was created and no incompatible table was dropped',
+  )
+  t.equal(
+    check.prepare('SELECT v FROM userData WHERE k = ?').get('keep').v,
+    'me',
+    'unrelated application data is unchanged',
+  )
+  t.equal(
+    check.prepare('SELECT hex(body) AS body FROM cacheInterceptorV99999').get().body,
+    'CAFEBABE',
+    'incompatible cache data is unchanged',
+  )
+  t.end()
+})
+
+test('non-version tables sharing the cache prefix remain compatible', (t) => {
+  const dbPath = tmpDb(t, 'prefix-table')
+  const seed = new DatabaseSync(dbPath)
+  seed.exec(`
     CREATE TABLE cacheInterceptorVBackup (k TEXT PRIMARY KEY, v TEXT);
     INSERT INTO cacheInterceptorVBackup (k, v) VALUES ('keep', 'me');
   `)
   seed.close()
 
   const store = new SqliteCacheStore({ location: dbPath })
-
-  // The current version's table must be fully functional.
-  store.set(makeKey({ path: '/fresh' }), makeValue({ body: Buffer.from('fresh'), end: 5 }))
-  await flush()
-  const result = store.get(makeKey({ path: '/fresh' }))
-  t.ok(result, 'current table works after cleanup')
-  t.equal(result.body.toString(), 'fresh')
   store.close()
 
   const check = new DatabaseSync(dbPath, { readOnly: true })
   t.teardown(() => check.close())
-  const tables = check
-    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
-    .all()
-    .map((row) => row.name)
-  t.notOk(tables.includes('cacheInterceptorV99998'), 'V99998 table dropped')
-  t.notOk(tables.includes('cacheInterceptorV99999'), 'V99999 table dropped')
-  t.ok(tables.includes('cacheInterceptorVBackup'), 'non-digit-suffix table preserved')
   t.equal(
     check.prepare('SELECT v FROM cacheInterceptorVBackup WHERE k = ?').get('keep').v,
     'me',
-    'non-digit-suffix table rows intact',
+    'prefix-sharing user table remains intact',
   )
   t.ok(
-    tables.some((name) => /^cacheInterceptorV\d+$/.test(name)),
-    'current version table exists',
+    tableNames(check).some((name) => /^cacheInterceptorV\d+$/.test(name)),
+    'the current cache table was created',
   )
-  const staleIndexes = check
-    .prepare(
-      `SELECT name FROM sqlite_master WHERE type = 'index' AND (name LIKE 'idx_cacheInterceptorV99998%' OR name LIKE 'idx_cacheInterceptorV99999%')`,
-    )
-    .all()
-  t.equal(staleIndexes.length, 0, 'stale indexes dropped along with their tables')
   t.end()
 })
 
-test('unrelated user tables in the same file are not dropped', async (t) => {
-  const dbPath = tmpDb(t, 'stale-tables-user')
+test('corrupt database fails hard and is not replaced', (t) => {
+  const dbPath = tmpDb(t, 'corrupt-db')
+  const original = Buffer.from('this is not a sqlite database')
+  fs.writeFileSync(dbPath, original)
 
-  const seed = new DatabaseSync(dbPath)
-  seed.exec(`
-    CREATE TABLE cacheInterceptorV99999 (id INTEGER PRIMARY KEY, url TEXT);
-    INSERT INTO cacheInterceptorV99999 (url) VALUES ('https://old.example.com/');
-    CREATE TABLE userData (k TEXT PRIMARY KEY, v TEXT);
-    INSERT INTO userData (k, v) VALUES ('keep', 'me');
-  `)
-  seed.close()
-
-  const store = new SqliteCacheStore({ location: dbPath })
-  store.close()
-
-  const check = new DatabaseSync(dbPath, { readOnly: true })
-  t.teardown(() => check.close())
-  const tables = check
-    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
-    .all()
-    .map((row) => row.name)
-  t.notOk(tables.includes('cacheInterceptorV99999'), 'stale cache table dropped')
-  t.ok(tables.includes('userData'), 'user table preserved')
-  const row = check.prepare('SELECT v FROM userData WHERE k = ?').get('keep')
-  t.equal(row.v, 'me', 'user table rows intact')
+  let error
+  try {
+    new SqliteCacheStore({ location: dbPath })
+    t.fail('construction should reject a corrupt database')
+  } catch (err) {
+    error = err
+  }
+  t.equal(error?.errcode, 26, 'original SQLITE_NOTADB error propagates')
+  t.strictSame(fs.readFileSync(dbPath), original, 'corrupt file is preserved byte-for-byte')
   t.end()
 })


### PR DESCRIPTION
Supersedes the automatic recovery/migration approaches in #79 and #92.

## Policy

A SQLite cache file is not destructively repaired or migrated in place.

- `SQLITE_NOTADB`, `SQLITE_CORRUPT`, and other schema-read errors propagate from construction unchanged.
- A numeric `cacheInterceptorV{N}` table from any schema version other than the current one is a hard constructor error.
- The database, incompatible cache tables, sidecars, and unrelated application tables are left untouched for operator inspection or explicit removal.

## Implementation

Run a read-only schema compatibility preflight before applying PRAGMAs or creating the current table. On failure, close the just-opened handle and rethrow either:

- the original SQLite error for corruption/read failures; or
- `SqliteCacheSchemaError` with code `ERR_SQLITE_CACHE_SCHEMA_MISMATCH` for version mismatch.

Non-version tables that merely share the prefix, such as `cacheInterceptorVBackup`, remain supported.

## Tests

The regressions prove that:

- old/future cache schemas fail before the current table is created;
- incompatible cache bytes and unrelated application data remain unchanged;
- corrupt non-SQLite files are preserved byte-for-byte and surface `SQLITE_NOTADB`;
- schema inspection errors are not downgraded to warnings; and
- normal current-schema and prefix-sharing database use still works.

Validation: ESLint plus all six SQLite-focused suites, 381 assertions passing.
