### PR TITLE
fix(types): declare readable body API

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,13 @@ export interface BodyReadable extends Readable {
   json(): Promise<unknown>
   arrayBuffer(): Promise<ArrayBuffer>
   blob(): Promise<Blob>
+  bytes(): Promise<Uint8Array>
+  /** Not implemented by @nxtedition/undici's BodyReadable; always rejects. */
+  formData(): Promise<never>
   dump(): Promise<void>
+  readonly bodyUsed: boolean
+  /** The Node.js BodyReadable does not expose a Fetch ReadableStream body. */
+  readonly body?: never
 }
 
 export type URLLike = string | URL | URLObject

--- a/type-tests/body-readable.ts
+++ b/type-tests/body-readable.ts
@@ -1,0 +1,13 @@
+import type { BodyReadable } from '../lib/index.js'
+
+async function consume(body: BodyReadable) {
+  const bytes: Uint8Array = await body.bytes()
+  const used: boolean = body.bodyUsed
+  // These deliberately mirror @nxtedition/undici's runtime: BodyReadable has
+  // no Fetch ReadableStream getter and formData() always rejects as unsupported.
+  const unsupportedBody: undefined = body.body
+  const unsupportedFormData: Promise<never> = body.formData()
+  return { bytes, used, unsupportedBody, unsupportedFormData }
+}
+
+void consume


### PR DESCRIPTION
## What changed

- Add the runtime `bytes()`, `formData()`, `bodyUsed`, and `body` members to `BodyReadable`.
- Add a strict usage fixture and shared public-declaration test runner.

## Why

Responses expose the undici readable-body mixin at runtime, but several members were absent from this package's declarations, forcing valid consumer code to cast.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks