### PR TITLE
fix(cache): enforce RFC rules for locally generated 304 responses

### DIFF
--- a/lib/interceptor/cache/headers.js
+++ b/lib/interceptor/cache/headers.js
@@ -2,6 +2,8 @@
 // and revalidation paths: Vary selector maps, conditional-request headers and
 // ETag handling. Pure functions — no store or handler state.
 
+const ENTITY_TAG_RE = /^(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"$/
+
 /**
  * Builds the Vary selector map (RFC 9111 §4.1): for each field named in the
  * response Vary header, records the request's value (a null sentinel when the
@@ -131,5 +133,5 @@ export function weakMatch(ifNoneMatch, etag) {
  * @returns {boolean}
  */
 export function isEtagUsable(etag) {
-  return typeof etag === 'string' && /^(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"$/.test(etag)
+  return typeof etag === 'string' && ENTITY_TAG_RE.test(etag)
 }

--- a/lib/interceptor/cache/headers.js
+++ b/lib/interceptor/cache/headers.js
@@ -123,39 +123,13 @@ export function weakMatch(ifNoneMatch, etag) {
 }
 
 /**
- * Note: this deviates from the spec a little. Empty etags ("", W/"") are valid,
- *  however, including them in cached responses serves little to no purpose.
+ * Whether a field value is exactly one RFC 9110 §8.8.3 entity-tag.
+ * opaque-tag is DQUOTE *etagc DQUOTE, so the empty strong and weak tags are
+ * valid; space, DQUOTE, DEL and characters above obs-text are not valid etagc.
  *
- * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-etag
- *
- * @param {string|any} etag
+ * @param {unknown} etag
  * @returns {boolean}
  */
 export function isEtagUsable(etag) {
-  if (typeof etag !== 'string') {
-    return false
-  }
-
-  if (etag.length <= 2) {
-    // Shortest an etag can be is two chars (just ""). This is where we deviate
-    //  from the spec requiring a min of 3 chars however
-    return false
-  }
-
-  if (etag[0] === '"' && etag[etag.length - 1] === '"') {
-    // ETag: ""asd123"" or ETag: "W/"asd123"", kinda undefined behavior in the
-    //  spec. Some servers will accept these while others don't.
-    // ETag: "asd123"
-    return !(etag[1] === '"' || etag.startsWith('"W/'))
-  }
-
-  if (etag.startsWith('W/"') && etag[etag.length - 1] === '"') {
-    // ETag: W/"", also where we deviate from the spec & require a min of 3
-    //  chars
-    // ETag: for W/"", W/"asd123"
-    return etag.length !== 4
-  }
-
-  // Anything else
-  return false
+  return typeof etag === 'string' && /^(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"$/.test(etag)
 }

--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -68,6 +68,25 @@ function originAllowed(origin, origins) {
   return false
 }
 
+/**
+ * Builds the metadata for a locally generated 304. Content-Range has defined
+ * semantics only on 206/416 (RFC 9110 §14.4), so it cannot be copied from a
+ * selected partial response. A 304 Content-Length is permitted only when it
+ * equals the corresponding full 200 response length (§8.6); the length on a
+ * cached 206 describes only its byte window, so omit that too.
+ */
+function notModifiedEntry(entry) {
+  const headers = Object.create(null)
+  for (const name of Object.keys(entry.headers ?? {})) {
+    const lower = name.toLowerCase()
+    if (lower === 'content-range' || (entry.statusCode === 206 && lower === 'content-length')) {
+      continue
+    }
+    headers[name] = entry.headers[name]
+  }
+  return { statusCode: 304, headers, cachedAt: entry.cachedAt }
+}
+
 export default ({ origins } = {}) => {
   assertCacheOrigins(origins, 'opts.origins')
   return (dispatch) => (opts, handler) => {
@@ -249,14 +268,7 @@ export default ({ origins } = {}) => {
         ? headers['if-none-match'].join(',')
         : headers['if-none-match']
       if (typeof ifNoneMatch === 'string' && entry.etag && weakMatch(ifNoneMatch, entry.etag)) {
-        return serveFromCache(
-          { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
-          opts,
-          handler,
-          write,
-          url,
-          lookupMs,
-        )
+        return serveFromCache(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
       }
       // If-None-Match didn't match (RFC 9110 §13.1.2): "proceed as normal".
       // The entry is fresh, so serve the stored 200 below (fall through)
@@ -268,14 +280,7 @@ export default ({ origins } = {}) => {
         lastModified &&
         new Date(lastModified) <= new Date(headers['if-modified-since'])
       ) {
-        return serveFromCache(
-          { statusCode: 304, headers: entry.headers, cachedAt: entry.cachedAt },
-          opts,
-          handler,
-          write,
-          url,
-          lookupMs,
-        )
+        return serveFromCache(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
       }
       // Modified since the caller's validator (or no comparable last-modified):
       // RFC 9110 §13.1.3 — proceed as normal. The entry is fresh, so serve the

--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -262,7 +262,13 @@ export default ({ origins } = {}) => {
     // rather than falling through to the full 200. A duplicated If-Modified-Since
     // is malformed (it is a single-value field), so a non-string value is left
     // to fall through and serve the stored 200 ("proceed as normal").
-    const servableFromCache = entry != null && fresh && !mustRevalidate
+    // RFC 9111 §4.3.2 scopes a cache's evaluation of caller preconditions to
+    // stored 200/206 responses. This also follows RFC 9110 §13.2.1: a server
+    // ignores preconditions when the unconditional response would be neither
+    // 2xx nor 412. In particular, a matching If-None-Match must not turn a
+    // fresh cached 307 (or future cached 301/404/etc.) into a synthetic 304.
+    const conditionApplicable = entry?.statusCode === 200 || entry?.statusCode === 206
+    const servableFromCache = entry != null && fresh && !mustRevalidate && conditionApplicable
     if (servableFromCache && headers['if-none-match']) {
       const ifNoneMatch = Array.isArray(headers['if-none-match'])
         ? headers['if-none-match'].join(',')
@@ -285,7 +291,11 @@ export default ({ origins } = {}) => {
       // Modified since the caller's validator (or no comparable last-modified):
       // RFC 9110 §13.1.3 — proceed as normal. The entry is fresh, so serve the
       // stored 200 below (fall through) instead of refetching from the origin.
-    } else if (entry && (headers['if-none-match'] || headers['if-modified-since'])) {
+    } else if (
+      entry &&
+      conditionApplicable &&
+      (headers['if-none-match'] || headers['if-modified-since'])
+    ) {
       // Stale (or validation-demanding) entry + caller conditionals: forward to
       // origin so the caller's own validators do the validation.
       entry = undefined

--- a/test/cache-advanced.js
+++ b/test/cache-advanced.js
@@ -702,8 +702,7 @@ test('cache: valid double-quoted etag is stored and returned from cache', async 
   t.equal(entry.etag, '"abc123"', 'valid etag stored and returned')
 })
 
-test('cache: empty-string etag is not treated as usable; stored as empty string', async (t) => {
-  // isEtagUsable('""') returns false (length <= 2), so cache stores '' for the etag.
+test('cache: empty strong etag is valid and stored verbatim', async (t) => {
   t.plan(2)
   const server = await startServer((req, res) => {
     res.writeHead(200, { 'cache-control': 's-maxage=60', etag: '""' })
@@ -729,7 +728,7 @@ test('cache: empty-string etag is not treated as usable; stored as empty string'
     headers: {},
   })
   t.ok(entry, 'entry stored in cache')
-  t.equal(entry.etag, '', 'unusable etag stored as empty string (not the original value)')
+  t.equal(entry.etag, '""', 'the RFC-valid empty opaque tag is retained')
 })
 
 test('cache: weak etag W/"valid" is treated as usable and stored', async (t) => {
@@ -761,8 +760,7 @@ test('cache: weak etag W/"valid" is treated as usable and stored', async (t) => 
   t.equal(entry.etag, 'W/"valid123"', 'weak etag stored')
 })
 
-test('cache: W/"" (empty weak etag) is not usable; stored as empty string', async (t) => {
-  // isEtagUsable('W/""') returns false (length === 4), so cache stores ''.
+test('cache: empty weak etag is valid and stored verbatim', async (t) => {
   t.plan(2)
   const server = await startServer((req, res) => {
     res.writeHead(200, { 'cache-control': 's-maxage=60', etag: 'W/""' })
@@ -788,7 +786,7 @@ test('cache: W/"" (empty weak etag) is not usable; stored as empty string', asyn
     headers: {},
   })
   t.ok(entry, 'entry stored in cache')
-  t.equal(entry.etag, '', 'empty weak etag stored as empty string')
+  t.equal(entry.etag, 'W/""', 'the RFC-valid empty weak opaque tag is retained')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/cache-coverage-interceptor.js
+++ b/test/cache-coverage-interceptor.js
@@ -1175,6 +1175,14 @@ test('cache: isEtagUsable rejects non-string etags', async (t) => {
   t.equal(isEtagUsable(123), false)
   t.equal(isEtagUsable(['"a"']), false)
   t.equal(isEtagUsable('"a"'), true, 'control: a normal quoted etag is usable')
+  t.equal(isEtagUsable('""'), true, 'opaque-tag permits zero etagc characters')
+  t.equal(isEtagUsable('W/""'), true, 'the empty weak entity-tag is valid')
+  t.equal(isEtagUsable('"a,b\\c"'), true, 'comma and backslash are valid etagc')
+  t.equal(isEtagUsable('"\x80"'), true, 'obs-text is valid etagc')
+  t.equal(isEtagUsable('"a b"'), false, 'space is not etagc')
+  t.equal(isEtagUsable('"a"b"'), false, 'an embedded quote is not etagc')
+  t.equal(isEtagUsable('"\x7f"'), false, 'DEL is not etagc')
+  t.equal(isEtagUsable('w/"a"'), false, 'the weak prefix is case-sensitive')
 })
 
 test('cache: serveFromCache tags absent id/method as null in the lookup doc', async (t) => {

--- a/test/cache-range.js
+++ b/test/cache-range.js
@@ -367,6 +367,38 @@ test('range: HEAD response with Content-Range is not stored', async (t) => {
 // Staleness, revalidation and conditional interplay
 // ---------------------------------------------------------------------------
 
+test('range: cached 206 synthetic 304 omits partial-only metadata', async (t) => {
+  t.plan(6)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(206, {
+      'cache-control': 'max-age=60',
+      'content-range': 'bytes 2-5/10',
+      'content-length': '4',
+      etag: '"tag-1"',
+    })
+    res.end('2345')
+  })
+  t.teardown(server.close.bind(server))
+  const dispatch = makeDispatch()
+  const { base } = makeOpts(t, server)
+
+  await rawRequest(dispatch, { ...base, headers: { range: 'bytes=2-5' } })
+  await flush()
+
+  const conditional = await rawRequest(dispatch, {
+    ...base,
+    headers: { range: 'bytes=2-5', 'if-none-match': '"tag-1"' },
+  })
+  t.equal(conditional.statusCode, 304, 'matching condition answered locally')
+  t.equal(conditional.body, '', '304 has no body')
+  t.notOk(conditional.headers['content-range'], 'Content-Range was not copied onto a 304')
+  t.notOk(conditional.headers['content-length'], 'partial Content-Length was not copied')
+  t.ok(conditional.headers.age !== undefined, 'normal cached-response Age metadata remains')
+  t.equal(hits, 1, 'origin was not contacted for the fresh conditional hit')
+})
+
 test('range: stale 206 is refetched, not conditionally revalidated', async (t) => {
   t.plan(6)
   const origin = rangeServer({ maxAge: 0, etag: '"tag-1"' })

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -381,6 +381,43 @@ test('cache: If-None-Match as array is treated as one list, does not crash', asy
   t.equal(hits, 1, 'non-matching array does not contact the origin')
 })
 
+test('cache: caller preconditions are ignored for a fresh cached redirect', async (t) => {
+  t.plan(5)
+  let hits = 0
+  const server = await startServer((req, res) => {
+    hits++
+    res.writeHead(307, {
+      'cache-control': 'max-age=60',
+      etag: '"redirect-v1"',
+      location: '/target',
+    })
+    res.end('redirect-body')
+  })
+  t.teardown(server.close.bind(server))
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const dispatch = makeDispatch()
+  const base = {
+    origin: `http://0.0.0.0:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    cache: { store },
+  }
+
+  await rawRequest(dispatch, { ...base, headers: {} })
+  await new Promise((resolve) => setImmediate(resolve))
+  const result = await rawRequest(dispatch, {
+    ...base,
+    headers: { 'if-none-match': '"redirect-v1"' },
+  })
+
+  t.equal(result.statusCode, 307, 'matching precondition did not synthesize a 304')
+  t.equal(result.headers.location, '/target', 'stored redirect metadata was preserved')
+  t.equal(result.headers.etag, '"redirect-v1"', 'redirect validator was preserved')
+  t.equal(result.body, 'redirect-body', 'stored redirect body was served normally')
+  t.equal(hits, 1, 'fresh redirect came from the cache')
+})
+
 // ---------------------------------------------------------------------------
 // get/set key asymmetry: the set path normalized the key via makeCacheKey
 // (origin.toString()) while the get path used raw opts, so a URL-object origin


### PR DESCRIPTION
## Summary

Tighten the paths where the cache evaluates caller preconditions or generates a local 304:

- Validate ETags using the exact RFC grammar, including valid empty strong/weak tags and valid `etagc` characters.
- When a cached 206 produces a local 304, omit partial-only `Content-Range` and `Content-Length`.
- Evaluate caller preconditions only against stored 200/206 responses, so a matching ETag cannot turn a cached 307—or future cached 301/404/etc.—into a synthetic 304.

## RFC rationale

[RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3) defines `opaque-tag = DQUOTE *etagc DQUOTE`; empty tags are valid, as are comma, backslash, and obs-text. Space, embedded DQUOTE, DEL, and lowercase `w/` are not.

[RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6) says a 304 **MUST NOT** carry Content-Length unless it equals the corresponding full 200 length. A cached 206 length is only its byte window. [§14.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4) gives Content-Range semantics only on 206 and 416.

[RFC 9110 §13.2.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1) says preconditions are ignored when the unconditional response would be neither 2xx nor 412; [RFC 9111 §4.3.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.2) scopes cache evaluation to stored 200/206 responses.

## Tests

- New focused regressions cover exact ETag grammar, empty tags, cached-206 304 metadata, and cached-307 preconditions.
- Relevant conditional/update304 corpus suites: 29 passed, 0 required failures, 0 retries.
- Full `npm run test:cache-tests`: 244 passed, 0 required failures, 0 retries.
- ESLint, Prettier, and `git diff --check` pass.

This is based on the multi-line If-None-Match work already merged through #83/#85; it does not duplicate that fix.
