### PR TITLE
fix(response-error): reset trailers on reconnect

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -22,6 +22,7 @@ class Handler extends DecoratorHandler {
     this.#statusCode = 0
     this.#decoder = null
     this.#headers = null
+    this.#trailers = undefined
     this.#body = ''
     this.#bodySize = 0
     this.#reason = null

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -22,7 +22,7 @@ class Handler extends DecoratorHandler {
     this.#statusCode = 0
     this.#decoder = null
     this.#headers = null
-    this.#trailers = undefined
+    this.#trailers = null
     this.#body = ''
     this.#bodySize = 0
     this.#reason = null

--- a/test/response-error-reset-trailers.js
+++ b/test/response-error-reset-trailers.js
@@ -1,0 +1,31 @@
+import { test } from 'tap'
+import responseError from '../lib/interceptor/response-error.js'
+
+test('response-error does not leak trailers across reconnects', (t) => {
+  let handler
+  const errors = []
+  const dispatch = responseError()((_opts, value) => {
+    handler = value
+  })
+  dispatch(
+    { error: true, origin: 'http://example.test', path: '/', method: 'GET', headers: {} },
+    {
+      onError(error) {
+        errors.push(error)
+      },
+    },
+  )
+
+  handler.onConnect(() => {})
+  handler.onHeaders(500, { 'content-type': 'text/plain' }, () => {})
+  handler.onData(Buffer.from('first attempt'))
+  handler.onComplete({ 'x-first-trailer': 'present' })
+
+  handler.onConnect(() => {})
+  handler.onError(new Error('second attempt transport failure'))
+
+  t.equal(errors.length, 2)
+  t.strictSame(errors[0].res.trailers, { 'x-first-trailer': 'present' })
+  t.equal(errors[1].res.trailers, undefined)
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Clear captured response trailers whenever a reused handler reconnects.
- Add a two-attempt regression proving the second transport error does not inherit the first response's trailers.

## Why

Response-error resets status, headers, decoder, and body on every connection but retained trailers. In retry/reuse scenarios, an error before second-attempt completion was decorated with stale trailers from the prior response.

## Validation

- focused reconnect regression
- response-error advanced suite
- ESLint and staged-file Prettier hooks