### PR TITLE
fix(log): finalize async dispatch failures

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -396,7 +396,13 @@ export default (logOpts) => (dispatch) => (opts, handler) => {
   const logHandler = new Handler(write, logOpts, opts, { handler })
 
   try {
-    return dispatch(opts, logHandler)
+    const result = dispatch(opts, logHandler)
+    return result != null && typeof result.then === 'function'
+      ? Promise.resolve(result).catch((err) => {
+          logHandler.onDispatchError(err)
+          throw err
+        })
+      : result
   } catch (err) {
     // An inner interceptor threw synchronously at dispatch time (e.g. proxy
     // loop detection). The error escapes past the already-registered handler,

--- a/test/review-bugfixes-6-log-async-dispatch.js
+++ b/test/review-bugfixes-6-log-async-dispatch.js
@@ -1,0 +1,41 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const kGlobalArray = Symbol.for('@nxtedition/nxt-undici#globalArray')
+
+test('log: an asynchronous dispatch rejection finalizes the in-flight handler', async (t) => {
+  const failure = new Error('async dispatch failed')
+  const errors = []
+  const logger = {
+    child() {
+      return this
+    },
+    debug() {},
+    warn() {},
+    error(...args) {
+      errors.push(args)
+    },
+  }
+  const before = globalThis[kGlobalArray]?.length ?? 0
+  const dispatch = interceptors.log()(() => Promise.reject(failure))
+  let onErrorCalls = 0
+
+  const caught = await dispatch(
+    { origin: 'http://example.test', path: '/', method: 'GET', logger },
+    {
+      onConnect() {},
+      onHeaders() {},
+      onData() {},
+      onComplete() {},
+      onError() {
+        onErrorCalls++
+      },
+    },
+  ).catch((err) => err)
+
+  t.equal(caught, failure, 'the original rejection remains observable by an outer layer')
+  t.equal(globalThis[kGlobalArray]?.length ?? 0, before, 'no in-flight registry entry leaks')
+  t.equal(onErrorCalls, 0, 'the log layer does not double-deliver the outer error path')
+  t.equal(errors.length, 1, 'the rejection receives one terminal failure log')
+  t.equal(errors[0][0].err, failure)
+})


### PR DESCRIPTION
## What changed

- Observe Promise-like results returned by the inner dispatch function.
- Finalize logging, tracing, and the global in-flight registry before rethrowing an asynchronous rejection.
- Add a regression covering error identity, exactly-once logging, registry cleanup, and non-duplication of `onError`.

## Why

The log interceptor only handled synchronous dispatch throws. A rejected `DispatchFn` promise left a zombie handler in the global in-flight registry and emitted a start log/trace without a terminal counterpart. The rejection still needs to propagate so an outer layer can deliver it through the handler chain.

## Validation

- `npx tap test/review-bugfixes-6-log-async-dispatch.js test/review-bugfixes-4-log-sync-throw.js test/log-advanced.js test/trace.js`
- `npx eslint lib/interceptor/log.js test/review-bugfixes-6-log-async-dispatch.js`
- staged-file ESLint and Prettier hooks