### PR TITLE
fix(cache): correct Age accounting and synthesize missing Date

### DIFF
--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -47,10 +47,23 @@ export class CacheHandler extends DecoratorHandler {
   #write
   #id
   #url
+  #requestTime
 
   constructor(
     key,
-    { store, logger, handler, maxEntrySize, maxEntryTTL, heuristic, defaultTTL, write, id, url },
+    {
+      store,
+      logger,
+      handler,
+      maxEntrySize,
+      maxEntryTTL,
+      heuristic,
+      defaultTTL,
+      write,
+      id,
+      url,
+      requestTime,
+    },
   ) {
     super(handler)
 
@@ -65,6 +78,11 @@ export class CacheHandler extends DecoratorHandler {
     this.#write = write ?? null
     this.#id = id ?? null
     this.#url = url ?? null
+    // RFC 9111 §4.2.3 measures corrected Age from the time the request was
+    // initiated, not merely from response receipt. Revalidation can pass the
+    // original conditional request time when this handler is created only
+    // after replacement response headers arrive.
+    this.#requestTime = requestTime ?? Date.now()
   }
 
   // The single `undici:cache-store` emitter. `err` is the raw error (or null);
@@ -244,7 +262,7 @@ export class CacheHandler extends DecoratorHandler {
 
     const etag = typeof headers.etag === 'string' && isEtagUsable(headers.etag) ? headers.etag : ''
     const hasValidator = etag !== '' || typeof headers['last-modified'] === 'string'
-    const age = determineAge(headers, now)
+    const age = determineAge(headers, now, this.#requestTime)
     const times = computeEntryTimes(
       lifetimeInfo.lifetime,
       lifetimeInfo.explicit,

--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -125,6 +125,20 @@ export class CacheHandler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, headers, resume) {
+    const responseTime = Date.now()
+    if (headers.date == null) {
+      // RFC 9110 §6.6.1: a recipient with a clock MUST append the receipt
+      // time as Date when a response without Date is cached or forwarded.
+      // Copy instead of mutating the transport's header object; use a null
+      // prototype because response field names are not trusted object keys.
+      const withDate = Object.create(null)
+      for (const name of Object.keys(headers)) {
+        withDate[name] = headers[name]
+      }
+      withDate.date = new Date(responseTime).toUTCString()
+      headers = withDate
+    }
+
     if (statusCode < 200) {
       // Interim 1xx (e.g. 103 Early Hints) is not the final response — pass it
       // through with no store doc; the final response emits its own.
@@ -241,7 +255,7 @@ export class CacheHandler extends DecoratorHandler {
       return this.#skip('vary-invalid', statusCode, headers, resume)
     }
 
-    const now = Date.now()
+    const now = responseTime
 
     let lifetimeInfo = determineLifetime(
       statusCode,

--- a/lib/interceptor/cache/freshness.js
+++ b/lib/interceptor/cache/freshness.js
@@ -85,12 +85,13 @@ export function determineLifetime(
 }
 
 /**
- * Corrected initial age in whole seconds per RFC 9111 §4.2.3 (simplified):
- * the larger of the Age header and the apparent age (receipt time minus the
- * origin Date). A response relayed through intermediaries that don't add Age
- * would otherwise get an over-extended TTL and be served stale.
+ * Corrected initial age in whole seconds per RFC 9111 §4.2.3: the larger of
+ * apparent age (response receipt time minus the origin Date) and corrected
+ * age (the Age header plus request-to-response delay). Age is relative to
+ * request initiation, so omitting response_delay over-extends freshness by
+ * the entire upstream round trip for a slow response.
  */
-export function determineAge(headers, now) {
+export function determineAge(headers, responseTime, requestTime = responseTime) {
   const rawAge = headers.age
   // A duplicated Age header arrives as an array; take the first value. A
   // single line may still carry a (malformed) list — `Age: 7200, 0` — and the
@@ -108,8 +109,9 @@ export function determineAge(headers, now) {
       ? parseInt(rawAgeValue, 10)
       : 0
   const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
-  const apparentAge = date ? Math.max(0, Math.floor((now - date.getTime()) / 1000)) : 0
-  return Math.max(age, apparentAge)
+  const apparentAge = date ? Math.max(0, Math.floor((responseTime - date.getTime()) / 1000)) : 0
+  const responseDelay = Math.max(0, Math.floor((responseTime - requestTime) / 1000))
+  return Math.max(age + responseDelay, apparentAge)
 }
 
 /**

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -78,6 +78,8 @@ export class RevalidationHandler {
   #lookupMs
   #background
   #dispatch
+  #requestTime
+  #responseTime = null
   /** @type {null | 'pass' | 'validated' | 'stale'} */
   #mode = null
   /** @type {CacheHandler | import('../../utils.js').DecoratorHandler | object | null} */
@@ -132,6 +134,7 @@ export class RevalidationHandler {
     // sharing the triggering id would double-count the hit.
     this.#background = background ?? false
     this.#dispatch = dispatch ?? null
+    this.#requestTime = Date.now()
   }
 
   // The `undici:cache-store` emitter for the freshen store write — the same
@@ -191,6 +194,7 @@ export class RevalidationHandler {
     if (statusCode === 304) {
       this.#mode = 'validated'
       this.#headers304 = headers
+      this.#responseTime = Date.now()
       return true
     }
 
@@ -237,6 +241,7 @@ export class RevalidationHandler {
           write: this.#write,
           id: this.#id,
           url: this.#url,
+          requestTime: this.#requestTime,
         })
     this.#inner.onConnect((reason) => this.#abort?.(reason))
     return this.#inner.onHeaders(statusCode, headers, resume)
@@ -420,7 +425,7 @@ export class RevalidationHandler {
     const entry = this.#entry
     const headers304 = this.#headers304 ?? {}
     try {
-      const now = Date.now()
+      const now = this.#responseTime ?? Date.now()
 
       // Case-insensitive pre-scan of two 304 fields consumed OUTSIDE the
       // lowercasing merge below: Age is excluded from the merge (cachedAt is
@@ -571,17 +576,19 @@ export class RevalidationHandler {
       }
 
       // Corrected initial age of the VALIDATING response (RFC 9111 §4.2.3 /
-      // §4.3.4). The apparent age from the 304's Date is clamped to the
-      // stored entry's own current age (now - cachedAt already includes the
-      // original initial age): a skewed/old Date must not push the freshened
-      // entry further into the past than the response it just validated. The
-      // 304's explicit Age header is NOT clamped — an intermediary shared
-      // cache answering the conditional from its own store legitimately
-      // reports ages exceeding our local resident time, and discarding them
-      // would over-extend freshness past the origin's grant.
+      // §4.3.4). Only apparent age from the 304's Date is clamped to the
+      // stored entry's own current age: a skewed/old Date must not push the
+      // freshened entry further into the past than the response it validated.
+      // The mandatory request-to-response delay and the 304's explicit Age
+      // are not clamped — an intermediary can legitimately report an age
+      // exceeding our local resident time.
+      const previousAge = Math.max(0, Math.floor((now - entry.cachedAt) / 1000))
+      const apparentAge = Math.min(determineAge(merged, now), previousAge)
+      const responseDelay = determineAge({}, now, this.#requestTime)
       const age = Math.max(
-        Math.min(determineAge(merged, now), Math.max(0, Math.floor((now - entry.cachedAt) / 1000))),
-        age304 != null ? determineAge({ age: age304 }, now) : 0,
+        apparentAge,
+        responseDelay,
+        age304 != null ? determineAge({ age: age304 }, now, this.#requestTime) : 0,
       )
       const times = computeEntryTimes(
         lifetimeInfo.lifetime,

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -84,6 +84,39 @@ test('parseHttpDate: accepts the three RFC 9110 formats, rejects everything else
   t.end()
 })
 
+test('storability: a missing Date is appended at receipt before forwarding and storage', async (t) => {
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.sendDate = false
+    res.writeHead(200, { 'cache-control': 'max-age=60' })
+    res.end('body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), path: '/', method: 'GET', headers: {}, cache: { store } }
+  const earliestReceipt = Date.now() - 1000
+
+  const first = await rawRequest(dispatch, opts)
+  const receivedDate = parseHttpDate(first.headers.date)?.getTime()
+  t.ok(
+    receivedDate != null && receivedDate >= earliestReceipt && receivedDate <= Date.now(),
+    'forwarded response carries a receipt-time Date',
+  )
+
+  await flush()
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.headers.date, first.headers.date, 'the same generated Date is stored')
+
+  const second = await rawRequest(dispatch, opts)
+  t.equal(hits, 1, 'the dated response is reusable from cache')
+  t.equal(second.headers.date, first.headers.date, 'cache hit preserves the generated Date')
+  t.end()
+})
+
 // ---------------------------------------------------------------------------
 // Expires fallback (RFC 9111 §4.2.1 / §5.3)
 // ---------------------------------------------------------------------------

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -29,10 +29,12 @@ import { createServer } from 'node:http'
 import { once } from 'node:events'
 import { parseCacheControl, parseHttpDate } from '../lib/utils.js'
 import {
+  determineAge,
   determineLifetime,
   computeEntryTimes,
   forbidsRequestDrivenStale,
 } from '../lib/interceptor/cache/freshness.js'
+import { CacheHandler } from '../lib/interceptor/cache/cache-handler.js'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
 import undici from '@nxtedition/undici'
 
@@ -201,6 +203,48 @@ test('determineLifetime: malformed max-age no longer falls through to Expires', 
 // ---------------------------------------------------------------------------
 // freshness.js
 // ---------------------------------------------------------------------------
+
+test('determineAge: corrected age includes request-to-response delay', (t) => {
+  const responseTime = Date.UTC(2026, 6, 10, 12, 0, 0)
+  const requestTime = responseTime - 5e3
+  t.equal(
+    determineAge(
+      { age: '7', date: new Date(responseTime).toUTCString() },
+      responseTime,
+      requestTime,
+    ),
+    12,
+    'Age: 7 plus a 5-second response delay yields corrected age 12',
+  )
+
+  const sets = []
+  const store = { set: (key, value) => sets.push({ key, value }) }
+  const handler = new CacheHandler(
+    { origin: 'http://example.test', method: 'GET', path: '/', headers: {} },
+    {
+      store,
+      requestTime: Date.now() - 5e3,
+      handler: {
+        onConnect() {},
+        onHeaders() {},
+        onComplete() {},
+      },
+    },
+  )
+  handler.onConnect(() => {})
+  handler.onHeaders(
+    200,
+    {
+      age: '0',
+      date: new Date().toUTCString(),
+      'cache-control': 'max-age=3',
+    },
+    () => {},
+  )
+  handler.onComplete({})
+  t.equal(sets.length, 0, 'a slow response already older than max-age is not stored as fresh')
+  t.end()
+})
 
 test('determineLifetime: immutable is not a freshness source (yields no lifetime)', (t) => {
   const now = Date.now()

--- a/test/review-bugfixes-5-revalidation.js
+++ b/test/review-bugfixes-5-revalidation.js
@@ -15,6 +15,7 @@ import { test } from 'tap'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import { parseHttpDate } from '../lib/utils.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
@@ -129,6 +130,36 @@ test('304 freshening honors the validating response Age header', async (t) => {
     hits > hitsBefore,
     'second request revalidates again: Age 100 > max-age 60 means the freshened entry is still stale',
   )
+  t.end()
+})
+
+test('304 freshening appends a missing Date at validation receipt', async (t) => {
+  const server = await startServer((req, res) => {
+    res.sendDate = false
+    res.writeHead(304, { etag: '"v1"', 'cache-control': 'max-age=60' })
+    res.end()
+  })
+  t.teardown(() => server.close())
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  const dispatch = makeDispatch()
+  const opts = { origin: origin(server), method: 'GET', path: '/x', headers: {}, cache: { store } }
+
+  seedStale(store, origin(server))
+  await settle()
+  const earliestReceipt = Date.now() - 1000
+
+  const response = await rawRequest(dispatch, opts)
+  const receivedDate = parseHttpDate(response.headers.date)?.getTime()
+  t.ok(
+    receivedDate != null && receivedDate >= earliestReceipt && receivedDate <= Date.now(),
+    'served metadata carries the 304 receipt-time Date',
+  )
+
+  await settle()
+  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  t.equal(entry.headers.date, response.headers.date, 'the generated 304 Date updated storage')
   t.end()
 })
 


### PR DESCRIPTION
## Summary

- Include request-to-response delay in corrected initial age for normal responses, replacement responses, and 304 freshening.
- Preserve legitimate validating-response `Age` instead of clamping it to local residence time.
- Append a receipt-time `Date` when a normal or 304 origin response omits it.
- Forward and store the same generated value without mutating transport-owned headers.

Previously, a response taking five seconds to arrive with `Age: 0, max-age=3` could be stored as newly fresh even though it was stale on arrival. A 304 without `Date` also retained stale Date metadata because it bypasses the normal write handler.

## RFC rationale

[RFC 9111 §4.2.3](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3) defines `response_delay = response_time - request_time`, `corrected_age_value = age_value + response_delay`, and requires corrected age to be interpreted relative to request initiation.

[RFC 9110 §6.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.1) says a recipient with a clock that receives a response without `Date` **MUST** record receipt time and append the corresponding field when caching or forwarding it. That applies to validation responses too.

## Tests

- Added deterministic response-delay storage coverage.
- Added normal-response and 304 missing-Date forwarding/storage regressions.
- Relevant cache suites pass, including 22/22 assertions in the updated revalidation regression file.
- `npm run test:cache-tests`: 244 passed, 0 required failures, 0 retries.
- ESLint, Prettier, and `git diff --check` pass.

Apache HttpClient's cache tests for response-delay age correction and missing Date inspired these regressions.
