### PR TITLE
fix(dns): clear synchronous resolver failures

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -128,7 +128,14 @@ export default () => (dispatch) => {
       // Track settlement so an already-settled promise is never registered.
       let settled = false
       promise = new Promise((resolve) => {
-        lookup(hostname, { all: true }, (err, records) => {
+        const onLookup = (err, records) => {
+          // A resolver is required to invoke its callback once, but custom
+          // implementations can accidentally callback and then throw (or
+          // callback twice). Ignore every terminal signal after the first so
+          // it cannot overwrite a successful cache entry with a later error.
+          if (settled) {
+            return
+          }
           settled = true
           promises.delete(hostname)
 
@@ -160,7 +167,26 @@ export default () => (dispatch) => {
 
             resolve([null, val])
           }
-        })
+        }
+
+        try {
+          lookup(hostname, { all: true }, onLookup)
+        } catch (err) {
+          if (settled) {
+            // The resolver already called back and callback-side processing
+            // threw (for example records.map on malformed synchronous data).
+            // Preserve resolve()'s [err, val] contract so refresh callers never
+            // receive a bare rejection and request callers use the ordinary
+            // lookup-failure path.
+            resolve([err, null])
+            return
+          }
+          // Let the normal callback path remove in-flight state and create the
+          // short negative-cache entry. Allowing the Promise constructor to
+          // turn this into a bare rejection would leave that rejected promise
+          // registered below forever.
+          onLookup(err)
+        }
       })
       if (!settled) {
         promises.set(hostname, promise)

--- a/test/dns-resolver-errors.js
+++ b/test/dns-resolver-errors.js
@@ -1,0 +1,73 @@
+import { test } from 'tap'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { interceptors } from '../lib/index.js'
+
+function request(dispatch, dns) {
+  return new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://resolver-errors.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        dns,
+      },
+      {
+        onConnect() {},
+        onHeaders(statusCode) {
+          resolve(statusCode)
+          return true
+        },
+        onData() {},
+        onComplete() {},
+        onError: reject,
+      },
+    )
+  })
+}
+
+function successfulDispatch(opts, handler) {
+  handler.onConnect(() => {})
+  handler.onHeaders(200, {}, () => {})
+  handler.onComplete([])
+}
+
+test('dns: a synchronously throwing resolver is cleared and can recover', async (t) => {
+  let calls = 0
+  const lookup = (hostname, options, callback) => {
+    calls++
+    if (calls === 1) {
+      throw new Error('resolver exploded')
+    }
+    callback(null, [{ address: '127.0.0.1', family: 4 }])
+  }
+
+  const dispatch = interceptors.dns()(successfulDispatch)
+  const dns = { lookup, negativeTTL: 0 }
+
+  await t.rejects(request(dispatch, dns), /resolver exploded/)
+
+  // getFastNow() advances once per second. Wait for a tick so the zero-length
+  // negative-cache entry is expired before checking that resolution retries.
+  await sleep(1500)
+
+  t.equal(await request(dispatch, dns), 200)
+  t.equal(calls, 2, 'the rejected in-flight promise was not retained forever')
+})
+
+test('dns: a synchronous callback-processing throw rejects and does not stick', async (t) => {
+  let calls = 0
+  const lookup = (hostname, options, callback) => {
+    calls++
+    callback(null, calls === 1 ? null : [{ address: '127.0.0.1', family: 4 }])
+  }
+  const dispatch = interceptors.dns()(successfulDispatch)
+
+  await t.rejects(
+    request(dispatch, { lookup }),
+    /map|invalid DNS lookup result/,
+    'malformed callback data rejects without retaining the settled lookup',
+  )
+  t.equal(await request(dispatch, { lookup }), 200)
+  t.equal(calls, 2, 'the callback-side exception was not turned into a pending promise')
+})


### PR DESCRIPTION
## What changed

- Route synchronous custom-resolver throws through the normal lookup failure path.
- Keep first-terminal semantics for duplicate callbacks/callback-then-throw implementations.
- Avoid retaining rejected or pending in-flight entries after callback-side failures.
- Add recovery regressions.

## Why

A bare throw inside the resolver's Promise executor produced a rejected promise that was then stored in the in-flight map forever. Every future lookup for that host reused the same failure and could never recover.

## Validation

- new resolver-error regressions
- DNS advanced, negative-cache, and trace suites (111 assertions)
- ESLint, Prettier, and diff checks