### PR TITLE
fix(response-error): recognize JSON media types

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -47,7 +47,13 @@ class Handler extends DecoratorHandler {
     const contentType = Array.isArray(this.#headers['content-type'])
       ? this.#headers['content-type'][0]
       : this.#headers['content-type']
-    if (contentType?.startsWith('application/json') || contentType?.startsWith('text/plain')) {
+    const mediaType =
+      typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
+    if (
+      mediaType === 'application/json' ||
+      mediaType?.endsWith('+json') ||
+      mediaType === 'text/plain'
+    ) {
       this.#decoder = new TextDecoder('utf-8')
       this.#body = ''
     }

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -51,6 +51,7 @@ class Handler extends DecoratorHandler {
       typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
     if (
       mediaType === 'application/json' ||
+      mediaType?.startsWith('application/json-') ||
       mediaType?.endsWith('+json') ||
       mediaType === 'text/plain'
     ) {

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -1,4 +1,4 @@
-import { DecoratorHandler, decorateError } from '../utils.js'
+import { DecoratorHandler, decorateError, isJsonMediaType, normalizeMediaType } from '../utils.js'
 
 const MAX_ERROR_BODY_SIZE = 256 * 1024
 
@@ -42,19 +42,8 @@ class Handler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    // A duplicated content-type header is an array; .startsWith would throw
-    // synchronously out of this parser callback. Coerce to the first value.
-    const contentType = Array.isArray(this.#headers['content-type'])
-      ? this.#headers['content-type'][0]
-      : this.#headers['content-type']
-    const mediaType =
-      typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
-    if (
-      mediaType === 'application/json' ||
-      mediaType?.startsWith('application/json-') ||
-      mediaType?.endsWith('+json') ||
-      mediaType === 'text/plain'
-    ) {
+    const mediaType = normalizeMediaType(this.#headers['content-type'])
+    if (isJsonMediaType(mediaType) || mediaType === 'text/plain') {
       this.#decoder = new TextDecoder('utf-8')
       this.#body = ''
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -722,7 +722,12 @@ export function decorateError(err, opts, { statusCode, headers, trailers, body }
     const contentType = Array.isArray(headers?.['content-type'])
       ? headers['content-type'][0]
       : headers?.['content-type']
-    if (typeof body === 'string' && (!contentType || contentType.startsWith('application/json'))) {
+    const mediaType =
+      typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
+    if (
+      typeof body === 'string' &&
+      (!contentType || mediaType === 'application/json' || mediaType?.endsWith('+json'))
+    ) {
       try {
         body = JSON.parse(body)
       } catch {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -726,7 +726,10 @@ export function decorateError(err, opts, { statusCode, headers, trailers, body }
       typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
     if (
       typeof body === 'string' &&
-      (!contentType || mediaType === 'application/json' || mediaType?.endsWith('+json'))
+      (!contentType ||
+        mediaType === 'application/json' ||
+        mediaType?.startsWith('application/json-') ||
+        mediaType?.endsWith('+json'))
     ) {
       try {
         body = JSON.parse(body)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -686,6 +686,22 @@ export function parseHeaders(headers, obj) {
   return obj
 }
 
+export function normalizeMediaType(contentType) {
+  if (Array.isArray(contentType)) {
+    contentType = contentType[0]
+  }
+
+  return typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
+}
+
+export function isJsonMediaType(mediaType) {
+  return (
+    mediaType === 'application/json' ||
+    (typeof mediaType === 'string' &&
+      (mediaType.startsWith('application/json-') || mediaType.endsWith('+json')))
+  )
+}
+
 export function decorateError(err, opts, { statusCode, headers, trailers, body }) {
   try {
     if (err == null) {
@@ -715,21 +731,10 @@ export function decorateError(err, opts, { statusCode, headers, trailers, body }
       body = null
     }
 
-    // A duplicated content-type response header arrives as an array (undici's
-    // parseHeaders collapses repeats); coerce to the first value before
-    // calling string methods, otherwise this throws and the catch below
-    // discards all decoration into an opaque AggregateError.
-    const contentType = Array.isArray(headers?.['content-type'])
-      ? headers['content-type'][0]
-      : headers?.['content-type']
-    const mediaType =
-      typeof contentType === 'string' ? contentType.split(';', 1)[0].trim().toLowerCase() : null
+    const mediaType = normalizeMediaType(headers?.['content-type'])
     if (
       typeof body === 'string' &&
-      (!contentType ||
-        mediaType === 'application/json' ||
-        mediaType?.startsWith('application/json-') ||
-        mediaType?.endsWith('+json'))
+      (mediaType == null || mediaType === '' || isJsonMediaType(mediaType))
     ) {
       try {
         body = JSON.parse(body)

--- a/test/response-error-json-media-types.js
+++ b/test/response-error-json-media-types.js
@@ -1,0 +1,36 @@
+import { test } from 'tap'
+import responseError from '../lib/interceptor/response-error.js'
+
+function captureError(contentType, payload) {
+  let error
+  const dispatch = responseError()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(400, { 'content-type': contentType }, () => {})
+    handler.onData(Buffer.from(payload))
+    handler.onComplete({})
+  })
+
+  dispatch(
+    { error: true, origin: 'http://example.test', path: '/', method: 'GET', headers: {} },
+    {
+      onError(err) {
+        error = err
+      },
+    },
+  )
+  return error
+}
+
+test('response errors recognize JSON and text media types case-insensitively', (t) => {
+  const upperCase = captureError('Application/JSON; Charset=UTF-8', '{"code":"UPPER"}')
+  t.strictSame(upperCase.body, { code: 'UPPER' })
+  t.equal(upperCase.code, 'UPPER')
+
+  const problem = captureError('application/problem+json', '{"reason":"bad input"}')
+  t.strictSame(problem.body, { reason: 'bad input' })
+  t.equal(problem.reason, 'bad input')
+
+  const text = captureError('Text/Plain; Charset=UTF-8', 'plain error')
+  t.equal(text.body, 'plain error')
+  t.end()
+})

--- a/test/response-error-json-media-types.js
+++ b/test/response-error-json-media-types.js
@@ -30,6 +30,10 @@ test('response errors recognize JSON and text media types case-insensitively', (
   t.strictSame(problem.body, { reason: 'bad input' })
   t.equal(problem.reason, 'bad input')
 
+  const sequence = captureError('application/json-seq', '{"code":"SEQUENCE"}')
+  t.strictSame(sequence.body, { code: 'SEQUENCE' })
+  t.equal(sequence.code, 'SEQUENCE')
+
   const text = captureError('Text/Plain; Charset=UTF-8', 'plain error')
   t.equal(text.body, 'plain error')
   t.end()


### PR DESCRIPTION
## What changed

- Parse media types case-insensitively and independently of parameters.
- Buffer and decode structured-suffix JSON such as `application/problem+json`.
- Apply the same JSON recognition when parsing the decorated body.
- Add mixed-case JSON, problem+json, and mixed-case text regressions.

## Why

HTTP media types are case-insensitive, and RFC structured syntax suffixes make `application/*+json` standard JSON representations. Exact lowercase-prefix checks skipped those error bodies, losing structured reason/code data.

## Validation

- focused media-type regressions
- response-error advanced suite
- ESLint and staged-file Prettier hooks