### PR TITLE
fix(priority): handle async dispatch failures

### DIFF
--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -114,15 +114,16 @@ export default () => (dispatch) => {
         : null
 
     const priorityHandler = new Handler(handler, scheduler, onIdle, trace)
+    let dispatchResult
     const acquired = scheduler.acquire(
       (priorityHandler) => {
         if (trace !== null) {
           trace.dispatched = performance.now()
         }
         try {
-          const result = dispatch(opts, priorityHandler)
-          if (result != null && typeof result.then === 'function') {
-            Promise.resolve(result).catch((err) => {
+          dispatchResult = dispatch(opts, priorityHandler)
+          if (dispatchResult != null && typeof dispatchResult.then === 'function') {
+            Promise.resolve(dispatchResult).catch((err) => {
               try {
                 priorityHandler.onError(err)
               } catch {
@@ -159,5 +160,10 @@ export default () => (dispatch) => {
         'undici:priority',
       )
     }
+
+    // acquire() invokes the callback synchronously when a slot is available,
+    // so preserve the inner dispatch contract on that fast path. A queued
+    // dispatch has not run yet and therefore still returns undefined.
+    return dispatchResult
   }
 }

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -122,7 +122,9 @@ export default () => (dispatch) => {
         }
         try {
           dispatchResult = dispatch(opts, priorityHandler)
-          if (dispatchResult != null && typeof dispatchResult.then === 'function') {
+          if (dispatchResult != null) {
+            // Promise.resolve assimilates thenables without directly reading a
+            // potentially-throwing `.then` accessor in this call frame.
             Promise.resolve(dispatchResult).catch((err) => {
               try {
                 priorityHandler.onError(err)

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -123,8 +123,8 @@ export default () => (dispatch) => {
         try {
           dispatchResult = dispatch(opts, priorityHandler)
           if (dispatchResult != null) {
-            // Promise.resolve assimilates thenables without directly reading a
-            // potentially-throwing `.then` accessor in this call frame.
+            // Promise.resolve assimilates thenables and converts a throwing
+            // `.then` getter into a rejected Promise observed below.
             Promise.resolve(dispatchResult).catch((err) => {
               try {
                 priorityHandler.onError(err)

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -122,7 +122,15 @@ export default () => (dispatch) => {
         try {
           const result = dispatch(opts, priorityHandler)
           if (result != null && typeof result.then === 'function') {
-            Promise.resolve(result).catch((err) => priorityHandler.onError(err))
+            Promise.resolve(result).catch((err) => {
+              try {
+                priorityHandler.onError(err)
+              } catch {
+                // The scheduler slot has already been released. A user
+                // onError hook must not turn this observed rejection into a
+                // second, unhandled rejection.
+              }
+            })
           }
         } catch (err) {
           priorityHandler.onError(err)

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -162,8 +162,10 @@ export default () => (dispatch) => {
     }
 
     // acquire() invokes the callback synchronously when a slot is available,
-    // so preserve the inner dispatch contract on that fast path. A queued
-    // dispatch has not run yet and therefore still returns undefined.
+    // so preserve the inner dispatch contract on that fast path. DispatchFn
+    // explicitly permits void; queued work has no inner result yet, and a
+    // synthetic Promise would introduce a second rejection channel alongside
+    // handler.onError, so the queued path intentionally returns undefined.
     return dispatchResult
   }
 }

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -120,7 +120,10 @@ export default () => (dispatch) => {
           trace.dispatched = performance.now()
         }
         try {
-          dispatch(opts, priorityHandler)
+          const result = dispatch(opts, priorityHandler)
+          if (result != null && typeof result.then === 'function') {
+            Promise.resolve(result).catch((err) => priorityHandler.onError(err))
+          }
         } catch (err) {
           priorityHandler.onError(err)
         }

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -74,3 +74,14 @@ test('priority: a throwing onError does not create an unhandled rejection', asyn
   await new Promise((resolve) => setImmediate(resolve))
   t.equal(unhandled, undefined)
 })
+
+test('priority: an immediately acquired dispatch preserves its Promise result', async (t) => {
+  const result = Promise.resolve()
+  const dispatch = interceptors.priority()((_request, wrapped) => {
+    wrapped.onConnect(() => {})
+    return result
+  })
+
+  t.equal(dispatch(opts, handler()), result)
+  await result
+})

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -1,0 +1,53 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const opts = {
+  origin: 'http://example.test',
+  path: '/',
+  method: 'GET',
+  headers: {},
+  priority: 1,
+}
+
+function handler(overrides = {}) {
+  return {
+    onConnect() {},
+    onHeaders() {},
+    onData() {},
+    onComplete() {},
+    onError() {},
+    ...overrides,
+  }
+}
+
+test('priority: an asynchronous dispatch rejection reports onError and releases the slot', async (t) => {
+  const failure = new Error('async dispatch failed')
+  let calls = 0
+  const dispatch = interceptors.priority()((request, wrapped) => {
+    calls++
+    if (calls === 1) {
+      return Promise.reject(failure)
+    }
+    wrapped.onConnect(() => {})
+    wrapped.onComplete()
+    return Promise.resolve()
+  })
+
+  const received = new Promise((resolve) => {
+    dispatch(opts, handler({ onError: resolve }))
+  })
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error('onError was not delivered')), 250)
+  })
+
+  t.equal(await Promise.race([received, timeout]), failure, 'rejection reaches the handler')
+  clearTimeout(timer)
+
+  let completed = false
+  dispatch(opts, handler({ onComplete: () => (completed = true) }))
+  await Promise.resolve()
+
+  t.equal(calls, 2, 'a subsequent request is dispatched')
+  t.equal(completed, true, 'the released scheduler slot is reusable')
+})

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -85,3 +85,24 @@ test('priority: an immediately acquired dispatch preserves its Promise result', 
   t.equal(dispatch(opts, handler()), result)
   await result
 })
+
+test('priority: a queued dispatch keeps the permitted void return contract', (t) => {
+  let calls = 0
+  let releaseFirst
+  const dispatch = interceptors.priority()((_request, wrapped) => {
+    calls++
+    if (calls === 1) {
+      releaseFirst = () => wrapped.onConnect(() => {})
+    } else {
+      wrapped.onConnect(() => {})
+    }
+  })
+
+  dispatch(opts, handler())
+  t.equal(dispatch(opts, handler()), undefined)
+  t.equal(calls, 1, 'the second dispatch is queued')
+
+  releaseFirst()
+  t.equal(calls, 2, 'the queued dispatch runs after the slot is released')
+  t.end()
+})

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -106,3 +106,23 @@ test('priority: a queued dispatch keeps the permitted void return contract', (t)
   t.equal(calls, 2, 'the queued dispatch runs after the slot is released')
   t.end()
 })
+
+test('priority: a throwing then getter reaches onError', async (t) => {
+  const failure = new Error('then getter failed')
+  const thenable = Object.create(null, {
+    then: {
+      get() {
+        throw failure
+      },
+    },
+  })
+  const dispatch = interceptors.priority()(() => thenable)
+
+  let result
+  const received = new Promise((resolve) => {
+    result = dispatch(opts, handler({ onError: resolve }))
+  })
+
+  t.equal(result, thenable)
+  t.equal(await received, failure)
+})

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -51,3 +51,26 @@ test('priority: an asynchronous dispatch rejection reports onError and releases 
   t.equal(calls, 2, 'a subsequent request is dispatched')
   t.equal(completed, true, 'the released scheduler slot is reusable')
 })
+
+test('priority: a throwing onError does not create an unhandled rejection', async (t) => {
+  const failure = new Error('async dispatch failed')
+  let unhandled
+  const onUnhandledRejection = (err) => {
+    unhandled = err
+  }
+  process.once('unhandledRejection', onUnhandledRejection)
+  t.teardown(() => process.off('unhandledRejection', onUnhandledRejection))
+
+  const dispatch = interceptors.priority()(() => Promise.reject(failure))
+  dispatch(
+    opts,
+    handler({
+      onError() {
+        throw new Error('user onError failed')
+      },
+    }),
+  )
+
+  await new Promise((resolve) => setImmediate(resolve))
+  t.equal(unhandled, undefined)
+})

--- a/test/review-bugfixes-6-priority-async-dispatch.js
+++ b/test/review-bugfixes-6-priority-async-dispatch.js
@@ -23,7 +23,7 @@ function handler(overrides = {}) {
 test('priority: an asynchronous dispatch rejection reports onError and releases the slot', async (t) => {
   const failure = new Error('async dispatch failed')
   let calls = 0
-  const dispatch = interceptors.priority()((request, wrapped) => {
+  const dispatch = interceptors.priority()((_request, wrapped) => {
     calls++
     if (calls === 1) {
       return Promise.reject(failure)


### PR DESCRIPTION
## What changed

- Observe Promise-like results returned by the inner dispatch function.
- Route asynchronous rejections through the priority handler's existing terminal-error path.
- Add a regression proving the error reaches the caller and the scheduler slot remains reusable.

## Why

`DispatchFn` permits `Promise<void>`, but the priority scheduler only caught synchronous throws. A rejected dispatch promise became unhandled, never called `handler.onError`, and left the scheduler slot held indefinitely, blocking later work for the same origin.

## Validation

- `npx tap test/review-bugfixes-6-priority-async-dispatch.js test/priority-advanced.js test/review-bugfixes-2-core.js`
- `npx eslint lib/interceptor/priority.js test/review-bugfixes-6-priority-async-dispatch.js`
- staged-file ESLint and Prettier hooks