### PR TITLE
fix(cache): snapshot response chunks before user delivery

### DIFF
--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -344,7 +344,6 @@ export class CacheHandler extends DecoratorHandler {
   onData(chunk) {
     if (this.#value) {
       this.#value.size += chunk.length
-      this.#value.body.push(chunk)
 
       if (this.#value.size > this.#maxEntrySize) {
         // The buffer flips to discarded exactly once per attempt (#value stays
@@ -352,6 +351,12 @@ export class CacheHandler extends DecoratorHandler {
         const statusCode = this.#value.statusCode
         this.#value = null
         this.#trace(statusCode, false, 'too-large', null, null, null)
+      } else {
+        // Snapshot before forwarding the same chunk downstream. A raw handler
+        // (or a request-body consumer while the response is still streaming)
+        // can mutate its Buffer in place; retaining that shared reference
+        // would persist the caller's bytes at onComplete and poison later hits.
+        this.#value.body.push(Buffer.from(chunk))
       }
     }
 

--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -353,7 +353,7 @@ export class CacheHandler extends DecoratorHandler {
         this.#trace(statusCode, false, 'too-large', null, null, null)
       } else {
         // Snapshot before forwarding the same chunk downstream. A raw handler
-        // (or a request-body consumer while the response is still streaming)
+        // (or a response-body consumer while the response is still streaming)
         // can mutate its Buffer in place; retaining that shared reference
         // would persist the caller's bytes at onComplete and poison later hits.
         this.#value.body.push(Buffer.from(chunk))

--- a/test/review-bugfixes-6-cache-body-snapshot.js
+++ b/test/review-bugfixes-6-cache-body-snapshot.js
@@ -1,0 +1,56 @@
+import { test } from 'tap'
+import { interceptors, cache as cacheModule } from '../lib/index.js'
+
+const { SqliteCacheStore } = cacheModule
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+test('cache: caller mutation of an origin body chunk does not poison the stored body', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  let originHits = 0
+  const originChunk = Buffer.from('hello')
+  const dispatch = interceptors.cache()((_opts, handler) => {
+    originHits++
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'cache-control': 'max-age=60' }, () => {})
+    handler.onData(originChunk)
+    handler.onComplete(null)
+    return true
+  })
+
+  const request = (mutate) =>
+    new Promise((resolve, reject) => {
+      const chunks = []
+      dispatch(
+        {
+          origin: 'http://cache-body-snapshot.local',
+          path: '/',
+          method: 'GET',
+          headers: {},
+          cache: { store },
+        },
+        {
+          onConnect() {},
+          onHeaders() {},
+          onData(chunk) {
+            chunks.push(Buffer.from(chunk))
+            if (mutate) {
+              chunk[0] = 0x58 // X
+            }
+          },
+          onComplete() {
+            resolve(Buffer.concat(chunks).toString())
+          },
+          onError: reject,
+        },
+      )
+    })
+
+  t.equal(await request(true), 'hello', 'the first caller receives the origin bytes')
+  await flush()
+
+  t.equal(await request(false), 'hello', 'the cached body retains the original bytes')
+  t.equal(originHits, 1, 'the second request was served from cache')
+})


### PR DESCRIPTION
## Summary

`CacheHandler` retained the same mutable Buffer reference that it passed to the downstream `onData` callback. A raw handler could mutate that Buffer before `onComplete`, changing the bytes later persisted and poisoning subsequent hits.

Snapshot each eligible chunk with `Buffer.from(chunk)` before user delivery. If the response exceeds `maxEntrySize`, buffering is still discarded as before.

This is a follow-up to #29, which fixed the equivalent response-header ownership bug.

## Requirement strength

This is an implementation ownership/integrity bug rather than a new cache-directive rule. RFC 9111's storage model assumes the stored representation is the one received from the origin; the defensive copy preserves that invariant for mutable JavaScript byte arrays.

The cost is one copy per chunk while the response remains eligible for caching. Oversized or otherwise unstorable responses are not retained.

## Tests

- A hostile raw handler overwrites the first byte during `onData`.
- The first caller, stored body, and later cache hit retain the original bytes; only one origin dispatch occurs.
- `npm run test:cache-tests`: 244 passed, 0 required failures, 0 retries.
- ESLint, Prettier, and `git diff --check` pass.
