### PR TITLE
fix(types): declare supported origin forms

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,6 +23,7 @@ export interface BodyReadable extends Readable {
 export type URLLike = string | URL | URLObject
 export type HeaderInput =
   Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
+export type OriginLike = URLLike | readonly URLLike[]
 
 export interface Dispatcher {
   dispatch(opts: object, handler: DispatchHandler): void
@@ -75,7 +76,7 @@ export type BodyFactory = (opts: {
 
 export interface DispatchOptions {
   id?: string | null
-  origin?: string | null
+  origin?: OriginLike | null
   path?: string | null
   method?: string | null
   body?: Readable | Uint8Array | string | BodyFactory | null
@@ -134,7 +135,7 @@ export type RetryFn = (
 export type FollowFn = (location: string, count: number, opts: DispatchOptions) => boolean
 
 export type LookupFn = (
-  origin: string | URLLike | Array<string | URLLike>,
+  origin: OriginLike,
   opts: { signal?: AbortSignal },
   callback: (err: Error | null, address: string | null) => void,
 ) => void | Promise<string>

--- a/type-tests/origin-like.ts
+++ b/type-tests/origin-like.ts
@@ -1,0 +1,18 @@
+import type { DispatchOptions } from '../lib/index.js'
+
+const options: DispatchOptions = {
+  origin: [
+    'http://one.example.test',
+    new URL('http://two.example.test'),
+    { protocol: 'http:', hostname: 'three.example.test' },
+  ],
+}
+
+const readonlyOrigins = [
+  'http://one.example.test',
+  new URL('http://two.example.test'),
+  { protocol: 'http:', hostname: 'three.example.test' },
+] as const
+const readonlyOptions: DispatchOptions = { origin: readonlyOrigins }
+
+void [options, readonlyOptions]


### PR DESCRIPTION
## What changed

- Introduce `OriginLike` for strings, URLs, URL-shaped objects, and arrays of those values.
- Use it for dispatch origins and lookup callbacks.
- Add a strict multi-form fixture and shared public-declaration test runner.

## Why

`defaultLookup` explicitly normalizes and selects from these runtime forms, but `DispatchOptions.origin` only permitted strings.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks