### PR TITLE
fix(pressure): settle async dispatch failures

### DIFF
--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -474,7 +474,10 @@ export default (opts) => {
     const pressureHandler = new Handler(handler, rec)
 
     try {
-      return dispatch(opts, pressureHandler)
+      const result = dispatch(opts, pressureHandler)
+      return result != null && typeof result.then === 'function'
+        ? Promise.resolve(result).catch((err) => pressureHandler.onError(err))
+        : result
     } catch (err) {
       pressureHandler.onError(err)
     }

--- a/test/review-bugfixes-6-pressure-async-dispatch.js
+++ b/test/review-bugfixes-6-pressure-async-dispatch.js
@@ -1,0 +1,34 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'http://example.test'
+
+test('pressure: an asynchronous dispatch rejection settles the origin gauges', async (t) => {
+  const failure = new Error('async dispatch failed')
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  t.teardown(() => pressure.close())
+
+  const dispatch = pressure(() => Promise.reject(failure))
+  let received
+
+  await dispatch(
+    { origin: ORIGIN, path: '/', method: 'GET' },
+    {
+      onConnect() {},
+      onHeaders() {},
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        received = err
+      },
+    },
+  )
+
+  t.equal(received, failure, 'the rejection reaches the handler')
+  t.match(pressure.stats(ORIGIN), {
+    pending: 0,
+    running: 0,
+    completed: 1,
+    errored: 1,
+  })
+})


### PR DESCRIPTION
## What changed

- Observe Promise-like values returned by the inner dispatch function.
- Route asynchronous rejections through the same pressure-handler error path as synchronous throws.
- Add a regression asserting both downstream delivery and pending/running/completed/error gauge accounting.

## Why

`DispatchFn` permits `Promise<void>`, but the pressure interceptor only caught synchronous throws. A rejected promise bypassed `handler.onError` and left its per-origin record permanently pending, corrupting pressure readings and preventing idle eviction.

## Validation

- `npx tap test/review-bugfixes-6-pressure-async-dispatch.js test/pressure-advanced.js test/trace-pressure.js`
- `npx eslint lib/interceptor/pressure.js test/review-bugfixes-6-pressure-async-dispatch.js`
- staged-file ESLint and Prettier hooks