### PR TITLE
fix(request): honor falsy abort reasons

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -45,13 +45,16 @@ export class RequestHandler {
     this.body = body
     this.context = null
     this.highWaterMark = highWaterMark
+    this.aborted = false
     this.reason = null
 
     if (signal?.aborted) {
-      this.reason = signal.reason ?? new RequestAbortedError()
+      this.aborted = true
+      this.reason = signal.reason === undefined ? new RequestAbortedError() : signal.reason
     } else if (signal) {
       const onAbort = () => {
-        this.reason = signal.reason ?? new RequestAbortedError()
+        this.aborted = true
+        this.reason = signal.reason === undefined ? new RequestAbortedError() : signal.reason
         if (this.res) {
           this.res.on('error', noop).destroy(this.reason)
         } else if (this.abort) {
@@ -72,7 +75,7 @@ export class RequestHandler {
   }
 
   onConnect(abort) {
-    if (this.reason !== null) {
+    if (this.aborted) {
       abort(this.reason)
       return
     }

--- a/lib/request.js
+++ b/lib/request.js
@@ -72,7 +72,7 @@ export class RequestHandler {
   }
 
   onConnect(abort) {
-    if (this.reason) {
+    if (this.reason !== null) {
       abort(this.reason)
       return
     }

--- a/test/request-falsy-abort-reason.js
+++ b/test/request-falsy-abort-reason.js
@@ -33,3 +33,20 @@ test('RequestHandler honors a falsy abort reason received before onConnect', (t)
   t.equal(reason, 0)
   t.end()
 })
+
+test('RequestHandler honors null as an abort reason', (t) => {
+  const controller = new AbortController()
+  const handler = new RequestHandler({ method: 'GET', body: null, signal: controller.signal }, () =>
+    t.fail('an aborted request must not resolve'),
+  )
+
+  controller.abort(null)
+
+  let reason = Symbol('not called')
+  handler.onConnect((value) => {
+    reason = value
+  })
+
+  t.equal(reason, null)
+  t.end()
+})

--- a/test/request-falsy-abort-reason.js
+++ b/test/request-falsy-abort-reason.js
@@ -1,0 +1,35 @@
+import { test } from 'tap'
+import { RequestHandler } from '../lib/request.js'
+
+test('RequestHandler honors a pre-aborted signal with a falsy reason', (t) => {
+  const controller = new AbortController()
+  controller.abort(false)
+  const handler = new RequestHandler({ method: 'GET', body: null, signal: controller.signal }, () =>
+    t.fail('an aborted request must not resolve'),
+  )
+
+  let reason = Symbol('not called')
+  handler.onConnect((value) => {
+    reason = value
+  })
+
+  t.equal(reason, false)
+  t.end()
+})
+
+test('RequestHandler honors a falsy abort reason received before onConnect', (t) => {
+  const controller = new AbortController()
+  const handler = new RequestHandler({ method: 'GET', body: null, signal: controller.signal }, () =>
+    t.fail('an aborted request must not resolve'),
+  )
+
+  controller.abort(0)
+
+  let reason = Symbol('not called')
+  handler.onConnect((value) => {
+    reason = value
+  })
+
+  t.equal(reason, 0)
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Track aborted state independently from the abort reason.
- Preserve and deliver valid falsy reasons such as `false` and `0` before connection.
- Add regressions for already-aborted and abort-before-connect signals.

## Why

`AbortSignal.reason` can be any JavaScript value. Request setup used the reason's truthiness as the aborted-state flag, so a signal aborted with `false` or `0` was treated as live and the request proceeded.

## Validation

- focused falsy-reason regressions
- request handler suite
- ESLint and staged-file Prettier hooks