### PR TITLE
fix(dns): handle async dispatch failures

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -272,9 +272,12 @@ export default () => (dispatch) => {
   }
 
   return async (opts, handler) => {
+    // Keep terminal delivery once-only across both synchronous throws and
+    // rejected DispatchFn promises, including the DNS/IP bypass paths.
+    const wrapped = new DecoratorHandler(handler)
     try {
       if (!opts.dns || !opts.origin) {
-        return dispatch(opts, handler)
+        return await dispatch(opts, wrapped)
       }
 
       const ttl = opts.dns.ttl ?? 2e3
@@ -289,7 +292,7 @@ export default () => (dispatch) => {
       const { host, hostname, pathname } = url
 
       if (net.isIP(hostname)) {
-        return dispatch(opts, handler)
+        return await dispatch(opts, wrapped)
       }
 
       const state = getResolverState(lookup)
@@ -498,20 +501,24 @@ export default () => (dispatch) => {
         if (typeof headers.host !== 'string' || !headers.host) {
           headers.host = host
         }
-        return dispatch(
+
+        // DispatchFn permits a Promise return. Await it inside the guarded
+        // try/catch so an asynchronous downstream failure settles the record
+        // and reaches onError; request() ignores the dispatch return value.
+        return await dispatch(
           {
             ...opts,
             origin: url.origin,
             headers,
           },
-          new Handler(handler, onSettle),
+          new Handler(wrapped, onSettle),
         )
       } catch (err) {
         onSettle(err)
         throw err
       }
     } catch (err) {
-      handler.onError(err)
+      wrapped.onError(err)
     }
   }
 }

--- a/test/dns-async-dispatch-error.js
+++ b/test/dns-async-dispatch-error.js
@@ -1,0 +1,73 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function request(dispatch, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const errors = []
+    const returned = dispatch(
+      {
+        origin: 'http://async-dispatch.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        dns: {
+          lookup(hostname, options, callback) {
+            callback(null, [{ address: '127.0.0.1', family: 4 }])
+          },
+        },
+        ...opts,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve({ errors })
+        },
+        onError(err) {
+          errors.push(err)
+          resolve({ errors })
+        },
+      },
+    )
+    Promise.resolve(returned).catch(reject)
+  })
+}
+
+test('dns: an asynchronous downstream rejection is delivered via onError', async (t) => {
+  const failure = new Error('asynchronous dispatch failure')
+  const dispatch = interceptors.dns()(async () => {
+    await Promise.resolve()
+    throw failure
+  })
+
+  const { errors } = await request(dispatch)
+
+  t.same(errors, [failure])
+})
+
+test('dns: a downstream onError followed by a synchronous throw stays once-only', async (t) => {
+  const reported = new Error('reported failure')
+  const escaped = new Error('escaped failure')
+  const dispatch = interceptors.dns()((opts, handler) => {
+    handler.onError(reported)
+    throw escaped
+  })
+
+  const { errors } = await request(dispatch)
+
+  t.same(errors, [reported])
+})
+
+test('dns: an asynchronous rejection is handled on the IP bypass path', async (t) => {
+  const failure = new Error('IP dispatch failure')
+  const dispatch = interceptors.dns()(async () => {
+    throw failure
+  })
+
+  const { errors } = await request(dispatch, { origin: 'http://127.0.0.1' })
+
+  t.same(errors, [failure])
+})


### PR DESCRIPTION
## What changed

- Await Promise-returning inner dispatches on active and bypass paths.
- Once-guard terminal delivery across report-then-throw/reject behavior.
- Settle selected-record accounting before delivering asynchronous failures.
- Add active, IP-bypass, and exactly-once regressions.

## Why

`DispatchFn` permits Promise returns, but DNS only caught synchronous throws. Rejections bypassed `onError`, leaked pending accounting, and could leave public requests hanging.

## Validation

- new async-dispatch regressions
- DNS advanced, misc, and trace suites (88 assertions)
- ESLint, Prettier, and diff checks