### PR TITLE
fix(types): declare binary body factory results

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,7 +63,7 @@ export type { TraceWriter } from '@nxtedition/trace'
 import type { TraceWriter } from '@nxtedition/trace'
 
 export type BodyFactoryResult =
-  Readable | Uint8Array | string | Iterable<unknown> | AsyncIterable<unknown>
+  Readable | ArrayBuffer | ArrayBufferView | string | Iterable<unknown> | AsyncIterable<unknown>
 
 /** Called with an options object (not a bare signal); the signal aborts when the
  *  request is destroyed before the factory resolves. May be async. */

--- a/type-tests/body-factory-binary.ts
+++ b/type-tests/body-factory-binary.ts
@@ -1,0 +1,7 @@
+import type { BodyFactory } from '../lib/index.js'
+
+const arrayBufferFactory: BodyFactory = () => new ArrayBuffer(8)
+const dataViewFactory: BodyFactory = () => new DataView(new ArrayBuffer(8))
+const typedArrayFactory: BodyFactory = () => new Uint16Array(4)
+
+void [arrayBufferFactory, dataViewFactory, typedArrayFactory]


### PR DESCRIPTION
## What changed

- Declare `ArrayBuffer` and every `ArrayBufferView` as valid body-factory results.
- Add strict fixtures for ArrayBuffer, DataView, and a non-byte typed array.
- Add the shared public-declaration test runner.

## Why

The body factory normalizes these binary forms at runtime, but its type only exposed `Uint8Array`, rejecting supported callers.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks