### PR TITLE
fix(cache): refetch after a 304 fails validator identification

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -449,6 +449,7 @@ export default ({ origins } = {}) => {
         id: opts.id ?? null,
         url,
         lookupMs,
+        dispatch,
       }),
     )
   }

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -77,6 +77,7 @@ export class RevalidationHandler {
   #url
   #lookupMs
   #background
+  #dispatch
   /** @type {null | 'pass' | 'validated' | 'stale'} */
   #mode = null
   /** @type {CacheHandler | import('../../utils.js').DecoratorHandler | object | null} */
@@ -105,6 +106,7 @@ export class RevalidationHandler {
       url,
       lookupMs,
       background,
+      dispatch,
     },
   ) {
     this.#key = key
@@ -129,6 +131,7 @@ export class RevalidationHandler {
     // (freshen / replacement) and suppresses lookup docs — a second lookup doc
     // sharing the triggering id would double-count the hit.
     this.#background = background ?? false
+    this.#dispatch = dispatch ?? null
   }
 
   // The `undici:cache-store` emitter for the freshen store write — the same
@@ -249,7 +252,11 @@ export class RevalidationHandler {
     }
     // Freshen even when the user aborted mid-flight — the 304 validated the
     // entry either way, and the store write benefits every other caller.
-    this.#deliver(this.#mode === 'validated' ? this.#freshen() : this.#entry)
+    if (this.#mode === 'validated') {
+      const freshened = this.#freshen()
+      return freshened == null ? this.#retryUnconditional() : this.#deliver(freshened)
+    }
+    this.#deliver(this.#entry)
   }
 
   onError(err) {
@@ -265,7 +272,8 @@ export class RevalidationHandler {
     if (this.#mode === 'validated') {
       // The 304 already validated the entry; a broken tail on the (empty)
       // validation response doesn't invalidate it.
-      return this.#deliver(this.#freshen())
+      const freshened = this.#freshen()
+      return freshened == null ? this.#retryUnconditional() : this.#deliver(freshened)
     }
     if (this.#mode === 'stale' || this.#allowStaleOnError) {
       // Pre-response connection errors (ECONNREFUSED, reset, ...) count as
@@ -348,10 +356,65 @@ export class RevalidationHandler {
     }
   }
 
+  #retryUnconditional() {
+    if (this.#delivered) {
+      return
+    }
+    if (this.#userAborted) {
+      return this.#fail(this.#userAbortReason ?? new Error('aborted'))
+    }
+    if (this.#dispatch == null) {
+      return this.#fail(new Error('cache revalidation validator did not identify stored response'))
+    }
+
+    this.#mode = 'pass'
+    if (this.#write !== null && !this.#background) {
+      traceLookup(
+        this.#write,
+        this.#opts,
+        this.#url,
+        'miss',
+        'validator-mismatch',
+        null,
+        null,
+        null,
+        this.#lookupMs,
+      )
+    }
+
+    this.#inner = this.#noStore
+      ? this.#userHandler
+      : new CacheHandler(this.#key, {
+          ...this.#cacheOpts,
+          store: this.#store,
+          logger: this.#logger,
+          handler: this.#userHandler,
+          write: this.#write,
+          id: this.#id,
+          url: this.#url,
+        })
+
+    // Revalidation's validators were internal cache fields. Retry through the
+    // already-lower dispatch with the original key headers so the origin must
+    // provide a full response. This also covers a background refresh, whose
+    // #opts already contain the internal conditional fields.
+    const headers = Object.create(null)
+    for (const name of Object.keys(this.#key.headers ?? {})) {
+      headers[name] = this.#key.headers[name]
+    }
+    try {
+      return this.#dispatch({ ...this.#opts, headers }, this.#inner)
+    } catch (err) {
+      this.#fail(err)
+    }
+  }
+
   /**
    * RFC 9111 §4.3.4: merge the 304's headers over the stored ones and reset
    * the freshness clock. Returns the entry to serve; the store is only
-   * updated when the merged response is still storable.
+   * updated when the merged response is still storable. Returns null when
+   * the 304 validator does not identify this entry, triggering an
+   * unconditional recovery request instead of serving unvalidated bytes.
    */
   #freshen() {
     const entry = this.#entry
@@ -382,20 +445,17 @@ export class RevalidationHandler {
         etag304 = etag304[0]
       }
 
-      // RFC 9111 §4.3.4 validator identification: a 304 carrying a usable
-      // ETag that does not (weak-)match the stored entry's does not identify
-      // it and must not update it. Adopting the new validator would label
-      // the OLD body with it, and every later If-None-Match would then
-      // re-affirm the stale body indefinitely (a sloppy origin behind a
-      // load balancer answering 304 with the other node's ETag). Serve the
-      // stored entry for this one use, unfreshened.
-      if (
-        typeof etag304 === 'string' &&
-        isEtagUsable(etag304) &&
-        entry.etag &&
-        !weakMatch(etag304, entry.etag)
-      ) {
-        return entry
+      // RFC 9111 §4.3.4 applies the first matching identification rule. A
+      // strong validator in the 304 requires the same STRONG validator in the
+      // stored set; weak comparison is only available when the 304 validator
+      // is weak. No match means this body was not successfully validated.
+      if (typeof etag304 === 'string' && isEtagUsable(etag304)) {
+        const identified = etag304.startsWith('W/')
+          ? entry.etag != null && weakMatch(etag304, entry.etag)
+          : etag304 === entry.etag
+        if (!identified) {
+          return null
+        }
       }
 
       // Same exclusions as at store time — hop-by-hop, fields listed in the
@@ -693,6 +753,7 @@ export function backgroundRefresh(dispatch, opts, key, store, entry, write = nul
         id: opts.id ?? null,
         url,
         background: true,
+        dispatch,
       }),
     )
   } catch (err) {

--- a/test/review-bugfixes-5-revalidation.js
+++ b/test/review-bugfixes-5-revalidation.js
@@ -132,14 +132,19 @@ test('304 freshening honors the validating response Age header', async (t) => {
   t.end()
 })
 
-test('304 with a non-matching ETag does not freshen the entry or adopt the validator', async (t) => {
+test('304 with a non-matching ETag retries unconditionally instead of serving stale', async (t) => {
   let hits = 0
   const seenINM = []
   const server = await startServer((req, res) => {
     hits++
     seenINM.push(req.headers['if-none-match'] ?? null)
-    res.writeHead(304, { etag: '"v2"', 'cache-control': 'max-age=60' })
-    res.end()
+    if (req.headers['if-none-match']) {
+      res.writeHead(304, { etag: '"v2"', 'cache-control': 'max-age=60' })
+      res.end()
+    } else {
+      res.writeHead(200, { etag: '"v2"', 'cache-control': 'max-age=60' })
+      res.end('fresh-v2-body')
+    }
   })
   t.teardown(() => server.close())
 
@@ -152,14 +157,16 @@ test('304 with a non-matching ETag does not freshen the entry or adopt the valid
   await settle()
 
   const res1 = await rawRequest(dispatch, opts)
-  t.equal(res1.statusCode, 200, 'stored entry served for the validated use')
-  t.equal(res1.body, 'stale-body')
+  t.equal(res1.statusCode, 200)
+  t.equal(res1.body, 'fresh-v2-body', 'unidentified stored bytes were not served')
   t.equal(seenINM[0], '"v1"', 'first conditional used the stored validator')
+  t.equal(seenINM[1], null, 'mismatching 304 was recovered with an unconditional request')
+  t.equal(hits, 2, 'the logical request needed one recovery fetch')
 
   await settle()
   const res2 = await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'entry was NOT freshened: second request revalidates again')
-  t.equal(seenINM[1], '"v1"', 'the mismatching "v2" validator was NOT adopted')
+  t.equal(hits, 2, 'the full recovery response was cached')
+  t.equal(res2.body, 'fresh-v2-body')
   t.end()
 })
 
@@ -169,11 +176,16 @@ test('304 with a duplicated (array) ETag does not evade the identification guard
   const server = await startServer((req, res) => {
     hits++
     seenINM.push(req.headers['if-none-match'] ?? null)
-    // Two ETag field lines (malformed) — undici parses them into an array.
-    res.setHeader('etag', ['"v2"', '"v3"'])
-    res.setHeader('cache-control', 'max-age=60')
-    res.writeHead(304)
-    res.end()
+    if (req.headers['if-none-match']) {
+      // Two ETag field lines (malformed) — undici parses them into an array.
+      res.setHeader('etag', ['"v2"', '"v3"'])
+      res.setHeader('cache-control', 'max-age=60')
+      res.writeHead(304)
+      res.end()
+    } else {
+      res.writeHead(200, { etag: '"v3"', 'cache-control': 'max-age=60' })
+      res.end('fresh-v3-body')
+    }
   })
   t.teardown(() => server.close())
 
@@ -186,12 +198,14 @@ test('304 with a duplicated (array) ETag does not evade the identification guard
   await settle()
 
   const res1 = await rawRequest(dispatch, opts)
-  t.equal(res1.statusCode, 200, 'stored entry served for the validated use')
+  t.equal(res1.statusCode, 200)
+  t.equal(res1.body, 'fresh-v3-body', 'malformed validator did not validate the stored bytes')
 
   await settle()
-  await rawRequest(dispatch, opts)
-  t.equal(hits, 2, 'entry was NOT freshened despite the array-shaped mismatching ETag')
-  t.equal(seenINM[1], '"v1"', 'the mismatching validator was NOT adopted')
+  const res2 = await rawRequest(dispatch, opts)
+  t.equal(hits, 2, 'the unconditional recovery response was cached')
+  t.equal(seenINM[1], null, 'the recovery request omitted the cache validator')
+  t.equal(res2.body, 'fresh-v3-body')
   t.end()
 })
 


### PR DESCRIPTION
## Summary

When a 304 carried a validator that did not identify the selected stored response, the cache declined to freshen it but still served the old body.

This change treats failed identification as such and performs one unconditional recovery request:

- remove the cache's internal conditional validators;
- use the full response for the current request;
- store a cacheable replacement; and
- apply the same recovery to synchronous and background validation.

## RFC rationale

[RFC 9111 §4.3.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4) says a strong validator identifies only a stored response with the same strong validator; weak matching is available only for a weak validator. When no stored response has the strong validator carried by the 304, the cache **MUST NOT** update any stored response.

The RFC mandates refusing the update; the unconditional fetch is the recovery mechanism that safely obtains a response for the current request.

## Tests

- Covers nonmatching strong validators, malformed duplicated ETag lines, removal of internal validators, replacement storage, and reuse.
- Focused revalidation/trace suites pass.
- Conformance: 244 passed, 0 required failures, 1 retried.

## Corpus incompatibility / #88 coordination

The retry is `304-etag-update-response-ETag`. The external case changes strong ETag `"abcdef"` to `"ghijkl"` in a 304 and expects the old body to adopt it, contrary to §4.3.4's **MUST NOT update** rule. The branch instead refetches unconditionally, which the harness classifies as a retry.

#88 introduces a retry gate with an empty baseline. Before both merge, either record this explicit RFC incompatibility in that baseline or correct/override the external case. The analysis is also documented on #71.
