### PR TITLE
fix(types): declare EventEmitter signals

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'node:stream'
+import type { EventEmitter } from 'node:events'
 import type { Priority } from '@nxtedition/scheduler'
 
 export interface URLObject {
@@ -24,6 +25,7 @@ export type URLLike = string | URL | URLObject
 export type HeaderInput =
   Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
 export type OriginLike = URLLike | readonly URLLike[]
+export type RequestSignal = AbortSignal | EventEmitter
 
 export interface Dispatcher {
   dispatch(opts: object, handler: DispatchHandler): void
@@ -82,7 +84,7 @@ export interface DispatchOptions {
   body?: Readable | Uint8Array | string | BodyFactory | null
   query?: Record<string, unknown> | null
   headers?: HeaderInput | null
-  signal?: AbortSignal | null
+  signal?: RequestSignal | null
   reset?: boolean | null
   blocking?: boolean | null
   timeout?: number | { headers?: number | null; body?: number | null } | null
@@ -136,7 +138,7 @@ export type FollowFn = (location: string, count: number, opts: DispatchOptions) 
 
 export type LookupFn = (
   origin: OriginLike,
-  opts: { signal?: AbortSignal },
+  opts: { signal?: RequestSignal },
   callback: (err: Error | null, address: string | null) => void,
 ) => void | Promise<string>
 

--- a/type-tests/event-emitter-signal.ts
+++ b/type-tests/event-emitter-signal.ts
@@ -1,0 +1,6 @@
+import { EventEmitter } from 'node:events'
+import type { RequestOptions } from '../lib/index.js'
+
+const options: RequestOptions = { signal: new EventEmitter() }
+
+void options


### PR DESCRIPTION
## What changed

- Add the EventEmitter-style signal form supported by RequestHandler and retry waits.
- Propagate it through dispatch and lookup option declarations.
- Add a strict fixture and shared public-declaration test runner.

## Why

The runtime deliberately supports both EventTarget AbortSignals and EventEmitter signals, but TypeScript consumers could only pass AbortSignal.

## Validation

- strict `tsc --noEmit` public type fixture
- ESLint and staged-file Prettier hooks