### PR TITLE
fix(cache-control): ignore immutable arguments

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,8 +218,13 @@ export function parseCacheControl(header) {
         // storing/serving a response the origin forbade.
         output[key] = true
         break
-      case 'public':
       case 'immutable':
+        // RFC 8246 §2: immutable takes no arguments, but if one is present it
+        // has no meaning and MUST be ignored. Ignore the argument, not the
+        // directive itself.
+        output[key] = true
+        break
+      case 'public':
       case 'no-transform':
       case 'must-understand':
       case 'only-if-cached':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,6 +14,46 @@ export function getFastNow() {
 }
 
 /**
+ * A quoted-string directive argument may itself contain commas that the
+ * top-level comma split cut into separate fragments (`immutable="x, public"`).
+ * When `value` opens a double-quote that its own fragment does not close,
+ * advance past the continuation fragments (to the one carrying the closing
+ * quote, or to the end for an unterminated quote) so a fragment like `public`
+ * is not mis-parsed as its own directive. Returns the new loop index.
+ * The qualified private/no-cache parser has its own richer version because it
+ * must also reassemble the field-name list; this one only needs to skip.
+ */
+function endsWithUnescapedQuote(value) {
+  if (value[value.length - 1] !== '"') {
+    return false
+  }
+
+  // A quote preceded by an odd run of backslashes is part of quoted-pair,
+  // not the quoted-string terminator. With an even run, the final backslash
+  // is itself escaped and the quote remains unescaped.
+  let backslashes = 0
+  for (let i = value.length - 2; i >= 0 && value[i] === '\\'; i--) {
+    backslashes++
+  }
+  return backslashes % 2 === 0
+}
+
+function skipQuotedArgument(directives, i, value) {
+  const trimmed = value.trim()
+  if (trimmed[0] !== '"' || (trimmed.length > 1 && endsWithUnescapedQuote(trimmed))) {
+    return i
+  }
+  for (let j = i + 1; j < directives.length; j++) {
+    i = j
+    const part = directives[j].trim()
+    if (endsWithUnescapedQuote(part)) {
+      break
+    }
+  }
+  return i
+}
+
+/**
  * Vendored from undici's parseCacheControlHeader (lib/util/cache.js) with two
  * deliberate deviations, both toward the conservative reading of RFC 9111:
  * - duplicated max-age keeps the SMALLER value (§4.2.1 says a cache is free to
@@ -32,31 +72,6 @@ export function getFastNow() {
  * @param {string | string[] | null | undefined} header
  * @returns {Record<string, boolean | number | string[]> | null}
  */
-/**
- * A quoted-string directive argument may itself contain commas that the
- * top-level comma split cut into separate fragments (`immutable="x, public"`).
- * When `value` opens a double-quote that its own fragment does not close,
- * advance past the continuation fragments (to the one carrying the closing
- * quote, or to the end for an unterminated quote) so a fragment like `public`
- * is not mis-parsed as its own directive. Returns the new loop index.
- * The qualified private/no-cache parser has its own richer version because it
- * must also reassemble the field-name list; this one only needs to skip.
- */
-function skipQuotedArgument(directives, i, value) {
-  const trimmed = value.trim()
-  if (trimmed[0] !== '"' || (trimmed.length > 1 && trimmed[trimmed.length - 1] === '"')) {
-    return i
-  }
-  for (let j = i + 1; j < directives.length; j++) {
-    i = j
-    const part = directives[j].trim()
-    if (part.length !== 0 && part[part.length - 1] === '"') {
-      break
-    }
-  }
-  return i
-}
-
 export function parseCacheControl(header) {
   let directives
   if (Array.isArray(header)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,31 @@ export function getFastNow() {
  * @param {string | string[] | null | undefined} header
  * @returns {Record<string, boolean | number | string[]> | null}
  */
+/**
+ * A quoted-string directive argument may itself contain commas that the
+ * top-level comma split cut into separate fragments (`immutable="x, public"`).
+ * When `value` opens a double-quote that its own fragment does not close,
+ * advance past the continuation fragments (to the one carrying the closing
+ * quote, or to the end for an unterminated quote) so a fragment like `public`
+ * is not mis-parsed as its own directive. Returns the new loop index.
+ * The qualified private/no-cache parser has its own richer version because it
+ * must also reassemble the field-name list; this one only needs to skip.
+ */
+function skipQuotedArgument(directives, i, value) {
+  const trimmed = value.trim()
+  if (trimmed[0] !== '"' || (trimmed.length > 1 && trimmed[trimmed.length - 1] === '"')) {
+    return i
+  }
+  for (let j = i + 1; j < directives.length; j++) {
+    i = j
+    const part = directives[j].trim()
+    if (part.length !== 0 && part[part.length - 1] === '"') {
+      break
+    }
+  }
+  return i
+}
+
 export function parseCacheControl(header) {
   let directives
   if (Array.isArray(header)) {
@@ -215,13 +240,21 @@ export function parseCacheControl(header) {
         // empty-value fallthrough above): any malformed valued form
         // (`no-store="x"`, `no-store=`, `private=`) fails RESTRICTIVE and is
         // treated as the bare directive. Dropping no-store would fail OPEN —
-        // storing/serving a response the origin forbade.
+        // storing/serving a response the origin forbade. A quoted argument
+        // spanning commas is consumed so its tail can't leak as a directive.
+        if (value !== undefined) {
+          i = skipQuotedArgument(directives, i, value)
+        }
         output[key] = true
         break
       case 'immutable':
         // RFC 8246 §2: immutable takes no arguments, but if one is present it
         // has no meaning and MUST be ignored. Ignore the argument, not the
-        // directive itself.
+        // directive itself — and consume a comma-spanning quoted argument
+        // (`immutable="x, public"`) so its tail isn't parsed as a directive.
+        if (value !== undefined) {
+          i = skipQuotedArgument(directives, i, value)
+        }
         output[key] = true
         break
       case 'public':
@@ -234,6 +267,9 @@ export function parseCacheControl(header) {
         // direction for grants; the safety-critical group above is the
         // opposite. `value === undefined` is the genuine valueless form.
         if (value !== undefined) {
+          // Still consume a comma-spanning quoted argument before ignoring, so
+          // its tail (`public="x, no-store`) can't leak as a directive.
+          i = skipQuotedArgument(directives, i, value)
           continue
         }
 

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -108,6 +108,36 @@ test('parseCacheControl - malformed arguments follow directive-specific safe beh
     { immutable: true },
     'an empty argument is ignored without dropping immutable',
   )
+  // A quoted argument may contain commas the top-level split cut apart; the
+  // continuation must be consumed, not parsed as a separate directive.
+  t.strictSame(
+    parseCacheControl('immutable="x, public"'),
+    { immutable: true },
+    'comma inside a quoted immutable argument does not leak a phantom public',
+  )
+  t.strictSame(
+    parseCacheControl('immutable="x, public'),
+    { immutable: true },
+    'unterminated quoted immutable argument consumes its tail',
+  )
+  t.strictSame(
+    parseCacheControl('immutable="x, public", max-age=60'),
+    { immutable: true, 'max-age': 60 },
+    'a real directive after the closing quote is still parsed',
+  )
+  // Same class of bug for the sibling valueless directives; the unterminated
+  // form is the one that actually leaks (a closing quote keeps the tail from
+  // matching a directive name on its own).
+  t.strictSame(
+    parseCacheControl('public="x, no-store'),
+    {},
+    'comma inside a quoted public argument does not leak a phantom no-store',
+  )
+  t.strictSame(
+    parseCacheControl('no-store="x, public'),
+    { 'no-store': true },
+    'comma inside a quoted no-store argument does not leak a phantom public',
+  )
   t.end()
 })
 

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -86,14 +86,28 @@ test('parseCacheControl - negative delta-seconds are rejected (RFC 9111 non-nega
   t.end()
 })
 
-test('parseCacheControl - valueless directive with explicit = is an invalid qualified form', (t) => {
+test('parseCacheControl - malformed arguments follow directive-specific safe behavior', (t) => {
   t.strictSame(parseCacheControl('public='), {}, 'public= is not treated as public')
   // no-store is safety-critical: a malformed valued form fails RESTRICTIVE
   // (treated as bare no-store) — dropping it would fail open and store a
   // response the origin forbade. See review-bugfixes-5-directives.js.
   t.strictSame(parseCacheControl('no-store='), { 'no-store': true }, 'no-store= fails restrictive')
   t.strictSame(parseCacheControl('public'), { public: true }, 'bare public still works')
-  t.strictSame(parseCacheControl('immutable=x'), {}, 'qualified immutable ignored')
+  t.strictSame(
+    parseCacheControl('immutable=x'),
+    { immutable: true },
+    'RFC 8246 ignores token arguments without dropping immutable',
+  )
+  t.strictSame(
+    parseCacheControl('immutable="ignored"'),
+    { immutable: true },
+    'RFC 8246 ignores quoted arguments without dropping immutable',
+  )
+  t.strictSame(
+    parseCacheControl('immutable='),
+    { immutable: true },
+    'an empty argument is ignored without dropping immutable',
+  )
   t.end()
 })
 

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -121,6 +121,16 @@ test('parseCacheControl - malformed arguments follow directive-specific safe beh
     'unterminated quoted immutable argument consumes its tail',
   )
   t.strictSame(
+    parseCacheControl('immutable="x\\", public'),
+    { immutable: true },
+    'an escaped trailing quote does not terminate the quoted argument',
+  )
+  t.strictSame(
+    parseCacheControl('immutable="x\\\\", max-age=60'),
+    { immutable: true, 'max-age': 60 },
+    'an even backslash run leaves the closing quote unescaped',
+  )
+  t.strictSame(
     parseCacheControl('immutable="x, public", max-age=60'),
     { immutable: true, 'max-age': 60 },
     'a real directive after the closing quote is still parsed',

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -98,9 +98,14 @@ test('parseCacheControl: malformed valued no-store/must-revalidate/proxy-revalid
     { 'proxy-revalidate': true },
     'proxy-revalidate= fails restrictive',
   )
-  // Permission-granting valueless directives keep the opposite (drop) rule.
+  // Permission-granting valueless directives keep the opposite (drop) rule,
+  // except immutable, whose own specification says to ignore arguments.
   t.strictSame(parseCacheControl('public='), {}, 'public= still ignored')
-  t.strictSame(parseCacheControl('immutable=x'), {}, 'immutable=x still ignored')
+  t.strictSame(
+    parseCacheControl('immutable=x'),
+    { immutable: true },
+    'immutable argument is ignored, not the directive (RFC 8246 §2)',
+  )
   t.end()
 })
 


### PR DESCRIPTION
## Summary

`immutable` takes no arguments, but RFC 8246 says an argument has no meaning and must be ignored. The parser currently drops the entire directive when `=` is present.

Retain `immutable` while discarding token, empty, and quoted arguments. When an ignored quoted argument spans comma-split fragments, consume the complete quoted string (or the remainder when unterminated) so argument text cannot leak into live directives. Closing-quote detection now distinguishes escaped quotes by counting the immediately preceding backslashes.

The comma-spanning protection is also applied to sibling valueless directives: restrictive directives such as malformed valued `no-store` retain their restrictive meaning, while permission-granting directives such as malformed valued `public` remain ignored.

This is independent of #77, which separately owns `immutable` lifetime semantics; this PR is limited to argument parsing.

## RFC rationale

[RFC 8246 §2](https://www.rfc-editor.org/rfc/rfc8246.html#section-2) says the immutable extension takes no arguments and, if an argument is present, it has no meaning and **MUST be ignored**. Ignoring the argument is different from ignoring the directive.

## Tests

- Covers bare `immutable` plus token, empty, and quoted argument forms.
- Covers closed and unterminated comma-spanning quoted arguments without phantom directives.
- Covers escaped trailing quotes and the even-backslash case where the quote is genuinely unescaped.
- Confirms malformed valued `public` remains non-granting and malformed valued `no-store` remains restrictive.
- Focused parser, directive, and storability run: 162 assertions passed.
- ESLint, Prettier, and `git diff --check` pass.
