### PR TITLE
fix(handler): make upgrades terminal

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 import stream from 'node:stream'
-import assert from 'node:assert'
 import { util } from '@nxtedition/undici'
 import createHttpError from 'http-errors'
 
@@ -572,15 +571,13 @@ export class DecoratorHandler {
   }
 
   onHeaders(statusCode, headers, resume) {
-    if (!this.#aborted && !this.#errored) {
-      assert(!this.#completed)
+    if (!this.#aborted && !this.#errored && !this.#completed) {
       return this.#handler.onHeaders?.(statusCode, headers, resume)
     }
   }
 
   onData(data) {
-    if (!this.#aborted && !this.#errored && data != null) {
-      assert(!this.#completed)
+    if (!this.#aborted && !this.#errored && !this.#completed && data != null) {
       return this.#handler.onData?.(data)
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -565,8 +565,8 @@ export class DecoratorHandler {
   }
 
   onUpgrade(statusCode, headers, socket) {
-    if (!this.#aborted && !this.#errored) {
-      assert(!this.#completed)
+    if (!this.#aborted && !this.#errored && !this.#completed) {
+      this.#completed = true
       return this.#handler.onUpgrade?.(statusCode, headers, socket)
     }
   }

--- a/test/decorator-upgrade-terminal.js
+++ b/test/decorator-upgrade-terminal.js
@@ -12,6 +12,12 @@ test('DecoratorHandler treats onUpgrade as a terminal callback', (t) => {
     onUpgrade() {
       calls.push('upgrade')
     },
+    onHeaders() {
+      calls.push('headers')
+    },
+    onData() {
+      calls.push('data')
+    },
     onComplete() {
       calls.push('complete')
     },
@@ -26,6 +32,8 @@ test('DecoratorHandler treats onUpgrade as a terminal callback', (t) => {
   })
   decorator.onUpgrade(101, {}, {})
   decorator.onUpgrade(101, {}, {})
+  decorator.onHeaders(200, {}, () => {})
+  decorator.onData(Buffer.from('late data'))
   decorator.onComplete({})
   decorator.onError(new Error('late transport error'))
   wrappedAbort(new Error('late caller abort'))

--- a/test/decorator-upgrade-terminal.js
+++ b/test/decorator-upgrade-terminal.js
@@ -1,0 +1,36 @@
+import { test } from 'tap'
+import { DecoratorHandler } from '../lib/utils.js'
+
+test('DecoratorHandler treats onUpgrade as a terminal callback', (t) => {
+  const calls = []
+  let wrappedAbort
+  let transportAborts = 0
+  const handler = {
+    onConnect(abort) {
+      wrappedAbort = abort
+    },
+    onUpgrade() {
+      calls.push('upgrade')
+    },
+    onComplete() {
+      calls.push('complete')
+    },
+    onError() {
+      calls.push('error')
+    },
+  }
+  const decorator = new DecoratorHandler(handler)
+
+  decorator.onConnect(() => {
+    transportAborts++
+  })
+  decorator.onUpgrade(101, {}, {})
+  decorator.onUpgrade(101, {}, {})
+  decorator.onComplete({})
+  decorator.onError(new Error('late transport error'))
+  wrappedAbort(new Error('late caller abort'))
+
+  t.strictSame(calls, ['upgrade'])
+  t.equal(transportAborts, 0)
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Mark `DecoratorHandler` complete before forwarding `onUpgrade`.
- Suppress duplicate upgrades and late completion, error, or caller-abort callbacks.
- Add a focused lifecycle regression and rerun the full utility suite.

## Why

A successful protocol upgrade is a terminal dispatcher branch: ownership transfers with the socket and no normal completion/error callback follows. The decorator previously forwarded `onUpgrade` without recording terminal state, allowing malformed or asynchronously failing inner dispatchers to deliver a second terminal event downstream.

## Validation

- `npx tap test/decorator-upgrade-terminal.js test/utils.js`
- `npx eslint lib/utils.js test/decorator-upgrade-terminal.js`
- staged-file ESLint and Prettier hooks