### PR TITLE
fix(cache): retire obsolete variants after 304 Vary changes

### DIFF
--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -679,11 +679,11 @@ export class RevalidationHandler {
   #expireSelected(entry, headers, cacheControlDirectives, now) {
     try {
       if (this.#noStore) {
-        // A request no-store forbids writing even an expired response row.
-        // Deleting all variants is conservative but safe; custom stores are
-        // allowed to omit delete(), in which case there is no variant-scoped
-        // removal operation available.
-        this.#store.delete?.(this.#key)
+        // Request no-store forbids persisting this validation response, but it
+        // is not an invalidation directive for an already stored response
+        // (RFC 9111 §5.2.1.5). The store contract has no variant-scoped
+        // delete, so a broad delete here would unnecessarily evict unrelated
+        // variants. Leave the selected row untouched, as before.
         return
       }
 

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -688,8 +688,10 @@ export class RevalidationHandler {
       }
 
       this.#store.set(this.#key, {
-        // Copy: the same bytes can still be served to the user handler.
-        body: entry.body ? Buffer.from(entry.body) : (entry.body ?? null),
+        // No copy: SqliteCacheStore.set() already snapshots the body, and this
+        // tombstone row is expired the instant it is written (staleAt below)
+        // and never served, so sharing entry.body's reference is harmless.
+        body: entry.body ?? null,
         start: 0,
         end: entry.body ? entry.body.byteLength : 0,
         statusCode: entry.statusCode,

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -593,9 +593,14 @@ export class RevalidationHandler {
       // the stored metadata stays consistent with the served headers and
       // variant matching doesn't break if the origin changed Vary. A merged
       // Vary of '*' (or a non-string duplicate) makes the entry uncacheable —
-      // serve this validated use but don't re-store it.
+      // serve this validated use but don't re-store it. The selected OLD row
+      // must also stop being selectable: RFC 9111 §4.3.4 updates the stored
+      // response's metadata, and retaining its pre-304 Vary would let a later
+      // max-stale request reuse a representation whose new Vary can never
+      // match.
       const vary = parseVary(merged.vary, this.#key.headers)
       if (vary == null) {
+        this.#expireSelected(entry, merged, cacheControlDirectives, now)
         return { ...entry, headers: merged }
       }
 

--- a/lib/interceptor/cache/revalidation.js
+++ b/lib/interceptor/cache/revalidation.js
@@ -42,7 +42,7 @@ const backgroundRefreshes = new WeakMap()
  * string value.
  */
 function varyKey(vary) {
-  if (!vary) {
+  if (!vary || Object.keys(vary).length === 0) {
     return ''
   }
   const names = Object.keys(vary).sort()
@@ -521,36 +521,7 @@ export class RevalidationHandler {
         // variant with immediate expiry so it drops out of lookups —
         // store.delete() would be too broad (it drops every variant of the
         // URL). Skipped under request no-store like every other write.
-        if (!this.#noStore) {
-          try {
-            this.#store.set(this.#key, {
-              // Copy: the same bytes are being served to the user handler
-              // (see the aliasing note on the freshened set() below).
-              body: entry.body ? Buffer.from(entry.body) : (entry.body ?? null),
-              start: 0,
-              end: entry.body ? entry.body.byteLength : 0,
-              statusCode: entry.statusCode,
-              statusMessage: entry.statusMessage ?? '',
-              headers: merged,
-              cacheControlDirectives,
-              etag: entry.etag ?? '',
-              vary: entry.vary,
-              cachedAt: entry.cachedAt,
-              // Comfortably in the past, not `now`: the sqlite store's read
-              // filter runs on getFastNow(), which can lag Date.now() by up
-              // to a second — a deleteAt of exactly `now` would leave the
-              // tombstone servable for that lag window.
-              staleAt: now - 60e3,
-              deleteAt: now - 60e3,
-            })
-          } catch (err) {
-            if (err.message === 'database is locked') {
-              this.#logger?.debug({ err }, 'failed to expire cache entry')
-            } else {
-              this.#logger?.error({ err }, 'failed to expire cache entry')
-            }
-          }
-        }
+        this.#expireSelected(entry, merged, cacheControlDirectives, now)
         return { ...entry, headers: merged }
       }
 
@@ -628,6 +599,17 @@ export class RevalidationHandler {
         return { ...entry, headers: merged }
       }
 
+      // The store keys variants by the persisted selector map. Writing the
+      // freshened entry under a NEW Vary selector does not supersede the row
+      // under its old selector; without expiring it, a request that fails the
+      // new selector can fall through to the old row and reuse the same body
+      // for a different variant (notably via max-stale/SWR). RFC 9111 §4.3.4
+      // requires the selected stored response's fields to be updated, not a
+      // second differently-keyed response to be added alongside it.
+      if (varyKey(entry.vary) !== varyKey(vary)) {
+        this.#expireSelected(entry, merged, cacheControlDirectives, now)
+      }
+
       const freshened = {
         // 206 entries never take the revalidation path, so the stored body is
         // the full representation: start 0, end = byte length (0 for HEAD).
@@ -686,6 +668,45 @@ export class RevalidationHandler {
       // Freshening must never break delivery of a validated entry.
       this.#logger?.error({ err }, 'failed to freshen cache entry')
       return entry
+    }
+  }
+
+  #expireSelected(entry, headers, cacheControlDirectives, now) {
+    try {
+      if (this.#noStore) {
+        // A request no-store forbids writing even an expired response row.
+        // Deleting all variants is conservative but safe; custom stores are
+        // allowed to omit delete(), in which case there is no variant-scoped
+        // removal operation available.
+        this.#store.delete?.(this.#key)
+        return
+      }
+
+      this.#store.set(this.#key, {
+        // Copy: the same bytes can still be served to the user handler.
+        body: entry.body ? Buffer.from(entry.body) : (entry.body ?? null),
+        start: 0,
+        end: entry.body ? entry.body.byteLength : 0,
+        statusCode: entry.statusCode,
+        statusMessage: entry.statusMessage ?? '',
+        headers,
+        cacheControlDirectives,
+        etag: entry.etag ?? '',
+        // Keep the OLD selector: the tombstone must supersede the row that was
+        // selected, not the replacement row that will use the new Vary map.
+        vary: entry.vary,
+        cachedAt: entry.cachedAt,
+        // Comfortably in the past, not `now`: the sqlite store's read filter
+        // uses getFastNow(), which can lag Date.now() by up to a second.
+        staleAt: now - 60e3,
+        deleteAt: now - 60e3,
+      })
+    } catch (err) {
+      if (err.message === 'database is locked') {
+        this.#logger?.debug({ err }, 'failed to expire cache entry')
+      } else {
+        this.#logger?.error({ err }, 'failed to expire cache entry')
+      }
     }
   }
 }

--- a/test/review-bugfixes-5-revalidation.js
+++ b/test/review-bugfixes-5-revalidation.js
@@ -315,6 +315,52 @@ test('304 must-understand overrides its paired no-store fallback', async (t) => 
   t.end()
 })
 
+test('304 changing Vary expires the selected row under its old selector', async (t) => {
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match']) {
+      res.writeHead(304, {
+        etag: '"v1"',
+        'cache-control': 'max-age=60',
+        vary: 'accept-language',
+      })
+      res.end()
+    } else {
+      res.writeHead(200, { 'cache-control': 'no-store' })
+      res.end('french-body')
+    }
+  })
+  t.teardown(() => server.close())
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), method: 'GET', path: '/x', cache: { store } }
+
+  // This selected row predates Vary, so it currently matches every language.
+  seedStale(store, origin(server), { etag: '"v1"', body: 'english-body' })
+  await settle()
+
+  const english = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'accept-language': 'en' },
+  })
+  t.equal(english.body, 'english-body', 'the matching 304 validates this use')
+  t.equal(hits, 1)
+  await settle()
+
+  // The freshened en row no longer matches. The pre-304 no-Vary row must not
+  // remain as a stale fallback, or max-stale leaks the en representation to fr.
+  const french = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'accept-language': 'fr', 'cache-control': 'max-stale=600' },
+  })
+  t.equal(hits, 2, 'the obsolete no-Vary row was not reused')
+  t.equal(french.body, 'french-body', 'the other variant came from the origin')
+  t.end()
+})
+
 test('freshened entry body is not aliased with the chunk delivered to the user', async (t) => {
   const server = await startServer((req, res) => {
     res.writeHead(304, { etag: '"v1"', 'cache-control': 'max-age=60' })

--- a/test/review-bugfixes-5-revalidation.js
+++ b/test/review-bugfixes-5-revalidation.js
@@ -11,6 +11,9 @@
 //   the old entry reusable until deleteAt.
 // - must-understand overrides its paired no-store fallback on a 304 because
 //   this cache implements 304 revalidation semantics (RFC 9111 §5.2.2.3).
+// - a 304 changing Vary to '*' must likewise retire the selected old row;
+//   merely declining to re-store leaves its old selector reusable via
+//   max-stale.
 // - the freshened entry's body must not be aliased between the store's
 //   pending write batch and the chunk delivered to the user handler.
 import { test } from 'tap'
@@ -358,6 +361,47 @@ test('304 changing Vary expires the selected row under its old selector', async 
   })
   t.equal(hits, 2, 'the obsolete no-Vary row was not reused')
   t.equal(french.body, 'french-body', 'the other variant came from the origin')
+  t.end()
+})
+
+test('304 changing Vary to * retires the selected row from max-stale reuse', async (t) => {
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    if (req.headers['if-none-match']) {
+      res.writeHead(304, {
+        etag: '"v1"',
+        'cache-control': 'max-age=60',
+        vary: '*',
+      })
+      res.end()
+    } else {
+      res.writeHead(200, { 'cache-control': 'no-store' })
+      res.end('fresh-uncacheable')
+    }
+  })
+  t.teardown(() => server.close())
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+  const dispatch = makeDispatch()
+  const base = { origin: origin(server), method: 'GET', path: '/x', cache: { store } }
+
+  seedStale(store, origin(server), { etag: '"v1"' })
+  await settle()
+
+  const validated = await rawRequest(dispatch, { ...base, headers: {} })
+  t.equal(validated.body, 'stale-body', 'the matching 304 validates this use')
+  t.equal(validated.headers.vary, '*', 'served metadata includes the updated Vary')
+  t.equal(hits, 1)
+  await settle()
+
+  const next = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'cache-control': 'max-stale=600' },
+  })
+  t.equal(hits, 2, 'the obsolete pre-Vary row was not reused')
+  t.equal(next.body, 'fresh-uncacheable', 'the next request reached the origin')
   t.end()
 })
 


### PR DESCRIPTION
## Summary

A 304 can change the selected response's `Vary`. The cache wrote the freshened response under its new selector but left the old selector row intact, allowing later `max-stale`/SWR reuse under request headers that no longer match.

This change:

- expires the selected row under its old selector before storing a changed selector;
- retires it when merged `Vary: *` cannot match;
- reuses the variant-scoped tombstone path when a 304 withdraws cacheability; and
- preserves request `no-store` isolation without broadly deleting unrelated variants.

## RFC rationale

[RFC 9111 §4.3.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4) requires the identified stored response's fields to be updated from the 304. Adding a differently keyed row while retaining the old selector does not update that response.

[RFC 9111 §4.1](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1) says every nominated request field must match, and `Vary: *` always fails. Request `no-store` (§5.2.1.5) prevents storing this exchange; it is not a broad invalidation command for unrelated variants.

## Tests

- Native regressions prove no-Vary → `Vary: Accept-Language` cannot leak an English body to a French request, and no-Vary → `Vary: *` cannot be resurrected by `max-stale`.
- Focused revalidation assertions pass.
- `npm run test:cache-tests`: 244 passed, 0 required failures, 0 retries.
- ESLint, Prettier, and `git diff --check` pass.
