### PR TITLE
fix(types): declare pressure tracing option

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -182,6 +182,8 @@ export interface LogInterceptorOptions {
 }
 
 export interface PressureInterceptorOptions {
+  /** Trace writer for pressure episode documents; null disables tracing. */
+  trace?: TraceWriter | null
   /** Sampling interval for the internal EWMA loop, in ms (default 200).
    *  Set to 0 to disable the internal timer and drive sampling yourself via
    *  `sample()` from a loop you already run. */

--- a/type-tests/pressure-trace.ts
+++ b/type-tests/pressure-trace.ts
@@ -1,0 +1,7 @@
+import { interceptors, type TraceWriter } from '../lib/index.js'
+
+const trace: TraceWriter = { write: null }
+const pressure = interceptors.pressure({ trace })
+const disabledPressure = interceptors.pressure({ trace: null })
+pressure.close()
+disabledPressure.close()


### PR DESCRIPTION
## What changed

- Add the runtime-supported `trace` field to `PressureInterceptorOptions`.
- Add a strict TypeScript fixture and shared public-declaration test runner.

## Why

`interceptors.pressure({ trace })` works at runtime and is covered by tracing tests, but consumers could not express it through the public declarations.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks