### PR TITLE
fix(response-error): retain falsy JSON bodies

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -7,7 +7,7 @@ class Handler extends DecoratorHandler {
   #decoder
   #headers
   #trailers
-  #body = ''
+  #body = null
   #bodySize = 0
   #opts
   #reason = null
@@ -23,7 +23,7 @@ class Handler extends DecoratorHandler {
     this.#decoder = null
     this.#headers = null
     this.#trailers = null
-    this.#body = ''
+    this.#body = null
     this.#bodySize = 0
     this.#reason = null
 
@@ -76,7 +76,9 @@ class Handler extends DecoratorHandler {
       return super.onComplete(trailers)
     }
 
-    this.#body += this.#decoder?.decode(undefined, { stream: false }) ?? ''
+    if (this.#decoder) {
+      this.#body += this.#decoder.decode(undefined, { stream: false })
+    }
 
     super.onError(
       decorateError(null, this.#opts, {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -812,7 +812,7 @@ export function decorateError(err, opts, { statusCode, headers, trailers, body }
       statusCode,
     }
 
-    if (body) {
+    if (body != null) {
       err.body = body
       if (body.reason != null) {
         err.reason ??= body.reason

--- a/test/response-error-falsy-body.js
+++ b/test/response-error-falsy-body.js
@@ -40,3 +40,10 @@ test('response errors do not attach an uncaptured body', (t) => {
   t.equal(Object.hasOwn(error, 'body'), false)
   t.end()
 })
+
+test('response errors do not attach a decoded JSON null body', (t) => {
+  const error = captureError('null')
+
+  t.equal(Object.hasOwn(error, 'body'), false)
+  t.end()
+})

--- a/test/response-error-falsy-body.js
+++ b/test/response-error-falsy-body.js
@@ -1,0 +1,35 @@
+import { test } from 'tap'
+import responseError from '../lib/interceptor/response-error.js'
+
+function captureError(payload) {
+  let error
+  const dispatch = responseError()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(400, { 'content-type': 'application/json' }, () => {})
+    handler.onData(Buffer.from(payload))
+    handler.onComplete({})
+  })
+
+  dispatch(
+    { error: true, origin: 'http://example.test', path: '/', method: 'GET', headers: {} },
+    {
+      onError(err) {
+        error = err
+      },
+    },
+  )
+  return error
+}
+
+test('response errors retain valid falsy JSON bodies', (t) => {
+  for (const [payload, expected] of [
+    ['false', false],
+    ['0', 0],
+    ['""', ''],
+  ]) {
+    const error = captureError(payload)
+    t.equal(Object.hasOwn(error, 'body'), true, `${payload} is attached`)
+    t.equal(error.body, expected)
+  }
+  t.end()
+})

--- a/test/response-error-falsy-body.js
+++ b/test/response-error-falsy-body.js
@@ -1,11 +1,11 @@
 import { test } from 'tap'
 import responseError from '../lib/interceptor/response-error.js'
 
-function captureError(payload) {
+function captureError(payload, contentType = 'application/json') {
   let error
   const dispatch = responseError()((_opts, handler) => {
     handler.onConnect(() => {})
-    handler.onHeaders(400, { 'content-type': 'application/json' }, () => {})
+    handler.onHeaders(400, { 'content-type': contentType }, () => {})
     handler.onData(Buffer.from(payload))
     handler.onComplete({})
   })
@@ -31,5 +31,12 @@ test('response errors retain valid falsy JSON bodies', (t) => {
     t.equal(Object.hasOwn(error, 'body'), true, `${payload} is attached`)
     t.equal(error.body, expected)
   }
+  t.end()
+})
+
+test('response errors do not attach an uncaptured body', (t) => {
+  const error = captureError('binary data', 'application/octet-stream')
+
+  t.equal(Object.hasOwn(error, 'body'), false)
   t.end()
 })


### PR DESCRIPTION
## What changed

- Attach every decoded response body except `null`/`undefined` to the decorated error.
- Add regressions for JSON `false`, `0`, and an empty string.

## Why

Valid JSON responses can be falsy. The decorator used a truthiness check, so those payloads silently disappeared from `err.body` even though they were successfully buffered and parsed.

## Validation

- focused response-error regressions
- utility suite
- ESLint and staged-file Prettier hooks