### PR TITLE
fix(dns): isolate state by resolver

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -88,9 +88,32 @@ const CONNECTION_ERROR_CODES = new Set([
 ])
 
 export default () => (dispatch) => {
-  const cache = new Map()
-  const negatives = new Map()
-  const promises = new Map()
+  // DNS options are per request, including a custom resolver. Keep every
+  // resolver's positive, negative and in-flight state isolated: service
+  // discovery clients commonly use the same logical hostname with different
+  // resolvers, and an answer (or failure) from one must never satisfy another.
+  // WeakMap also lets short-lived resolver functions and their cache state be
+  // collected together.
+  const resolverStates = new WeakMap()
+  const resolverStateRefs = new Set()
+  const resolverStateFinalizer = new FinalizationRegistry((ref) => resolverStateRefs.delete(ref))
+  let lastSweep = 0
+
+  function getResolverState(lookup) {
+    let state = resolverStates.get(lookup)
+    if (state == null) {
+      state = {
+        cache: new Map(),
+        negatives: new Map(),
+        promises: new Map(),
+      }
+      resolverStates.set(lookup, state)
+      const ref = new WeakRef(state)
+      resolverStateRefs.add(ref)
+      resolverStateFinalizer.register(state, ref, ref)
+    }
+    return state
+  }
 
   // The `cache` Map is otherwise only ever written, never trimmed, so a process
   // touching many distinct hostnames over its lifetime would leak entries that
@@ -99,25 +122,42 @@ export default () => (dispatch) => {
   // Negative entries are swept on the same cadence (they are also deleted
   // eagerly on the next successful lookup / overwritten on the next failure,
   // so the sweep only matters for hostnames that are never touched again).
-  let lastSweep = 0
+  function sweepState(now, state) {
+    for (const [hostname, records] of state.cache) {
+      if (records.every((x) => x.expires < now && x.pending === 0)) {
+        state.cache.delete(hostname)
+      }
+    }
+    for (const [hostname, negative] of state.negatives) {
+      if (negative.expires < now) {
+        state.negatives.delete(hostname)
+      }
+    }
+  }
+
   function sweep(now) {
     if (now - lastSweep < SWEEP_INTERVAL) {
       return
     }
     lastSweep = now
-    for (const [hostname, records] of cache) {
-      if (records.every((x) => x.expires < now && x.pending === 0)) {
-        cache.delete(hostname)
-      }
-    }
-    for (const [hostname, negative] of negatives) {
-      if (negative.expires < now) {
-        negatives.delete(hostname)
+
+    // Any request can clean every live resolver state, so a resolver that was
+    // used once cannot pin expired hostnames forever. Weak references preserve
+    // the WeakMap's lifetime semantics; dead refs are removed both here and by
+    // the finalizer, keeping the iterable registry bounded.
+    for (const ref of resolverStateRefs) {
+      const state = ref.deref()
+      if (state == null) {
+        resolverStateRefs.delete(ref)
+        resolverStateFinalizer.unregister(ref)
+      } else {
+        sweepState(now, state)
       }
     }
   }
 
-  function resolve(hostname, { ttl, negativeTTL, lookup }) {
+  function resolve(hostname, { ttl, negativeTTL, lookup, state }) {
+    const { cache, negatives, promises } = state
     let promise = promises.get(hostname)
     if (!promise) {
       // A synchronous lookup callback (custom resolvers answering from a local
@@ -178,6 +218,9 @@ export default () => (dispatch) => {
       const ttl = opts.dns.ttl ?? 2e3
       const negativeTTL = opts.dns.negativeTTL ?? 1e3
       const lookup = opts.dns.lookup ?? dns.lookup
+      if (typeof lookup !== 'function') {
+        throw new TypeError('opts.dns.lookup must be a function')
+      }
       const url = new URL(opts.path ?? '', opts.origin)
       const balance = opts.dns.balance
 
@@ -187,6 +230,8 @@ export default () => (dispatch) => {
         return dispatch(opts, handler)
       }
 
+      const state = getResolverState(lookup)
+      const { cache, negatives, promises } = state
       const now = getFastNow()
 
       sweep(now)
@@ -227,7 +272,7 @@ export default () => (dispatch) => {
         // from the logical opts, before the origin is rewritten to the IP.
         const write = traceWrite(opts.trace)
         const started = write !== null ? performance.now() : 0
-        const [err, val] = await resolve(hostname, { ttl, negativeTTL, lookup })
+        const [err, val] = await resolve(hostname, { ttl, negativeTTL, lookup, state })
         if (write !== null) {
           traceSafe(
             write,
@@ -298,7 +343,7 @@ export default () => (dispatch) => {
         // itself, not a per-request wait (nothing awaits a refresh).
         const write = traceWrite(opts.trace)
         const initiated = write !== null && !promises.has(hostname)
-        const promise = resolve(hostname, { ttl, negativeTTL, lookup })
+        const promise = resolve(hostname, { ttl, negativeTTL, lookup, state })
         if (initiated) {
           // Side-observe a copy of the chain: resolve() never rejects (it
           // settles with an [err, val] tuple) and .then returns a new promise,

--- a/test/dns-resolver-isolation.js
+++ b/test/dns-resolver-isolation.js
@@ -1,0 +1,113 @@
+import { test } from 'tap'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { interceptors } from '../lib/index.js'
+
+function request(dispatch, lookup) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(
+      {
+        origin: 'http://shared-resolver.test:8080',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        dns: { lookup, ttl: 60_000, negativeTTL: 60_000 },
+      },
+      {
+        onConnect() {},
+        onHeaders(value) {
+          statusCode = value
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(statusCode)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+function makeDispatch(origins) {
+  return interceptors.dns()((opts, handler) => {
+    origins.push(opts.origin)
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+}
+
+function resolver(address, onCall = () => {}) {
+  return (hostname, options, callback) => {
+    onCall()
+    callback(null, [{ address, family: 4 }])
+  }
+}
+
+test('dns: positive cache entries are isolated by custom resolver', async (t) => {
+  const origins = []
+  const dispatch = makeDispatch(origins)
+  let callsA = 0
+  let callsB = 0
+
+  await request(
+    dispatch,
+    resolver('192.0.2.10', () => callsA++),
+  )
+  await request(
+    dispatch,
+    resolver('192.0.2.20', () => callsB++),
+  )
+
+  t.same(origins, ['http://192.0.2.10:8080', 'http://192.0.2.20:8080'])
+  t.equal(callsA, 1)
+  t.equal(callsB, 1, 'the second resolver was not bypassed by the first resolver cache')
+})
+
+test('dns: negative cache entries are isolated by custom resolver', async (t) => {
+  const origins = []
+  const dispatch = makeDispatch(origins)
+  const failing = (hostname, options, callback) => {
+    callback(Object.assign(new Error('private resolver miss'), { code: 'ENOTFOUND' }))
+  }
+  let successfulCalls = 0
+  const successful = resolver('192.0.2.30', () => successfulCalls++)
+
+  await t.rejects(request(dispatch, failing), { code: 'ENOTFOUND' })
+  t.equal(await request(dispatch, successful), 200)
+
+  t.same(origins, ['http://192.0.2.30:8080'])
+  t.equal(successfulCalls, 1, 'one resolver failure did not poison another resolver')
+})
+
+test('dns: an invalid custom resolver reports an actionable error', async (t) => {
+  const dispatch = makeDispatch([])
+
+  await t.rejects(request(dispatch, 0), {
+    name: 'TypeError',
+    message: 'opts.dns.lookup must be a function',
+  })
+})
+
+test('dns: in-flight lookups are isolated by custom resolver', async (t) => {
+  const origins = []
+  const dispatch = makeDispatch(origins)
+  let releaseFirst
+  const first = (hostname, options, callback) => {
+    releaseFirst = () => callback(null, [{ address: '192.0.2.40', family: 4 }])
+  }
+
+  const firstRequest = request(dispatch, first)
+  const secondRequest = request(dispatch, resolver('192.0.2.50'))
+  const outcome = await Promise.race([
+    secondRequest.then(() => 'resolved'),
+    sleep(1000, undefined, { ref: false }).then(() => 'blocked'),
+  ])
+
+  releaseFirst()
+  await Promise.all([firstRequest, secondRequest])
+
+  t.equal(outcome, 'resolved', 'the second resolver did not join the first resolver lookup')
+  t.same(origins, ['http://192.0.2.50:8080', 'http://192.0.2.40:8080'])
+})


### PR DESCRIPTION
## What changed

- Scope positive, negative, in-flight, and sweep state by custom resolver identity using a WeakMap.
- Add coverage for positive-cache contamination, negative poisoning, and in-flight cross-joining.

## Why

DNS options are per request, but all state was keyed only by hostname. Two clients resolving the same logical host through different service-discovery functions could receive each other's answers or failures.

## Validation

- new isolation regressions
- DNS, negative-cache, and trace suites (114 assertions)
- ESLint, Prettier, and diff checks