### PR TITLE
fix(types): declare runtime request options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,6 +83,8 @@ export interface DispatchOptions {
   reset?: boolean | null
   blocking?: boolean | null
   timeout?: number | { headers?: number | null; body?: number | null } | null
+  /** Alias for `headersTimeout`. */
+  headerTimeout?: number | null
   headersTimeout?: number | null
   bodyTimeout?: number | null
   idempotent?: boolean | null
@@ -99,8 +101,11 @@ export interface DispatchOptions {
   /** Alias for `follow`; ignored when `follow` is also set. */
   redirect?: number | FollowFn | boolean | null
   error?: boolean | null
+  /** Alias for `error`; ignored when `error` is also set. */
+  throwOnError?: boolean | null
   verify?: VerifyOptions | boolean | null
   logger?: LoggerLike | null
+  userAgent?: string | null
   /** Per-request trace writer: undefined falls back to the per-thread writer
    *  installed via @nxtedition/trace's installTrace(), null disables tracing
    *  for this request. */

--- a/type-tests/request-runtime-options.ts
+++ b/type-tests/request-runtime-options.ts
@@ -1,0 +1,9 @@
+import type { RequestOptions } from '../lib/index.js'
+
+const options: RequestOptions = {
+  headerTimeout: 1000,
+  throwOnError: false,
+  userAgent: 'type-test/1.0',
+}
+
+void options


### PR DESCRIPTION
## What changed

- Declare `headerTimeout`, `throwOnError`, and `userAgent` request options already handled by the runtime wrapper.
- Add a strict options fixture and shared public-declaration test runner.

## Why

All three options are read and applied at runtime, but TypeScript consumers were told they were invalid properties.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks