### PR TITLE
fix(dns): validate resolver results

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -132,6 +132,49 @@ export default () => (dispatch) => {
           settled = true
           promises.delete(hostname)
 
+          let val = null
+          let shouldCacheNegative = true
+          if (!err) {
+            try {
+              if (!Array.isArray(records)) {
+                throw new TypeError('invalid DNS lookup result: expected an array of records')
+              }
+              if (records.length === 0) {
+                throw Object.assign(new Error(`No DNS records found for ${hostname}`), {
+                  code: 'ENOTFOUND',
+                  syscall: 'getaddrinfo',
+                  hostname,
+                })
+              }
+
+              const now = getFastNow()
+              val = records.map((record) => {
+                const address = record?.address
+                if (typeof address !== 'string' || net.isIP(address) === 0) {
+                  throw new TypeError('invalid DNS lookup result: expected IP address records')
+                }
+                return {
+                  address,
+                  expires: now + (ttl ?? 1e3),
+                  pending: 0,
+                  errored: 0,
+                  counter: 0,
+                }
+              })
+            } catch (cause) {
+              // A custom resolver invokes this callback outside the Promise
+              // executor when it resolves asynchronously. Contain malformed
+              // results here so they become ordinary lookup failures instead
+              // of uncaught exceptions, and do not cache unusable addresses.
+              // Empty successful results intentionally become ENOTFOUND and
+              // remain negative-cacheable; locally detected shape/type errors
+              // may be fixed by the resolver on its next call and must not
+              // poison that recovery for the full negative TTL.
+              err = cause
+              shouldCacheNegative = cause?.code === 'ENOTFOUND'
+            }
+          }
+
           if (err) {
             // Negative cache: remember the failure for a short while so a hot
             // caller of an unresolvable host fails fast instead of issuing a
@@ -141,21 +184,14 @@ export default () => (dispatch) => {
             // definition, but the same small TTL applies — the window only
             // needs to absorb a retry burst, and a short TTL keeps recovery
             // fast either way.
-            negatives.set(hostname, { err, expires: getFastNow() + negativeTTL })
+            if (shouldCacheNegative) {
+              negatives.set(hostname, { err, expires: getFastNow() + negativeTTL })
+            } else {
+              negatives.delete(hostname)
+            }
             resolve([err, null])
           } else {
             negatives.delete(hostname)
-            const now = getFastNow()
-            const val = records.map(({ address }) => {
-              return {
-                address,
-                expires: now + (ttl ?? 1e3),
-                pending: 0,
-                errored: 0,
-                counter: 0,
-              }
-            })
-
             cache.set(hostname, val)
 
             resolve([null, val])

--- a/test/dns-resolver-result-validation.js
+++ b/test/dns-resolver-result-validation.js
@@ -1,0 +1,97 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function request(dispatch, lookup) {
+  return new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://resolver-results.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        dns: { lookup, negativeTTL: 60_000 },
+      },
+      {
+        onConnect() {},
+        onHeaders(statusCode) {
+          resolve(statusCode)
+          return true
+        },
+        onData() {},
+        onComplete() {},
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('dns: malformed asynchronous resolver results reject instead of escaping callback', async (t) => {
+  const lookup = (hostname, options, callback) => {
+    setImmediate(callback, null, null)
+  }
+  const dispatch = interceptors.dns()(() => {
+    t.fail('transport must not receive a malformed resolver result')
+  })
+
+  const err = await request(dispatch, lookup).then(
+    () => null,
+    (err) => err,
+  )
+
+  t.equal(err?.message, 'invalid DNS lookup result: expected an array of records')
+  t.type(err?.cause, TypeError)
+})
+
+test('dns: a non-IP resolver record is rejected before dispatch', async (t) => {
+  const lookup = (hostname, options, callback) => {
+    setImmediate(callback, null, [{ address: 'fallback-dns.test', family: 4 }])
+  }
+  const dispatch = interceptors.dns()(() => {
+    t.fail('an invalid address must not be passed to the transport as a hostname')
+  })
+
+  const err = await request(dispatch, lookup).then(
+    () => null,
+    (err) => err,
+  )
+
+  t.equal(err?.message, 'invalid DNS lookup result: expected IP address records')
+  t.type(err?.cause, TypeError)
+})
+
+test('dns: malformed resolver output is not negative-cached', async (t) => {
+  let calls = 0
+  const lookup = (hostname, options, callback) => {
+    calls++
+    setImmediate(callback, null, calls === 1 ? null : [{ address: '127.0.0.1', family: 4 }])
+  }
+  const dispatch = interceptors.dns()((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+
+  await t.rejects(request(dispatch, lookup), /invalid DNS lookup result/)
+  t.equal(await request(dispatch, lookup), 200, 'a corrected result is accepted immediately')
+  t.equal(calls, 2, 'validation failures do not create a negative-cache entry')
+})
+
+test('dns: an empty successful result is negative-cached', async (t) => {
+  let calls = 0
+  const lookup = (hostname, options, callback) => {
+    calls++
+    setImmediate(callback, null, [])
+  }
+  const dispatch = interceptors.dns()(() => {
+    t.fail('transport must not receive an empty resolver result')
+  })
+
+  const expected = {
+    code: 'ENOTFOUND',
+    syscall: 'getaddrinfo',
+    hostname: 'resolver-results.test',
+  }
+  await t.rejects(request(dispatch, lookup), expected)
+  await t.rejects(request(dispatch, lookup), expected)
+  t.equal(calls, 1, 'the empty result does not cause a hot lookup loop')
+})


### PR DESCRIPTION
## What changed

- Require a non-empty array of valid IP-address records from custom resolvers.
- Contain malformed asynchronous callback values and route them through normal lookup errors.
- Negative-cache empty successful results to prevent hot loops, while leaving local shape/type validation failures immediately recoverable.
- Add malformed, non-IP, recovery, and empty-result regressions.

## Why

Callback-side processing happened outside the Promise executor for asynchronous resolvers. Malformed records could throw uncaught, non-IP strings could trigger unintended fallback DNS, and empty successful results caused repeated lookups. Caching locally-detected malformed output would also hide a corrected result for the full negative TTL.

## Validation

- result-validation and cross-branch recovery regressions
- DNS advanced, negative-cache, and trace suites
- ESLint, Prettier, and diff checks