### PR TITLE
fix(pressure): recognize custom client abort reasons

### DIFF
--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -379,6 +379,7 @@ class Handler extends DecoratorHandler {
   // terminal callback fires.
   #state = 'pending'
   #statusCode = 0
+  #clientAborted = false
 
   constructor(handler, rec) {
     // super() validates the handler and throws on a non-object before we touch
@@ -399,7 +400,14 @@ class Handler extends DecoratorHandler {
       this.#rec.pending -= 1
       this.#rec.running += 1
     }
-    super.onConnect(abort)
+    // Record aborts initiated through the downstream handler. AbortSignal
+    // reasons are user-defined and need not be named `AbortError`; without
+    // this lifecycle bit a caller using `controller.abort(new Error(...))`
+    // was misclassified as an origin transport failure.
+    super.onConnect((reason) => {
+      this.#clientAborted = true
+      abort(reason)
+    })
   }
 
   onHeaders(statusCode, headers, resume) {
@@ -432,7 +440,11 @@ class Handler extends DecoratorHandler {
     // dispatch throw) — count it, unless it's a client-initiated abort.
     const statusCode = err?.statusCode ?? this.#statusCode
     const isError =
-      err?.name === 'AbortError' ? false : statusCode >= 200 ? isErrorStatus(statusCode) : true
+      this.#clientAborted || err?.name === 'AbortError'
+        ? false
+        : statusCode >= 200
+          ? isErrorStatus(statusCode)
+          : true
     this.#settle(isError)
     super.onError(err)
   }

--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -395,6 +395,7 @@ class Handler extends DecoratorHandler {
     // classification. A handler upstream (e.g. response-retry) may reconnect
     // this same handler across retries, and response-retry itself resets here.
     this.#statusCode = 0
+    this.#clientAborted = false
     if (this.#state === 'pending') {
       this.#state = 'running'
       this.#rec.pending -= 1

--- a/test/review-bugfixes-6-pressure-abort-reason.js
+++ b/test/review-bugfixes-6-pressure-abort-reason.js
@@ -1,0 +1,40 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'http://example.test'
+
+test('pressure: a client abort with a custom reason is not an origin error', (t) => {
+  t.plan(3)
+
+  let wrappedHandler
+  let abortRequest
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  t.teardown(() => pressure.close())
+
+  const dispatch = pressure((opts, handler) => {
+    wrappedHandler = handler
+    handler.onConnect((reason) => {
+      t.equal(reason.message, 'cancelled by caller', 'custom reason reaches the dispatcher')
+    })
+  })
+
+  dispatch(
+    { origin: ORIGIN, path: '/', method: 'GET' },
+    {
+      onConnect(abort) {
+        abortRequest = abort
+      },
+      onHeaders() {},
+      onData() {},
+      onComplete() {},
+      onError() {},
+    },
+  )
+
+  const reason = new Error('cancelled by caller')
+  abortRequest(reason)
+  wrappedHandler.onError(reason)
+
+  t.match(pressure.stats(ORIGIN), { completed: 1, errored: 0 })
+  t.equal(pressure.stats(ORIGIN)?.running, 0, 'the aborted request still settles the gauge')
+})

--- a/test/review-bugfixes-6-pressure-abort-reason.js
+++ b/test/review-bugfixes-6-pressure-abort-reason.js
@@ -1,3 +1,6 @@
+// Regression test for pressure accounting with custom client abort reasons:
+// downstream aborts remain caller cancellations even when the reason is an
+// ordinary Error rather than a DOM-style AbortError.
 import { test } from 'tap'
 import { interceptors } from '../lib/index.js'
 

--- a/test/review-bugfixes-6-pressure-abort-reason.js
+++ b/test/review-bugfixes-6-pressure-abort-reason.js
@@ -13,9 +13,10 @@ test('pressure: a client abort with a custom reason is not an origin error', (t)
 
   const dispatch = pressure((opts, handler) => {
     wrappedHandler = handler
-    handler.onConnect((reason) => {
+    const onAbort = (reason) => {
       t.equal(reason.message, 'cancelled by caller', 'custom reason reaches the dispatcher')
-    })
+    }
+    handler.onConnect(onAbort)
   })
 
   dispatch(

--- a/test/review-bugfixes-6-pressure-abort-reason.js
+++ b/test/review-bugfixes-6-pressure-abort-reason.js
@@ -42,3 +42,35 @@ test('pressure: a client abort with a custom reason is not an origin error', (t)
   t.match(pressure.stats(ORIGIN), { completed: 1, errored: 0 })
   t.equal(pressure.stats(ORIGIN)?.running, 0, 'the aborted request still settles the gauge')
 })
+
+test('pressure: client abort state does not leak across reconnects', (t) => {
+  let wrappedHandler
+  let abortRequest
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  t.teardown(() => pressure.close())
+
+  const dispatch = pressure((_opts, handler) => {
+    wrappedHandler = handler
+    handler.onConnect(() => {})
+  })
+
+  dispatch(
+    { origin: ORIGIN, path: '/', method: 'GET' },
+    {
+      onConnect(abort) {
+        abortRequest = abort
+      },
+      onHeaders() {},
+      onData() {},
+      onComplete() {},
+      onError() {},
+    },
+  )
+
+  abortRequest(new Error('first attempt cancelled'))
+  wrappedHandler.onConnect(() => {})
+  wrappedHandler.onError(new Error('second attempt transport failure'))
+
+  t.match(pressure.stats(ORIGIN), { completed: 1, errored: 1, running: 0 })
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Record when the downstream request handler invokes its abort callback.
- Exclude that lifecycle path from origin error-rate accounting even when the caller supplied a custom `Error` reason.
- Add a regression test that verifies the custom reason still reaches the dispatcher and the pressure gauges settle.

## Why

`AbortController.abort(reason)` accepts arbitrary reasons. The pressure interceptor previously recognized client cancellations only when the resulting error was named `AbortError`, so `abort(new Error(...))` was counted as an origin transport failure and could incorrectly mark a healthy origin degraded.

## Validation

- `npx tap test/review-bugfixes-6-pressure-abort-reason.js test/pressure-advanced.js`
- `npx eslint lib/interceptor/pressure.js test/review-bugfixes-6-pressure-abort-reason.js`
- staged-file ESLint and Prettier hooks