### PR TITLE
fix(request-id): normalize parent header forms

### DIFF
--- a/lib/interceptor/request-id.js
+++ b/lib/interceptor/request-id.js
@@ -1,3 +1,5 @@
+import { parseHeaders } from '../utils.js'
+
 // https://github.com/fastify/fastify/blob/main/lib/reqIdGenFactory.js
 // 2,147,483,647 (2^31 − 1) stands for max SMI value (an internal optimization of V8).
 // With this upper bound, if you'll be generating 1k ids/sec, you're going to hit it in ~25 days.
@@ -12,13 +14,19 @@ function genReqId() {
 }
 
 export default () => (dispatch) => (opts, handler) => {
+  // The standalone interceptor accepts the same object/flat-array header
+  // shapes as undici. Normalize first so mixed-case or array-form request-id
+  // fields participate in the parent chain instead of being duplicated or
+  // replaced by an unrelated id.
+  const headers = parseHeaders(opts.headers)
+
   // Treat an empty string the same as absent in BOTH the selection and the
   // chaining test (the old `??`-vs-truthy split kept a falsy opts.id, skipped
   // the request-id header fallback, then dropped it anyway — losing a real
   // parent id and breaking trace correlation).
   let prevId = opts.id
   if (prevId == null || prevId === '') {
-    prevId = opts.headers?.['request-id']
+    prevId = headers['request-id']
   }
   const nextId = prevId != null && prevId !== '' ? `${prevId},${genReqId()}` : genReqId()
   return dispatch(
@@ -26,10 +34,7 @@ export default () => (dispatch) => (opts, handler) => {
       ...opts,
       id: nextId,
       logger: opts.logger?.child({ ureq: { id: nextId } }),
-      headers: {
-        ...opts.headers,
-        'request-id': nextId,
-      },
+      headers: { ...headers, 'request-id': nextId },
     },
     handler,
   )

--- a/lib/interceptor/request-id.js
+++ b/lib/interceptor/request-id.js
@@ -29,12 +29,13 @@ export default () => (dispatch) => (opts, handler) => {
     prevId = headers['request-id']
   }
   const nextId = prevId != null && prevId !== '' ? `${prevId},${genReqId()}` : genReqId()
+  headers['request-id'] = nextId
   return dispatch(
     {
       ...opts,
       id: nextId,
       logger: opts.logger?.child({ ureq: { id: nextId } }),
-      headers: { ...headers, 'request-id': nextId },
+      headers,
     },
     handler,
   )

--- a/test/review-bugfixes-6-request-id-headers.js
+++ b/test/review-bugfixes-6-request-id-headers.js
@@ -1,0 +1,32 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function captureRequest(headers) {
+  let captured
+  const dispatch = interceptors.requestId()((opts) => {
+    captured = opts
+  })
+
+  dispatch({ origin: 'http://example.test', path: '/', headers }, {})
+  return captured
+}
+
+test('request-id: a mixed-case parent header is preserved in the chain', (t) => {
+  const captured = captureRequest({ 'Request-ID': 'parent-id', 'X-Test': 'value' })
+
+  t.match(captured.id, /^parent-id,req-/)
+  t.equal(captured.headers['request-id'], captured.id)
+  t.equal(captured.headers['x-test'], 'value')
+  t.notOk('Request-ID' in captured.headers, 'does not leave a duplicate mixed-case field')
+  t.end()
+})
+
+test('request-id: a flat-array parent header is preserved in the chain', (t) => {
+  const captured = captureRequest(['Request-ID', 'parent-id', 'X-Test', 'value'])
+
+  t.match(captured.id, /^parent-id,req-/)
+  t.equal(captured.headers['request-id'], captured.id)
+  t.equal(captured.headers['x-test'], 'value')
+  t.notOk('0' in captured.headers, 'does not spread array indexes into the header object')
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Normalize request headers before selecting and extending the parent request ID.
- Preserve mixed-case and undici flat-array `Request-ID` values in the generated chain.
- Emit one normalized lowercase header object instead of spreading array indexes or leaving duplicate casing.
- Add focused regressions for both header forms.

## Why

The standalone request-ID interceptor read only `headers['request-id']` and then object-spread the input. Mixed-case parents were missed, while flat-array headers were converted into numeric object properties. This broke request correlation and could send an unrelated generated ID.

## Validation

- `npx tap test/review-bugfixes-6-request-id-headers.js test/request-id.js`
- `npx tap test/review-bugfixes-6-request-id-headers.js test/request-id.js test/review-bugfixes-2-core.js`
- `npx eslint lib/interceptor/request-id.js test/review-bugfixes-6-request-id-headers.js`
- staged-file ESLint and Prettier hooks