### PR TITLE
fix(request): validate high water mark

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -303,7 +303,7 @@ export interface RequestOptions extends Omit<DispatchOptions, 'upgrade'> {
   url?: URLLike | null
   dispatch?: DispatchFn | null
   dispatcher?: Dispatcher | null
-  /** highWaterMark for the response body readable (non-negative number). */
+  /** highWaterMark for the response body readable (non-negative integer). */
   highWaterMark?: number | null
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,7 +16,7 @@ export class RequestHandler {
         throw new InvalidArgumentError('invalid resolve')
       }
 
-      if (highWaterMark && (typeof highWaterMark !== 'number' || highWaterMark < 0)) {
+      if (highWaterMark != null && (!Number.isInteger(highWaterMark) || highWaterMark < 0)) {
         throw new InvalidArgumentError('invalid highWaterMark')
       }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,6 +16,8 @@ export class RequestHandler {
         throw new InvalidArgumentError('invalid resolve')
       }
 
+      // Match Node and @nxtedition/undici streams: highWaterMark must be a
+      // non-negative integer, but it is not restricted to safe integers.
       if (highWaterMark != null && (!Number.isInteger(highWaterMark) || highWaterMark < 0)) {
         throw new InvalidArgumentError('invalid highWaterMark')
       }

--- a/test/request-high-water-mark-validation.js
+++ b/test/request-high-water-mark-validation.js
@@ -16,5 +16,13 @@ test('RequestHandler rejects highWaterMark values that Node streams reject', (t)
   t.doesNotThrow(
     () => new RequestHandler({ method: 'GET', body: null, highWaterMark: 1 }, () => {}),
   )
+  t.doesNotThrow(
+    () =>
+      new RequestHandler(
+        { method: 'GET', body: null, highWaterMark: Number.MAX_SAFE_INTEGER + 1 },
+        () => {},
+      ),
+    'accepts the same non-safe integer values as Node streams',
+  )
   t.end()
 })

--- a/test/request-high-water-mark-validation.js
+++ b/test/request-high-water-mark-validation.js
@@ -1,0 +1,20 @@
+import { test } from 'tap'
+import { RequestHandler } from '../lib/request.js'
+
+test('RequestHandler rejects highWaterMark values that Node streams reject', (t) => {
+  for (const highWaterMark of [NaN, Infinity, -Infinity, 1.5]) {
+    t.throws(
+      () => new RequestHandler({ method: 'GET', body: null, highWaterMark }, () => {}),
+      { name: 'InvalidArgumentError', code: 'UND_ERR_INVALID_ARG' },
+      `rejects ${highWaterMark}`,
+    )
+  }
+
+  t.doesNotThrow(
+    () => new RequestHandler({ method: 'GET', body: null, highWaterMark: 0 }, () => {}),
+  )
+  t.doesNotThrow(
+    () => new RequestHandler({ method: 'GET', body: null, highWaterMark: 1 }, () => {}),
+  )
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Validate `highWaterMark` with the same non-negative-integer rule Node streams require.
- Keep `0` valid while rejecting NaN, infinities, negatives, and fractions up front.
- Add focused accepted/rejected-value coverage.

## Why

The prior truthiness guard let NaN and other invalid values through request construction. They failed later while creating the response stream, after dispatch had already begun, producing a late and less controlled error path.

## Validation

- focused high-water-mark regressions
- request handler suite
- ESLint and staged-file Prettier hooks