### PR TITLE
fix(request): default empty bodies to POST

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ function wrapDispatch(dispatcher) {
             id: opts.id ?? headers['request-id'],
             origin: opts.origin,
             path: opts.path,
-            method: opts.method ?? (opts.body ? 'POST' : 'GET'),
+            method: opts.method ?? (opts.body != null ? 'POST' : 'GET'),
             body: opts.body,
             query: opts.query,
             headers,

--- a/test/request-empty-body-method.js
+++ b/test/request-empty-body-method.js
@@ -1,0 +1,25 @@
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+function recordingDispatcher(methods) {
+  return {
+    dispatch(opts, handler) {
+      methods.push(opts.method)
+      handler.onConnect(() => {})
+      handler.onHeaders(200, { 'content-length': '0' }, () => {})
+      handler.onComplete({})
+    },
+  }
+}
+
+test('request defaults to POST when an empty string body is present', async (t) => {
+  const methods = []
+  const dispatcher = recordingDispatcher(methods)
+
+  const withBody = await request('http://example.test', { body: '', dispatcher, dns: false })
+  await withBody.body.dump()
+  const withoutBody = await request('http://example.test', { dispatcher, dns: false })
+  await withoutBody.body.dump()
+
+  t.strictSame(methods, ['POST', 'GET'])
+})


### PR DESCRIPTION
## What changed

- Base automatic method selection on body presence rather than truthiness.
- Add a public request regression contrasting an empty-string body with no body.

## Why

An empty string is a valid, present request body. The truthy check classified it as absent and defaulted the method to GET, unlike every other body value and contrary to the API's POST-on-body behavior.

## Validation

- focused public request regression
- request suite
- ESLint and staged-file Prettier hooks