### PR TITLE
fix(cache): exclude qualified private ETag validator metadata

### DIFF
--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -11,7 +11,7 @@ import {
   determineAge,
   determineLifetime,
 } from './freshness.js'
-import { isEtagUsable, isQualifiedFieldExcluded, parseVary } from './headers.js'
+import { isEtagUsable, isQualifiedPrivateField, parseVary } from './headers.js'
 
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
 
@@ -243,21 +243,16 @@ export class CacheHandler extends DecoratorHandler {
     }
 
     // ETag is persisted twice: in the response headers and as an indexed
-    // validator used by the read/revalidation paths. A qualified no-cache or
-    // private directive must exclude BOTH copies; otherwise the hidden copy
-    // could still synthesize a 304 or validate later requests after the field
-    // itself was deliberately removed from storedHeaders below (RFC 9111
-    // §3.1/§5.2.2.4/§5.2.2.7).
+    // validator used by the read/revalidation paths. Qualified private must
+    // exclude BOTH copies; otherwise the hidden copy violates RFC 9111
+    // §5.2.2.7 after the header itself is removed below.
     const etag =
-      !isQualifiedFieldExcluded(cacheControlDirectives, 'etag') &&
+      !isQualifiedPrivateField(cacheControlDirectives, 'etag') &&
       typeof headers.etag === 'string' &&
       isEtagUsable(headers.etag)
         ? headers.etag
         : ''
-    const hasValidator =
-      etag !== '' ||
-      (!isQualifiedFieldExcluded(cacheControlDirectives, 'last-modified') &&
-        typeof headers['last-modified'] === 'string')
+    const hasValidator = etag !== '' || typeof headers['last-modified'] === 'string'
     const age = determineAge(headers, now)
     const times = computeEntryTimes(
       lifetimeInfo.lifetime,

--- a/lib/interceptor/cache/cache-handler.js
+++ b/lib/interceptor/cache/cache-handler.js
@@ -11,7 +11,7 @@ import {
   determineAge,
   determineLifetime,
 } from './freshness.js'
-import { isEtagUsable, parseVary } from './headers.js'
+import { isEtagUsable, isQualifiedFieldExcluded, parseVary } from './headers.js'
 
 const DEFAULT_MAX_ENTRY_SIZE = 128 * 1024
 
@@ -242,8 +242,22 @@ export class CacheHandler extends DecoratorHandler {
       return this.#skip('no-lifetime', statusCode, headers, resume)
     }
 
-    const etag = typeof headers.etag === 'string' && isEtagUsable(headers.etag) ? headers.etag : ''
-    const hasValidator = etag !== '' || typeof headers['last-modified'] === 'string'
+    // ETag is persisted twice: in the response headers and as an indexed
+    // validator used by the read/revalidation paths. A qualified no-cache or
+    // private directive must exclude BOTH copies; otherwise the hidden copy
+    // could still synthesize a 304 or validate later requests after the field
+    // itself was deliberately removed from storedHeaders below (RFC 9111
+    // §3.1/§5.2.2.4/§5.2.2.7).
+    const etag =
+      !isQualifiedFieldExcluded(cacheControlDirectives, 'etag') &&
+      typeof headers.etag === 'string' &&
+      isEtagUsable(headers.etag)
+        ? headers.etag
+        : ''
+    const hasValidator =
+      etag !== '' ||
+      (!isQualifiedFieldExcluded(cacheControlDirectives, 'last-modified') &&
+        typeof headers['last-modified'] === 'string')
     const age = determineAge(headers, now)
     const times = computeEntryTimes(
       lifetimeInfo.lifetime,

--- a/lib/interceptor/cache/headers.js
+++ b/lib/interceptor/cache/headers.js
@@ -59,23 +59,18 @@ export function parseVary(varyHeader, requestHeaders) {
 }
 
 /**
- * Whether a response field is named by a qualified no-cache or private
- * directive. RFC 9111 §3.1 requires those fields to be excluded from storage
- * by all caches (no-cache) or shared caches (private). Field names are
- * case-insensitive (§5.2.2.4 / §5.2.2.7).
+ * Whether a response field is named by a qualified private directive.
+ * RFC 9111 §5.2.2.7 says a shared cache MUST NOT store such fields. This is
+ * intentionally narrower than qualified no-cache: §5.2.2.4 permits internal
+ * storage when the field is excluded from an unvalidated later response.
  */
-export function isQualifiedFieldExcluded(cacheControlDirectives, fieldName) {
+export function isQualifiedPrivateField(cacheControlDirectives, fieldName) {
   const name = fieldName.toLowerCase()
-  for (const directive of ['no-cache', 'private']) {
-    const fields = cacheControlDirectives[directive]
-    if (
-      Array.isArray(fields) &&
-      fields.some((field) => typeof field === 'string' && field.toLowerCase() === name)
-    ) {
-      return true
-    }
-  }
-  return false
+  const fields = cacheControlDirectives.private
+  return (
+    Array.isArray(fields) &&
+    fields.some((field) => typeof field === 'string' && field.toLowerCase() === name)
+  )
 }
 
 /**

--- a/lib/interceptor/cache/headers.js
+++ b/lib/interceptor/cache/headers.js
@@ -59,6 +59,26 @@ export function parseVary(varyHeader, requestHeaders) {
 }
 
 /**
+ * Whether a response field is named by a qualified no-cache or private
+ * directive. RFC 9111 §3.1 requires those fields to be excluded from storage
+ * by all caches (no-cache) or shared caches (private). Field names are
+ * case-insensitive (§5.2.2.4 / §5.2.2.7).
+ */
+export function isQualifiedFieldExcluded(cacheControlDirectives, fieldName) {
+  const name = fieldName.toLowerCase()
+  for (const directive of ['no-cache', 'private']) {
+    const fields = cacheControlDirectives[directive]
+    if (
+      Array.isArray(fields) &&
+      fields.some((field) => typeof field === 'string' && field.toLowerCase() === name)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Conditional request headers for revalidating a stored entry (RFC 9111
  * §4.3.1). Per RFC 9110 §13.1.3 and undici PR #5512, If-Modified-Since echoes
  * the stored Last-Modified VERBATIM when available (nginx's default

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -8,7 +8,13 @@ import {
   determineAge,
   determineLifetime,
 } from './freshness.js'
-import { conditionalHeaders, isEtagUsable, parseVary, weakMatch } from './headers.js'
+import {
+  conditionalHeaders,
+  isEtagUsable,
+  isQualifiedFieldExcluded,
+  parseVary,
+  weakMatch,
+} from './headers.js'
 import { serveFromCache, traceLookup } from './serve.js'
 import { cacheOptsOf } from './store.js'
 
@@ -550,8 +556,12 @@ export class RevalidationHandler {
         }
       }
 
-      const etag =
-        typeof merged.etag === 'string' && isEtagUsable(merged.etag)
+      // The header deletion above is not sufficient for ETag: entries carry a
+      // second, indexed validator copy. Do not fall back to that copy when the
+      // 304's merged directives explicitly exclude ETag from storage.
+      const etag = isQualifiedFieldExcluded(cacheControlDirectives, 'etag')
+        ? ''
+        : typeof merged.etag === 'string' && isEtagUsable(merged.etag)
           ? merged.etag
           : (entry.etag ?? '')
       const hasValidator = etag !== '' || typeof merged['last-modified'] === 'string'

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -11,7 +11,7 @@ import {
 import {
   conditionalHeaders,
   isEtagUsable,
-  isQualifiedFieldExcluded,
+  isQualifiedPrivateField,
   parseVary,
   weakMatch,
 } from './headers.js'
@@ -558,8 +558,8 @@ export class RevalidationHandler {
 
       // The header deletion above is not sufficient for ETag: entries carry a
       // second, indexed validator copy. Do not fall back to that copy when the
-      // 304's merged directives explicitly exclude ETag from storage.
-      const etag = isQualifiedFieldExcluded(cacheControlDirectives, 'etag')
+      // 304's merged private directive prohibits storing ETag.
+      const etag = isQualifiedPrivateField(cacheControlDirectives, 'etag')
         ? ''
         : typeof merged.etag === 'string' && isEtagUsable(merged.etag)
           ? merged.etag

--- a/test/cache-qualified-field-exclusion.js
+++ b/test/cache-qualified-field-exclusion.js
@@ -1,0 +1,124 @@
+import { test } from 'tap'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import undici from '@nxtedition/undici'
+
+const { SqliteCacheStore } = cacheModule
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(sc) {
+        statusCode = sc
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.from(chunk))
+        return true
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+for (const directive of ['private="etag"', 'no-cache="etag"']) {
+  test(`qualified ${directive} excludes ETag from stored validator metadata`, async (t) => {
+    const server = await startServer((req, res) => {
+      res.writeHead(200, {
+        'cache-control': `max-age=60, ${directive}`,
+        etag: '"secret"',
+      })
+      res.end('body')
+    })
+    t.teardown(() => server.close())
+
+    const store = new SqliteCacheStore({ location: ':memory:' })
+    t.teardown(() => store.close())
+    const dispatch = compose(new undici.Agent(), interceptors.cache())
+    const origin = `http://0.0.0.0:${server.address().port}`
+    const base = { origin, path: '/', method: 'GET', cache: { store } }
+
+    await rawRequest(dispatch, { ...base, headers: {} })
+    await flush()
+
+    const entry = store.get({ ...base, headers: {} })
+    t.equal(entry.headers.etag, undefined, 'ETag response field is excluded')
+    t.equal(entry.etag, '', 'the separate validator copy is excluded too')
+
+    const conditional = await rawRequest(dispatch, {
+      ...base,
+      headers: { 'if-none-match': '"secret"' },
+    })
+    t.equal(conditional.statusCode, 200, 'cache cannot synthesize a 304 from the excluded ETag')
+  })
+}
+
+for (const directive of ['private="etag"', 'no-cache="etag"']) {
+  test(`a 304 adding qualified ${directive} clears the stored validator`, async (t) => {
+    let hits = 0
+    const server = await startServer((req, res) => {
+      hits++
+      if (hits === 1) {
+        res.writeHead(304, { 'cache-control': `max-age=60, ${directive}` })
+        res.end()
+      } else {
+        res.writeHead(200, { 'cache-control': 'no-store' })
+        res.end('current')
+      }
+    })
+    t.teardown(() => server.close())
+
+    const store = new SqliteCacheStore({ location: ':memory:' })
+    t.teardown(() => store.close())
+    const dispatch = compose(new undici.Agent(), interceptors.cache())
+    const origin = `http://0.0.0.0:${server.address().port}`
+    const key = { origin, path: '/', method: 'GET', headers: {} }
+    const now = Date.now()
+    store.set(key, {
+      body: Buffer.from('stored'),
+      start: 0,
+      end: 6,
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers: { 'cache-control': 'max-age=0', etag: '"secret"' },
+      cacheControlDirectives: { 'max-age': 0 },
+      etag: '"secret"',
+      vary: {},
+      cachedAt: now - 1000,
+      staleAt: now - 1000,
+      deleteAt: now + 60_000,
+    })
+    await flush()
+
+    const validated = await rawRequest(dispatch, { ...key, cache: { store } })
+    t.equal(validated.body, 'stored')
+    await flush()
+
+    const entry = store.get(key)
+    t.equal(entry.headers.etag, undefined, '304 update removes the ETag response field')
+    t.equal(entry.etag, '', '304 update also clears the separate validator copy')
+
+    const conditional = await rawRequest(dispatch, {
+      ...key,
+      headers: { 'if-none-match': '"secret"' },
+      cache: { store },
+    })
+    t.equal(conditional.statusCode, 200, 'excluded old ETag cannot produce a later cached 304')
+  })
+}

--- a/test/cache-qualified-field-exclusion.js
+++ b/test/cache-qualified-field-exclusion.js
@@ -37,7 +37,7 @@ async function startServer(handler) {
 
 const flush = () => new Promise((resolve) => setImmediate(resolve))
 
-for (const directive of ['private="etag"']) {
+for (const directive of ['private="ETag"']) {
   test(`qualified ${directive} excludes ETag from stored validator metadata`, async (t) => {
     const server = await startServer((req, res) => {
       res.writeHead(200, {
@@ -69,7 +69,7 @@ for (const directive of ['private="etag"']) {
   })
 }
 
-for (const directive of ['private="etag"']) {
+for (const directive of ['private="ETag"']) {
   test(`a 304 adding qualified ${directive} clears the stored validator`, async (t) => {
     let hits = 0
     const server = await startServer((req, res) => {

--- a/test/cache-qualified-field-exclusion.js
+++ b/test/cache-qualified-field-exclusion.js
@@ -37,7 +37,7 @@ async function startServer(handler) {
 
 const flush = () => new Promise((resolve) => setImmediate(resolve))
 
-for (const directive of ['private="etag"', 'no-cache="etag"']) {
+for (const directive of ['private="etag"']) {
   test(`qualified ${directive} excludes ETag from stored validator metadata`, async (t) => {
     const server = await startServer((req, res) => {
       res.writeHead(200, {
@@ -69,7 +69,7 @@ for (const directive of ['private="etag"', 'no-cache="etag"']) {
   })
 }
 
-for (const directive of ['private="etag"', 'no-cache="etag"']) {
+for (const directive of ['private="etag"']) {
   test(`a 304 adding qualified ${directive} clears the stored validator`, async (t) => {
     let hits = 0
     const server = await startServer((req, res) => {


### PR DESCRIPTION
## Summary

Entries persist ETag both in response headers and as separate indexed validator metadata. Qualified `private="etag"` removed the header but left the indexed copy, which could still synthesize a local 304 or drive revalidation.

This change excludes both copies at initial storage and clears the indexed copy when a 304 adds qualified private. Field-name matching is case-insensitive.

## RFC rationale

[RFC 9111 §5.2.2.7](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.7) says a shared cache **MUST NOT store** fields listed by qualified `private`. A semantically equivalent hidden ETag copy is still storage.

This is intentionally limited to `private`. Qualified `no-cache` (§5.2.2.4) may retain internal validator state when the field is excluded from an unvalidated later response, so this PR does not impose a stricter deletion policy there.

## Tests

- Initial-storage and 304-update regressions verify the header and hidden validator are both removed and cannot generate a later cached 304.
- Focused cache/revalidation run: 180 assertions passed.
- ESLint, Prettier, and `git diff --check` pass.
