### PR TITLE
fix(headers): handle prototype-named fields safely

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -600,6 +600,15 @@ export class DecoratorHandler {
   }
 }
 
+function setOwnHeader(obj, key, value) {
+  Object.defineProperty(obj, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
+}
+
 /**
  * @param {Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]} headers
  * @param {Record<string, string | string[]>} [obj]
@@ -625,15 +634,16 @@ export function parseHeaders(headers, obj) {
       }
 
       const key = util.headerNameToString(key2)
-      let val = obj[key]
 
-      // `key in obj`, not `if (val)`: an empty-string value ('') is a valid,
-      // present header. A truthy check would treat it as absent and overwrite
-      // it on a duplicate occurrence, silently dropping the first value.
-      if (key in obj) {
+      // Check own presence, not truthiness: an empty string is a valid value,
+      // while inherited names such as `constructor` are not existing headers.
+      // Define new keys as own data properties so `__proto__` cannot invoke
+      // Object.prototype's legacy setter and mutate the result's prototype.
+      if (Object.hasOwn(obj, key)) {
+        let val = obj[key]
         if (!Array.isArray(val)) {
           val = [val]
-          obj[key] = val
+          setOwnHeader(obj, key, val)
         }
 
         if (Array.isArray(val2)) {
@@ -642,9 +652,11 @@ export function parseHeaders(headers, obj) {
           val.push(`${val2}`)
         }
       } else {
-        obj[key] = Array.isArray(val2)
-          ? val2.filter((x) => x != null).map((x) => `${x}`)
-          : `${val2}`
+        setOwnHeader(
+          obj,
+          key,
+          Array.isArray(val2) ? val2.filter((x) => x != null).map((x) => `${x}`) : `${val2}`,
+        )
       }
     }
   } else if (typeof headers === 'object' && headers !== null) {
@@ -659,14 +671,14 @@ export function parseHeaders(headers, obj) {
       }
 
       const key = util.headerNameToString(key2)
-      let val = obj[key]
 
       // See the array branch above: presence check, not truthiness, so a
       // stored empty string is not clobbered by a later duplicate.
-      if (key in obj) {
+      if (Object.hasOwn(obj, key)) {
+        let val = obj[key]
         if (!Array.isArray(val)) {
           val = [val]
-          obj[key] = val
+          setOwnHeader(obj, key, val)
         }
         if (Array.isArray(val2)) {
           val.push(...val2.filter((x) => x != null).map((x) => `${x}`))
@@ -674,9 +686,11 @@ export function parseHeaders(headers, obj) {
           val.push(`${val2}`)
         }
       } else {
-        obj[key] = Array.isArray(val2)
-          ? val2.filter((x) => x != null).map((x) => `${x}`)
-          : `${val2}`
+        setOwnHeader(
+          obj,
+          key,
+          Array.isArray(val2) ? val2.filter((x) => x != null).map((x) => `${x}`) : `${val2}`,
+        )
       }
     }
   } else if (headers != null) {

--- a/test/parse-headers-prototype-safety.js
+++ b/test/parse-headers-prototype-safety.js
@@ -1,0 +1,30 @@
+import { test } from 'tap'
+import { parseHeaders } from '../lib/utils.js'
+
+test('parseHeaders treats prototype names as ordinary header names', (t) => {
+  const fromPairs = parseHeaders(['__proto__', 'pair-proto', 'constructor', 'pair-constructor'])
+
+  t.equal(Object.getPrototypeOf(fromPairs), Object.prototype)
+  t.equal(Object.hasOwn(fromPairs, '__proto__'), true)
+  t.equal(fromPairs.__proto__, 'pair-proto')
+  t.equal(Object.hasOwn(fromPairs, 'constructor'), true)
+  t.equal(fromPairs.constructor, 'pair-constructor')
+
+  const source = JSON.parse('{"__proto__":"object-proto","constructor":"object-constructor"}')
+  const fromObject = parseHeaders(source)
+
+  t.equal(Object.getPrototypeOf(fromObject), Object.prototype)
+  t.equal(Object.hasOwn(fromObject, '__proto__'), true)
+  t.equal(fromObject.__proto__, 'object-proto')
+  t.equal(Object.hasOwn(fromObject, 'constructor'), true)
+  t.equal(fromObject.constructor, 'object-constructor')
+
+  const target = Object.create({
+    get constructor() {
+      throw new Error('inherited getters must not be read')
+    },
+  })
+  parseHeaders({ constructor: 'safe' }, target)
+  t.equal(target.constructor, 'safe')
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Detect duplicate fields with own-property checks instead of the prototype chain.
- Define normalized fields as own data properties, including `__proto__`.
- Avoid reading inherited getters while deciding whether a field already exists.
- Add pair-array, object-form, and inherited-getter regressions.

## Why

HTTP field names such as `constructor`, `toString`, and `__proto__` are legal tokens. `parseHeaders()` used `key in obj` and ordinary assignment, so inherited Object properties were mistaken for existing header values and `__proto__` invoked the legacy prototype setter. Results could contain functions/objects instead of strings or have their prototype mutated.

## Validation

- `npx tap test/parse-headers-prototype-safety.js test/utils.js test/parse-headers.js test/review-bugfixes-2-headers.js`
- `npx eslint lib/utils.js test/parse-headers-prototype-safety.js`
- staged-file ESLint and Prettier hooks