### PR TITLE
fix(http-date): apply RFC 850's rolling year window

### DIFF
--- a/lib/interceptor/cache/freshness.js
+++ b/lib/interceptor/cache/freshness.js
@@ -45,11 +45,12 @@ export function determineLifetime(
     // expired — the parse failure must surface as lifetime 0, not fall through
     // to heuristics. Arrays (duplicated, potentially conflicting Expires field
     // lines) are treated the same way.
-    const expires = typeof headers.expires === 'string' ? parseHttpDate(headers.expires) : undefined
+    const expires =
+      typeof headers.expires === 'string' ? parseHttpDate(headers.expires, now) : undefined
     if (!expires) {
       return { lifetime: 0, explicit: true }
     }
-    const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+    const date = typeof headers.date === 'string' ? parseHttpDate(headers.date, now) : undefined
     return {
       lifetime: Math.floor((expires.getTime() - (date ? date.getTime() : now)) / 1000),
       explicit: true,
@@ -71,7 +72,7 @@ export function determineLifetime(
       // §4.2.2 forbids heuristics when an explicit expiration exists; Expires
       // was handled (including the invalid form) above, so this is reached
       // only when none does.
-      const lastModified = parseHttpDate(headers['last-modified'])
+      const lastModified = parseHttpDate(headers['last-modified'], now)
       if (lastModified && lastModified.getTime() < now) {
         return { lifetime: Math.floor((now - lastModified.getTime()) / 10 / 1000), explicit: false }
       }
@@ -108,7 +109,8 @@ export function determineAge(headers, responseTime, requestTime = responseTime) 
     typeof rawAgeValue === 'string' && /^\d+$/.test(rawAgeValue.trim())
       ? parseInt(rawAgeValue, 10)
       : 0
-  const date = typeof headers.date === 'string' ? parseHttpDate(headers.date) : undefined
+  const date =
+    typeof headers.date === 'string' ? parseHttpDate(headers.date, responseTime) : undefined
   const apparentAge = date ? Math.max(0, Math.floor((responseTime - date.getTime()) / 1000)) : 0
   const responseDelay = Math.max(0, Math.floor((responseTime - requestTime) / 1000))
   return Math.max(age + responseDelay, apparentAge)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -349,6 +349,13 @@ export function parseHttpDate(date, now = Date.now()) {
     return undefined
   }
 
+  // Guard the reference clock: a non-finite `now` (NaN, a string, Infinity)
+  // would silently skew the RFC 850 two-digit-year window. A finite value in
+  // the wrong unit (seconds vs ms) is indistinguishable and left to callers.
+  if (typeof now !== 'number' || !Number.isFinite(now)) {
+    now = Date.now()
+  }
+
   let day
   let month
   let year

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -341,19 +341,15 @@ const ASCTIME_DATE_RE =
  * normalization check.
  *
  * @param {string} date
- * @param {number} [now] reference time in epoch milliseconds, as returned by Date.now()
+ * @param {number} [now] Reference time in epoch milliseconds (as from
+ *   `Date.now()`), used ONLY to place RFC 850 two-digit years in the rolling
+ *   50-year window. Resolved lazily — `Date.now()` is called only when an
+ *   RFC 850 date is actually parsed, and a non-finite value falls back to it.
  * @returns {Date | undefined} undefined when not a valid HTTP-date
  */
-export function parseHttpDate(date, now = Date.now()) {
+export function parseHttpDate(date, now) {
   if (typeof date !== 'string') {
     return undefined
-  }
-
-  // Guard the reference clock: a non-finite `now` (NaN, a string, Infinity)
-  // would silently skew the RFC 850 two-digit-year window. A finite value in
-  // the wrong unit (seconds vs ms) is indistinguishable and left to callers.
-  if (typeof now !== 'number' || !Number.isFinite(now)) {
-    now = Date.now()
   }
 
   let day
@@ -363,6 +359,9 @@ export function parseHttpDate(date, now = Date.now()) {
   let minute
   let second
   let hasTwoDigitYear = false
+  // Reference clock for RFC 850 two-digit-year windowing, resolved lazily (and
+  // guarded against a non-finite `now`) only if that branch is actually taken.
+  let nowMs = 0
 
   let m = IMF_DATE_RE.exec(date)
   if (m) {
@@ -378,7 +377,8 @@ export function parseHttpDate(date, now = Date.now()) {
     // RFC 9110 §5.6.7 uses a moving window, not the cookie date parser's
     // fixed 1970/2069 split: start in the current century, then map a year
     // more than 50 years in the future to the most recent past century.
-    const currentYear = new Date(now).getUTCFullYear()
+    nowMs = typeof now === 'number' && Number.isFinite(now) ? now : Date.now()
+    const currentYear = new Date(nowMs).getUTCFullYear()
     year = Math.floor(currentYear / 100) * 100 + Number(m[3])
     hasTwoDigitYear = true
     hour = Number(m[4])
@@ -400,7 +400,7 @@ export function parseHttpDate(date, now = Date.now()) {
   }
 
   if (hasTwoDigitYear) {
-    const futureLimit = new Date(now)
+    const futureLimit = new Date(nowMs)
     futureLimit.setUTCFullYear(futureLimit.getUTCFullYear() + 50)
     if (Date.UTC(year, month, day, hour, minute, second) > futureLimit.getTime()) {
       year -= 100

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -341,7 +341,7 @@ const ASCTIME_DATE_RE =
  * normalization check.
  *
  * @param {string} date
- * @param {number} [now]
+ * @param {number} [now] reference time in epoch milliseconds, as returned by Date.now()
  * @returns {Date | undefined} undefined when not a valid HTTP-date
  */
 export function parseHttpDate(date, now = Date.now()) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -341,9 +341,10 @@ const ASCTIME_DATE_RE =
  * normalization check.
  *
  * @param {string} date
+ * @param {number} [now]
  * @returns {Date | undefined} undefined when not a valid HTTP-date
  */
-export function parseHttpDate(date) {
+export function parseHttpDate(date, now = Date.now()) {
   if (typeof date !== 'string') {
     return undefined
   }
@@ -354,6 +355,7 @@ export function parseHttpDate(date) {
   let hour
   let minute
   let second
+  let hasTwoDigitYear = false
 
   let m = IMF_DATE_RE.exec(date)
   if (m) {
@@ -366,9 +368,12 @@ export function parseHttpDate(date) {
   } else if ((m = RFC850_DATE_RE.exec(date))) {
     day = Number(m[1])
     month = HTTP_DATE_MONTHS[m[2].toUpperCase()]
-    // RFC 6265 §5.1.1 two-digit year windowing: 70-99 → 19xx, 00-69 → 20xx.
-    year = Number(m[3])
-    year += year < 70 ? 2000 : 1900
+    // RFC 9110 §5.6.7 uses a moving window, not the cookie date parser's
+    // fixed 1970/2069 split: start in the current century, then map a year
+    // more than 50 years in the future to the most recent past century.
+    const currentYear = new Date(now).getUTCFullYear()
+    year = Math.floor(currentYear / 100) * 100 + Number(m[3])
+    hasTwoDigitYear = true
     hour = Number(m[4])
     minute = Number(m[5])
     second = Number(m[6])
@@ -385,6 +390,14 @@ export function parseHttpDate(date) {
 
   if (day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
     return undefined
+  }
+
+  if (hasTwoDigitYear) {
+    const futureLimit = new Date(now)
+    futureLimit.setUTCFullYear(futureLimit.getUTCFullYear() + 50)
+    if (Date.UTC(year, month, day, hour, minute, second) > futureLimit.getTime()) {
+      year -= 100
+    }
   }
 
   const result = new Date(Date.UTC(year, month, day, hour, minute, second))

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -510,3 +510,23 @@ test('parseHttpDate: case variants and mismatched weekday are accepted; real gar
   t.equal(parseHttpDate('2026-07-04T00:00:00Z'), undefined, 'ISO 8601 still rejected')
   t.end()
 })
+
+test('parseHttpDate: RFC 850 two-digit years use the moving 50-year window', (t) => {
+  const referenceTime = Date.UTC(2026, 10, 6, 8, 49, 37)
+  t.equal(
+    parseHttpDate('Sunday, 06-Nov-76 08:49:37 GMT', referenceTime)?.getUTCFullYear(),
+    2076,
+    'exactly 50 years in the future stays in the current century',
+  )
+  t.equal(
+    parseHttpDate('Sunday, 06-Nov-76 08:49:38 GMT', referenceTime)?.getUTCFullYear(),
+    1976,
+    'the cutoff compares the complete timestamp, not only the year',
+  )
+  t.equal(
+    parseHttpDate('Sunday, 06-Nov-77 08:49:37 GMT', referenceTime)?.getUTCFullYear(),
+    1977,
+    'more than 50 years in the future maps to the most recent past year',
+  )
+  t.end()
+})

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -31,7 +31,6 @@ import { parseCacheControl, parseHttpDate } from '../lib/utils.js'
 import {
   determineAge,
   determineLifetime,
-  determineAge,
   computeEntryTimes,
   forbidsRequestDrivenStale,
 } from '../lib/interceptor/cache/freshness.js'

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -31,6 +31,7 @@ import { parseCacheControl, parseHttpDate } from '../lib/utils.js'
 import {
   determineAge,
   determineLifetime,
+  determineAge,
   computeEntryTimes,
   forbidsRequestDrivenStale,
 } from '../lib/interceptor/cache/freshness.js'
@@ -527,6 +528,43 @@ test('parseHttpDate: RFC 850 two-digit years use the moving 50-year window', (t)
     parseHttpDate('Sunday, 06-Nov-77 08:49:37 GMT', referenceTime)?.getUTCFullYear(),
     1977,
     'more than 50 years in the future maps to the most recent past year',
+  )
+  t.end()
+})
+
+test('freshness helpers use their injected clock for RFC 850 dates', (t) => {
+  // Keep the reference century deliberately distinct from the process clock:
+  // these assertions fail if a freshness helper lets parseHttpDate() fall
+  // back to Date.now() instead of forwarding its deterministic `now`.
+  const referenceTime = Date.UTC(2126, 10, 6, 8, 49, 37)
+  const rfc850Date = 'Sunday, 06-Nov-76 08:49:37 GMT'
+  const resolvedTime = Date.UTC(2176, 10, 6, 8, 49, 37)
+
+  t.strictSame(
+    determineLifetime(200, { expires: rfc850Date }, {}, {}, referenceTime),
+    { lifetime: Math.floor((resolvedTime - referenceTime) / 1000), explicit: true },
+    'Expires is resolved relative to the injected clock',
+  )
+  t.strictSame(
+    determineLifetime(
+      200,
+      { date: rfc850Date, expires: 'Sun, 06 Nov 2176 08:49:37 GMT' },
+      {},
+      {},
+      referenceTime,
+    ),
+    { lifetime: 0, explicit: true },
+    'Date and Expires use the same injected reference time',
+  )
+  t.equal(
+    determineLifetime(200, { 'last-modified': rfc850Date }, {}, { heuristic: true }, referenceTime),
+    null,
+    'a future Last-Modified does not create heuristic freshness',
+  )
+  t.equal(
+    determineAge({ date: rfc850Date }, referenceTime),
+    0,
+    'a future Date does not create apparent age',
   )
   t.end()
 })


### PR DESCRIPTION
## Summary

Replace the fixed cookie-style 1970/2069 cutoff for obsolete RFC 850 dates with HTTP's rolling 50-year rule.

The parser now constructs the matching year in the current century, compares the complete timestamp with the point exactly 50 years in the future, and maps values beyond that boundary to the most recent past century. The optional reference time only makes boundary tests deterministic.

In 2026, the old split already interpreted RFC 850 years 70 through 76 a century too early.

## RFC rationale

[RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7) says a recipient parsing an RFC 850 two-digit year **MUST** interpret a timestamp more than 50 years in the future as the most recent past year with the same final two digits.

## Tests

- Covers exactly 50 years in the future, one second beyond the boundary, and the next two-digit year mapping to the previous century.
- Focused suites: 119 assertions passed.
- `npm run test:cache-tests`: 244 passed, 0 required failures, 0 retries.
- ESLint, Prettier, and `git diff --check` pass.

The external corpus's `freshness-expires-rfc850` case verifies the obsolete format generally; these regressions cover the moving-window boundary it does not exercise.
