### PR TITLE
fix(cache): select matching variants by response Date

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -783,42 +783,38 @@ export class SqliteCacheStore {
      * @type {SqliteStoreValue[]}
      */
     const values = this.#getValuesQuery.all(url, method, requestedStart, now)
-    const pending = []
+    const pendingRepresentations = new Set()
 
     for (const entry of this.#insertBatch) {
       if (entry.url === url && entry.method === method && entry.start <= requestedStart) {
         // Pending entries already represent the state that the next flush
         // will commit. Include expired entries long enough to suppress the
         // persisted representation they tombstone.
-        pending.push(entry)
+        pendingRepresentations.add(storedRepresentationIdentity(entry))
         values.push(entry)
       }
     }
 
-    if (pending.length !== 0) {
+    if (pendingRepresentations.size !== 0) {
       // The flush transaction deletes the prior row for the same stored
       // representation before inserting its replacement. Mirror that state
       // immediately: otherwise Date ordering could select a persisted row
       // that the pending replacement is about to supersede, making get()
-      // change answers merely because setImmediate flushed the batch.
-      for (let i = values.length - 1; i >= 0; i--) {
-        const value = values[i]
+      // change answers merely because setImmediate flushed the batch. The
+      // identity Set keeps this merge linear in candidates + pending writes.
+      // Compact in place as well, avoiding repeated Array#splice shifts.
+      let length = 0
+      for (const value of values) {
+        const isPending = value.seq != null
         if (
-          value.seq == null &&
-          pending.some((replacement) => sameStoredRepresentation(replacement, value))
+          (!isPending && pendingRepresentations.has(storedRepresentationIdentity(value))) ||
+          (isPending && value.deleteAt <= now)
         ) {
-          values.splice(i, 1)
+          continue
         }
+        values[length++] = value
       }
-
-      // Tombstones have now removed their persisted counterpart. They are not
-      // stored responses themselves, so discard them before ranking any
-      // other overlapping Vary selectors by Date.
-      for (let i = values.length - 1; i >= 0; i--) {
-        if (values[i].seq != null && values[i].deleteAt <= now) {
-          values.splice(i, 1)
-        }
-      }
+      values.length = length
     }
 
     if (values.length === 0) {
@@ -912,17 +908,17 @@ function matchesValue(value, range, headers) {
 }
 
 /**
- * The representation identity used by the supersede-on-flush DELETEs: full
- * responses replace full responses with the same Vary selector; 206 entries
- * replace only the same byte window.
+ * Stable identity matching the supersede-on-flush DELETEs exactly: full
+ * responses replace every non-206 response with the same serialized Vary
+ * selector; 206 entries replace only the same selector and byte window. JSON
+ * preserves value types and avoids delimiter collisions in selector text.
  */
-function sameStoredRepresentation(a, b) {
-  if (a.vary !== b.vary) {
-    return false
-  }
-  return a.statusCode === 206
-    ? b.statusCode === 206 && a.start === b.start && a.end === b.end
-    : b.statusCode !== 206
+function storedRepresentationIdentity(value) {
+  return JSON.stringify(
+    value.statusCode === 206
+      ? [value.vary, 'partial', value.start, value.end]
+      : [value.vary, 'full'],
+  )
 }
 
 /**

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -864,18 +864,19 @@ export class SqliteCacheStore {
  * duplicated/non-string Date values are invalid and fall back to receipt time.
  */
 function getResponseDate(headers, receivedAt) {
+  let dateName
   if (headers && typeof headers === 'object') {
     for (const name of Object.keys(headers)) {
       if (name.toLowerCase() === 'date') {
-        const value = headers[name]
-        if (typeof value === 'string') {
-          return parseHttpDate(value)?.getTime() ?? receivedAt
+        if (dateName != null) {
+          return receivedAt
         }
-        break
+        dateName = name
       }
     }
   }
-  return receivedAt
+  const date = dateName == null ? undefined : headers[dateName]
+  return typeof date === 'string' ? (parseHttpDate(date)?.getTime() ?? receivedAt) : receivedAt
 }
 
 /**

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -1,8 +1,8 @@
 import { DatabaseSync } from 'node:sqlite'
-import { parseRangeHeader, getFastNow } from './utils.js'
+import { parseHttpDate, parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
-const VERSION = 13
+const VERSION = 14
 const CACHE_TABLE = `cacheInterceptorV${VERSION}`
 
 class SqliteCacheSchemaError extends Error {
@@ -105,6 +105,7 @@ function forEachStore(fn) {
  *  statusMessage: string
  *  headers?: string
  *  vary?: string
+ *  responseDate: number
  *  etag?: string
  *  cacheControlDirectives?: string
  *  authorizationRequest?: number
@@ -241,6 +242,7 @@ export class SqliteCacheStore {
         etag TEXT NULL,
         vary TEXT NULL,
         authorizationRequest INTEGER NULL,
+        responseDate INTEGER NOT NULL,
         cachedAt INTEGER NOT NULL,
         -- body is deliberately the LAST column: the lookup filters candidate
         -- rows on start/deleteAt and vary, and any column stored after a
@@ -249,12 +251,12 @@ export class SqliteCacheStore {
         body BLOB NULL
       );
 
-      -- (url, method) with the implicit rowid tail satisfies the lookup's
-      -- ORDER BY id DESC via a backward index scan, so .get() truly stops at
-      -- the newest candidate. Adding more columns (the old start/deleteAt
-      -- suffix) breaks that ordering and forces a temp B-tree sort that
-      -- materializes every candidate row — blobs included — per lookup.
-      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method);
+      -- RFC 9111 §4 requires the most recent suitable response as determined
+      -- by Date. Keeping that order in the lookup index lets .get() truly stop
+      -- at the newest candidate without a temp sort that materializes every
+      -- candidate row — blobs included. id is the receipt-order tie-break for
+      -- Date's one-second resolution.
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method, responseDate DESC, id DESC);
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
       -- Covers the supersede-on-flush DELETEs (#supersedeFullQuery /
       -- #supersede206Query), whose predicate is url+method+vary (+statusCode,
@@ -280,6 +282,7 @@ export class SqliteCacheStore {
         cacheControlDirectives,
         vary,
         authorizationRequest,
+        responseDate,
         cachedAt
       FROM cacheInterceptorV${VERSION}
       WHERE
@@ -288,6 +291,7 @@ export class SqliteCacheStore {
         AND start <= ?
         AND deleteAt > ?
       ORDER BY
+        responseDate DESC,
         id DESC
     `)
 
@@ -307,8 +311,9 @@ export class SqliteCacheStore {
         cacheControlDirectives,
         vary,
         authorizationRequest,
+        responseDate,
         cachedAt
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     this.#deleteExpiredValuesQuery = this.#db.prepare(
@@ -514,7 +519,7 @@ export class SqliteCacheStore {
     }
 
     const entry = {
-      // Monotonic per-store sequence used only to break cachedAt ties in
+      // Monotonic per-store sequence used only to break response-Date ties in
       // #findValue (newest write wins). Not persisted — #flush ignores it.
       seq: this.#insertSeq++,
       url: makeValueUrl(key),
@@ -546,6 +551,10 @@ export class SqliteCacheStore {
       // headerValueEquals). Canonicalizing keeps "same variant" one row
       // instead of accumulating dead duplicates until deleteAt.
       vary: value.vary ? JSON.stringify(canonicalVary(value.vary)) : null,
+      // RFC 9111 §4 chooses among multiple suitable stored responses by the
+      // response Date, not by arrival/write order. A missing or invalid Date is
+      // assigned the receipt time for selection purposes.
+      responseDate: getResponseDate(value.headers, Date.now()),
       cachedAt: value.cachedAt,
     }
 
@@ -646,6 +655,7 @@ export class SqliteCacheStore {
               cacheControlDirectives,
               vary,
               authorizationRequest,
+              responseDate,
               cachedAt,
             } = this.#insertBatch[n++]
             // Supersede prior rows for the same representation (see the
@@ -671,6 +681,7 @@ export class SqliteCacheStore {
               cacheControlDirectives,
               vary,
               authorizationRequest,
+              responseDate,
               cachedAt,
             )
             if (!final && (n & 0xf) === 0 && performance.now() - startTime > 10) {
@@ -752,8 +763,8 @@ export class SqliteCacheStore {
     const requestedStart = range?.start ?? 0
 
     if (this.#insertBatch.length === 0) {
-      // Fast path: rows arrive sorted (cachedAt DESC, id DESC) and there are
-      // no pending batch entries to merge, so fetch only the newest candidate.
+      // Fast path: rows arrive sorted (response Date DESC, id DESC) and there
+      // are no pending batch entries to merge, so fetch only the newest candidate.
       // This covers misses and first-row hits (the overwhelmingly common
       // cases) with a single row materialized — re-cached duplicates of a hot
       // key would otherwise all be read including their blobs. Only when the
@@ -772,14 +783,41 @@ export class SqliteCacheStore {
      * @type {SqliteStoreValue[]}
      */
     const values = this.#getValuesQuery.all(url, method, requestedStart, now)
+    const pending = []
 
     for (const entry of this.#insertBatch) {
       if (entry.url === url && entry.method === method && entry.start <= requestedStart) {
-        // Include expired pending entries as tombstones. A fresh row already
-        // in SQLite must not remain visible until the asynchronous flush when
-        // a newer write for the same representation deliberately expires it
-        // (e.g. a 304 withdrawing cacheability or an Authorization grant).
+        // Pending entries already represent the state that the next flush
+        // will commit. Include expired entries long enough to suppress the
+        // persisted representation they tombstone.
+        pending.push(entry)
         values.push(entry)
+      }
+    }
+
+    if (pending.length !== 0) {
+      // The flush transaction deletes the prior row for the same stored
+      // representation before inserting its replacement. Mirror that state
+      // immediately: otherwise Date ordering could select a persisted row
+      // that the pending replacement is about to supersede, making get()
+      // change answers merely because setImmediate flushed the batch.
+      for (let i = values.length - 1; i >= 0; i--) {
+        const value = values[i]
+        if (
+          value.seq == null &&
+          pending.some((replacement) => sameStoredRepresentation(replacement, value))
+        ) {
+          values.splice(i, 1)
+        }
+      }
+
+      // Tombstones have now removed their persisted counterpart. They are not
+      // stored responses themselves, so discard them before ranking any
+      // other overlapping Vary selectors by Date.
+      for (let i = values.length - 1; i >= 0; i--) {
+        if (values[i].seq != null && values[i].deleteAt <= now) {
+          values.splice(i, 1)
+        }
       }
     }
 
@@ -787,14 +825,15 @@ export class SqliteCacheStore {
       return undefined
     }
 
-    // Most recently WRITTEN representation wins — receipt order, not
-    // cachedAt (see the #supersede* query comments: cachedAt is backdated by
-    // the corrected initial age, so a fresher write can carry an older
-    // cachedAt). Pending batch entries (tagged with a monotonic seq) are
-    // always newer than any flushed DB row, and within each source a higher
-    // seq/id wins.
+    // RFC 9111 §4: when multiple suitable responses match (overlapping Vary
+    // selectors), the most recent response Date wins. Receipt order breaks
+    // Date ties; a pending batch entry is newer than a flushed row for that
+    // tie, and within each source a higher seq/id wins.
     if (values.length > 1) {
       values.sort((a, b) => {
+        if (a.responseDate !== b.responseDate) {
+          return b.responseDate - a.responseDate
+        }
         const aBatch = a.seq != null
         const bBatch = b.seq != null
         if (aBatch !== bBatch) {
@@ -818,6 +857,25 @@ export class SqliteCacheStore {
 
     return undefined
   }
+}
+
+/**
+ * Selection timestamp for RFC 9111 §4. Field names are case-insensitive;
+ * duplicated/non-string Date values are invalid and fall back to receipt time.
+ */
+function getResponseDate(headers, receivedAt) {
+  if (headers && typeof headers === 'object') {
+    for (const name of Object.keys(headers)) {
+      if (name.toLowerCase() === 'date') {
+        const value = headers[name]
+        if (typeof value === 'string') {
+          return parseHttpDate(value)?.getTime() ?? receivedAt
+        }
+        break
+      }
+    }
+  }
+  return receivedAt
 }
 
 /**
@@ -850,6 +908,20 @@ function matchesValue(value, range, headers) {
   }
 
   return true
+}
+
+/**
+ * The representation identity used by the supersede-on-flush DELETEs: full
+ * responses replace full responses with the same Vary selector; 206 entries
+ * replace only the same byte window.
+ */
+function sameStoredRepresentation(a, b) {
+  if (a.vary !== b.vary) {
+    return false
+  }
+  return a.statusCode === 206
+    ? b.statusCode === 206 && a.start === b.start && a.end === b.end
+    : b.statusCode !== 206
 }
 
 /**

--- a/test/cache-selection-date.js
+++ b/test/cache-selection-date.js
@@ -1,0 +1,89 @@
+import { test } from 'tap'
+import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+test('store chooses the most recent matching response by Date, not write order', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/resource',
+    headers: { accept: 'text/plain' },
+  }
+  const now = Date.now()
+  const value = (body, date, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt: now + 7200e3,
+  })
+
+  // Both entries match `Accept: text/plain`. The less-specific response was
+  // generated later, but the older Vary-specific response arrived last.
+  store.set(key, value('newer', new Date(now).toUTCString(), {}))
+  await flush()
+  store.set(key, value('older', new Date(now - 60e3).toUTCString(), { accept: 'text/plain' }))
+  await flush()
+
+  const result = store.get(key)
+  t.equal(result.body.toString(), 'newer', 'RFC 9111 §4 Date ordering wins')
+
+  // Pending entries participate in the same selection before their batch is
+  // flushed; being the latest write must not let an older Date jump the queue.
+  store.set(key, value('oldest', new Date(now - 120e3).toUTCString(), { 'accept-language': null }))
+  t.equal(store.get(key).body.toString(), 'newer', 'Date ordering also covers pending writes')
+  await flush()
+  t.equal(store.get(key).body.toString(), 'newer', 'ordering is stable after the batch flush')
+})
+
+test('pending replacements immediately supersede their persisted representation', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/pending',
+    headers: {},
+  }
+  const now = Date.now()
+  const value = (body, date, deleteAt = now + 7200e3) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary: {},
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt,
+  })
+
+  store.set(key, value('persisted-newer-date', new Date(now).toUTCString()))
+  await flush()
+
+  // set() replaces this same stored representation. Its older Date must not
+  // resurrect the persisted row during the short pending-batch interval;
+  // after the flush only the replacement will exist.
+  store.set(key, value('pending-older-date', new Date(now - 60e3).toUTCString()))
+  t.equal(store.get(key).body.toString(), 'pending-older-date', 'pending replacement wins now')
+  await flush()
+  t.equal(store.get(key).body.toString(), 'pending-older-date', 'answer is stable after flush')
+
+  // An expired replacement is a variant-scoped tombstone. It must hide the
+  // persisted row immediately even when its response Date sorts earlier.
+  store.set(key, value('tombstone', new Date(now - 120e3).toUTCString(), now - 60e3))
+  t.equal(store.get(key), undefined, 'pending tombstone shadows the persisted row')
+})

--- a/test/cache-selection-date.js
+++ b/test/cache-selection-date.js
@@ -46,6 +46,58 @@ test('store chooses the most recent matching response by Date, not write order',
   t.equal(store.get(key).body.toString(), 'newer', 'ordering is stable after the batch flush')
 })
 
+test('duplicate case-insensitive Date fields fall back to receipt time', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/duplicate-date',
+    headers: { accept: 'text/plain' },
+  }
+  const now = Date.now()
+  const value = (body, headers, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers,
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt: now + 7200e3,
+  })
+
+  store.set(key, value('dated', { date: new Date(now - 60e3).toUTCString() }, {}))
+  await flush()
+  store.set(
+    key,
+    value(
+      'ambiguous',
+      {
+        Date: new Date(now - 120e3).toUTCString(),
+        date: new Date(now - 180e3).toUTCString(),
+      },
+      { accept: 'text/plain' },
+    ),
+  )
+
+  t.equal(
+    store.get(key).body.toString(),
+    'ambiguous',
+    'ambiguous Date metadata uses the newer receipt time while pending',
+  )
+  await flush()
+  t.equal(
+    store.get(key).body.toString(),
+    'ambiguous',
+    'the receipt-time fallback survives persistence',
+  )
+})
+
 test('pending replacements immediately supersede their persisted representation', async (t) => {
   const store = new SqliteCacheStore({ location: ':memory:' })
   t.teardown(() => store.close())

--- a/test/cache-selection-date.js
+++ b/test/cache-selection-date.js
@@ -1,7 +1,16 @@
 import { test } from 'tap'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
 const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+function tempDb(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cache-selection-date-'))
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
+  return path.join(dir, 'cache.sqlite')
+}
 
 test('store chooses the most recent matching response by Date, not write order', async (t) => {
   const store = new SqliteCacheStore({ location: ':memory:' })
@@ -138,4 +147,69 @@ test('pending replacements immediately supersede their persisted representation'
   // persisted row immediately even when its response Date sorts earlier.
   store.set(key, value('tombstone', new Date(now - 120e3).toUTCString(), now - 60e3))
   t.equal(store.get(key), undefined, 'pending tombstone shadows the persisted row')
+})
+
+test('many pending identities suppress only their exact persisted representations', (t) => {
+  const location = tempDb(t)
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/many-pending',
+    headers: {},
+  }
+  const now = Date.now()
+  const value = (body, date, vary, deleteAt = now + 7200e3) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt,
+  })
+
+  let store = new SqliteCacheStore({ location })
+  t.teardown(() => store.close())
+  for (let i = 0; i < 64; i++) {
+    store.set(key, value(`persisted-${i}`, new Date(now).toUTCString(), { [`x-${i}`]: null }))
+  }
+  // This neighboring selector overlaps requests carrying x-63 but is not the
+  // same stored representation as { x-63: null }.
+  store.set(
+    key,
+    value('distinct-neighbor', new Date(now + 60e3).toUTCString(), {
+      'x-63': 'present',
+      extra: null,
+    }),
+  )
+  store.close()
+
+  store = new SqliteCacheStore({ location })
+  for (let i = 0; i < 64; i++) {
+    store.set(
+      key,
+      value(
+        `pending-${i}`,
+        new Date(now - 60e3).toUTCString(),
+        { [`x-${i}`]: null },
+        i === 63 ? now - 60e3 : undefined,
+      ),
+    )
+  }
+
+  t.equal(
+    store.get(key).body.toString(),
+    'pending-62',
+    'exact replacements hide newer persisted rows and the final tombstone is not served',
+  )
+  t.equal(
+    store.get({ ...key, headers: { 'x-63': 'present' } }).body.toString(),
+    'distinct-neighbor',
+    'a neighboring serialized Vary selector is not over-suppressed',
+  )
+  t.end()
 })

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -789,8 +789,13 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
   t.equal(store.get(key).body.toString(), 'three', 'newest entry served')
 
   const db = new DatabaseSync(dbPath, { readOnly: true })
+  const table = db
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
+    )
+    .get().name
   const { c } = db
-    .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV13 WHERE url = ?`)
+    .prepare(`SELECT COUNT(*) c FROM ${table} WHERE url = ?`)
     .get('https://example.com/hot')
   db.close()
   t.equal(c, 1, 'older rows for the representation were superseded')

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -791,7 +791,13 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
   const db = new DatabaseSync(dbPath, { readOnly: true })
   const table = db
     .prepare(
-      `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'cacheInterceptorV%'`,
+      `SELECT name
+       FROM sqlite_master
+       WHERE type = 'table'
+         AND name GLOB 'cacheInterceptorV[0-9]*'
+         AND substr(name, length('cacheInterceptorV') + 1) NOT GLOB '*[^0-9]*'
+       ORDER BY CAST(substr(name, length('cacheInterceptorV') + 1) AS INTEGER) DESC
+       LIMIT 1`,
     )
     .get().name
   const { c } = db

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -30,16 +30,16 @@ function tableNames(db) {
     .map(({ name }) => name)
 }
 
-test('v12 is rejected byte-for-byte before the v13 table is created', (t) => {
-  const dbPath = tmpDb(t, 'schema-v12-to-v13')
+test('v13 is rejected byte-for-byte before the v14 table is created', (t) => {
+  const dbPath = tmpDb(t, 'schema-v13-to-v14')
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
-    CREATE TABLE cacheInterceptorV12 (
+    CREATE TABLE cacheInterceptorV13 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       url TEXT NOT NULL,
       body BLOB
     );
-    INSERT INTO cacheInterceptorV12 (url, body)
+    INSERT INTO cacheInterceptorV13 (url, body)
       VALUES ('https://old.example.com/secret', x'deadbeef');
   `)
   seed.close()
@@ -48,32 +48,32 @@ test('v12 is rejected byte-for-byte before the v13 table is created', (t) => {
   let error
   try {
     new SqliteCacheStore({ location: dbPath })
-    t.fail('construction should reject schema v12')
+    t.fail('construction should reject schema v13')
   } catch (err) {
     error = err
   }
 
   t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
-  t.match(error?.message, /expected cacheInterceptorV13, found cacheInterceptorV12/)
-  t.strictSame(fs.readFileSync(dbPath), before, 'the v12 database is byte-for-byte unchanged')
+  t.match(error?.message, /expected cacheInterceptorV14, found cacheInterceptorV13/)
+  t.strictSame(fs.readFileSync(dbPath), before, 'the v13 database is byte-for-byte unchanged')
 
   const check = new DatabaseSync(dbPath, { readOnly: true })
   t.teardown(() => check.close())
   t.strictSame(
     tableNames(check).filter((name) => /^cacheInterceptorV\d+$/.test(name)),
-    ['cacheInterceptorV12'],
-    'v13 was not created and v12 was not dropped',
+    ['cacheInterceptorV13'],
+    'v14 was not created and v13 was not dropped',
   )
   t.equal(
-    check.prepare('SELECT hex(body) AS body FROM cacheInterceptorV12').get().body,
+    check.prepare('SELECT hex(body) AS body FROM cacheInterceptorV13').get().body,
     'DEADBEEF',
-    'v12 data remains readable to an operator-selected older package',
+    'v13 data remains readable to an operator-selected older package',
   )
   t.end()
 })
 
-test('v13 operates and persists Authorization request provenance', (t) => {
-  const dbPath = tmpDb(t, 'schema-v13')
+test('v14 operates with Authorization provenance and response-Date ordering', (t) => {
+  const dbPath = tmpDb(t, 'schema-v14')
   const key = {
     origin: 'https://example.com',
     method: 'GET',
@@ -81,6 +81,7 @@ test('v13 operates and persists Authorization request provenance', (t) => {
     headers: {},
   }
   const now = Date.now()
+  const responseDate = new Date(now).toUTCString()
   const store = new SqliteCacheStore({ location: dbPath })
   store.set(key, {
     body: Buffer.from('secret'),
@@ -88,6 +89,7 @@ test('v13 operates and persists Authorization request provenance', (t) => {
     end: 6,
     statusCode: 200,
     statusMessage: 'OK',
+    headers: { date: responseDate },
     authorizationRequest: true,
     cachedAt: now,
     staleAt: now + 60e3,
@@ -103,13 +105,20 @@ test('v13 operates and persists Authorization request provenance', (t) => {
 
   const check = new DatabaseSync(dbPath, { readOnly: true })
   t.teardown(() => check.close())
-  t.ok(tableNames(check).includes('cacheInterceptorV13'), 'the current v13 table exists')
+  t.ok(tableNames(check).includes('cacheInterceptorV14'), 'the current v14 table exists')
+  const columns = check.prepare('PRAGMA table_info(cacheInterceptorV14)').all()
   t.ok(
-    check
-      .prepare('PRAGMA table_info(cacheInterceptorV13)')
-      .all()
-      .some(({ name }) => name === 'authorizationRequest'),
-    'v13 contains the provenance column',
+    columns.some(({ name }) => name === 'authorizationRequest'),
+    'v14 contains provenance',
+  )
+  t.ok(
+    columns.some(({ name }) => name === 'responseDate'),
+    'v14 contains response Date',
+  )
+  t.equal(
+    check.prepare('SELECT responseDate FROM cacheInterceptorV14').get().responseDate,
+    Date.parse(responseDate),
+    'v14 persists the parsed response Date used for selection',
   )
   t.end()
 })

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -107,7 +107,7 @@ test('#flush drops the batch instead of spinning when the FULL-eviction query th
 })
 
 test('schema v14: Date-ordered lookup needs no temp B-tree; body is last', async (t) => {
-  const dbPath = tmpDb(t, 'v13-plan')
+  const dbPath = tmpDb(t, 'v14-plan')
   const store = new SqliteCacheStore({ location: dbPath })
   store.set(makeKey(), makeValue())
   await flush()

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -1,7 +1,7 @@
 // Regression tests for the 2026-07 cache deep-review fixes (sqlite store):
 // - #flush must not busy-loop on setImmediate when the SQLITE_FULL eviction
 //   query itself throws (batch pinned forever, CPU pegged, warning spam).
-// - schema v12: the lookup query must not need a temp B-tree sort (which
+// - the current schema's lookup query must not need a temp B-tree sort (which
 //   materialized every candidate row's body blob per get), and the body blob
 //   must be the last column so candidate filtering never walks its overflow
 //   pages.
@@ -106,8 +106,8 @@ test('#flush drops the batch instead of spinning when the FULL-eviction query th
   t.end()
 })
 
-test('schema v12: no temp B-tree sort on lookup; body blob is the last column', async (t) => {
-  const dbPath = tmpDb(t, 'v12-plan')
+test('schema v14: Date-ordered lookup needs no temp B-tree; body is last', async (t) => {
+  const dbPath = tmpDb(t, 'v13-plan')
   const store = new SqliteCacheStore({ location: dbPath })
   store.set(makeKey(), makeValue())
   await flush()
@@ -128,13 +128,14 @@ test('schema v12: no temp B-tree sort on lookup; body blob is the last column', 
   const cols = db.prepare(`PRAGMA table_info(${table})`).all()
   t.equal(cols[cols.length - 1].name, 'body', 'body is the last column')
 
-  // Mirror of #getValuesQuery's shape: same WHERE and ORDER BY. The (url,
-  // method) index must satisfy ORDER BY id DESC via a backward scan — no
+  // Mirror of #getValuesQuery's shape: same WHERE and ORDER BY. The
+  // (url, method, responseDate, id) index must satisfy Date ordering with no
   // temp B-tree, which would materialize every candidate row (incl. blobs).
   const plan = db
     .prepare(
       `EXPLAIN QUERY PLAN SELECT id, start, end, deleteAt FROM ${table}
-       WHERE url = ? AND method = ? AND start <= ? AND deleteAt > ? ORDER BY id DESC`,
+       WHERE url = ? AND method = ? AND start <= ? AND deleteAt > ?
+       ORDER BY responseDate DESC, id DESC`,
     )
     .all()
   t.notOk(


### PR DESCRIPTION
## Stack

This PR is intentionally stacked on `codex/cache-auth-provenance`. That base introduces SQLite schema v13; this PR adds response-Date selection and produces the combined v14 schema.

## Summary

When multiple stored responses are suitable—typically overlapping `Vary` selectors—the store chose by write order. A delayed older response could therefore win merely because it arrived last.

This change:

- persists a numeric response-selection Date, falling back to receipt time for missing, invalid, non-string, or duplicated case-insensitive Date fields;
- orders persisted and pending candidates by response Date, using receipt order only for ties;
- extends the lookup index so the common first match remains efficient;
- makes pending replacements/tombstones immediately supersede their persisted representation, so answers do not change merely when the asynchronous batch flush runs;
- indexes pending representation identities once and compacts candidates in one pass, keeping the pending/SQLite merge O(candidates + pending writes); and
- makes schema-table inspection in tests select the highest numeric version deterministically.

## RFC rationale

[RFC 9111 §4](https://www.rfc-editor.org/rfc/rfc9111.html#section-4) says that when more than one suitable response is stored, a cache **MUST** use the most recent one as determined by `Date`. [§4.1](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1) permits known preference ranking first; Date is the required fallback when no such preference distinguishes the matches.

## Tests

- Proves a newer response Date wins even when the older matching variant is written later.
- Proves pending and flushed candidates use identical ordering.
- Proves duplicated case-insensitive Date fields fall back to receipt time before and after persistence.
- Adds older-Date replacement and older-Date tombstone regressions for the pending/SQLite seam.
- Exercises 64 pending identities plus an expired tombstone and a neighboring distinct selector, preserving exact supersession while covering the linear merge structure.
- Verifies v13 is rejected byte-for-byte, v14 operates with both provenance and response-Date columns, and `SuppressedError` cleanup behavior remains intact.
- Final schema/date-focused runs: 392 assertions passed.
- ESLint, Prettier, and `git diff --check` pass.

## Rollout

This stacked branch changes the persistent cache schema from v13 to v14 (and from main's v12 to v14 when the stack is merged). Following #96, mismatched cache files are never migrated, dropped, or treated as an automatic cold fill: startup throws `ERR_SQLITE_CACHE_SCHEMA_MISMATCH` before modifying the file.

Drain workers using the older schema before starting v14. Then either intentionally remove/rename the disposable old cache file so v14 can create a fresh one, or configure a version-specific cache path. Do not run different schema versions against the same file. If old contents must be preserved, retain the file and access it only with the matching package version. The default `:memory:` store is unaffected.
