### PR TITLE
fix(request): handle async dispatch rejections

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -218,7 +218,10 @@ export function request(dispatch, urlOrOpts, optsOrNully) {
   return new Promise((resolve) => {
     const handler = new RequestHandler(opts, resolve)
     try {
-      dispatch(opts, handler)
+      const result = dispatch(opts, handler)
+      if (result != null && typeof result.then === 'function') {
+        void Promise.resolve(result).catch((err) => handler.onError(err))
+      }
     } catch (err) {
       // A synchronous throw from dispatch otherwise skips onConnect/onError, so
       // the request body stream is never destroyed and the signal's abort

--- a/test/request-async-dispatch-rejection.js
+++ b/test/request-async-dispatch-rejection.js
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'node:events'
+import { Readable } from 'node:stream'
+import { test } from 'tap'
+import { request as publicRequest } from '../lib/index.js'
+import { request as coreRequest } from '../lib/request.js'
+
+test('request handles a dispatch function that returns a rejected promise', async (t) => {
+  const expected = new Error('async dispatch failure')
+  const signal = new EventEmitter()
+  const body = new Readable({ read() {} })
+  const dispatch = async () => {
+    await Promise.resolve()
+    throw expected
+  }
+
+  await t.rejects(coreRequest(dispatch, 'http://example.test', { body, signal }), expected)
+  t.equal(body.destroyed, true)
+  t.equal(signal.listenerCount('abort'), 0)
+})
+
+test('request errors an already-created response body on async dispatch rejection', async (t) => {
+  const expected = new Error('late async dispatch failure')
+  let rejectDispatch
+  const dispatch = (_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    return new Promise((_resolve, reject) => {
+      rejectDispatch = reject
+    })
+  }
+
+  const { body } = await coreRequest(dispatch, 'http://example.test')
+  const text = body.text()
+  rejectDispatch(expected)
+
+  await t.rejects(text, expected)
+})
+
+test('public request handles a DispatchFn promise rejection', async (t) => {
+  const expected = new Error('public async dispatch failure')
+  const dispatch = async () => {
+    await Promise.resolve()
+    throw expected
+  }
+
+  await t.rejects(
+    publicRequest('http://127.0.0.1', { dispatch, dns: false, retry: false }),
+    expected,
+  )
+})


### PR DESCRIPTION
## What changed

- Observe Promise-like values returned by a `DispatchFn`.
- Route asynchronous rejections through `RequestHandler.onError`, both before and after response headers.
- Add core and public API regressions covering rejection delivery plus request-body and signal-listener cleanup.

## Why

The request API caught synchronous dispatch throws but ignored rejected dispatch promises, despite the public `DispatchFn` contract allowing `Promise<void>`. Initial rejections hung the request and leaked body/signal resources; late rejections left an already-created response stream open.

## Validation

- focused async-dispatch regressions
- request handler suite
- ESLint and staged-file Prettier hooks