### PR TITLE
fix(dns): normalize host header casing

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -272,9 +272,12 @@ export default () => (dispatch) => {
   }
 
   return async (opts, handler) => {
+    // Keep terminal delivery once-only across both synchronous throws and
+    // rejected DispatchFn promises, including the DNS/IP bypass paths.
+    const wrapped = new DecoratorHandler(handler)
     try {
       if (!opts.dns || !opts.origin) {
-        return dispatch(opts, handler)
+        return await dispatch(opts, wrapped)
       }
 
       const ttl = opts.dns.ttl ?? 2e3
@@ -289,7 +292,7 @@ export default () => (dispatch) => {
       const { host, hostname, pathname } = url
 
       if (net.isIP(hostname)) {
-        return dispatch(opts, handler)
+        return await dispatch(opts, wrapped)
       }
 
       const state = getResolverState(lookup)
@@ -498,20 +501,24 @@ export default () => (dispatch) => {
         if (typeof headers.host !== 'string' || !headers.host) {
           headers.host = host
         }
-        return dispatch(
+
+        // DispatchFn permits a Promise return. Await it inside the guarded
+        // try/catch so an asynchronous downstream failure settles the record
+        // and reaches onError; request() ignores the dispatch return value.
+        return await dispatch(
           {
             ...opts,
             origin: url.origin,
             headers,
           },
-          new Handler(handler, onSettle),
+          new Handler(wrapped, onSettle),
         )
       } catch (err) {
         onSettle(err)
         throw err
       }
     } catch (err) {
-      handler.onError(err)
+      wrapped.onError(err)
     }
   }
 }

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import * as dns from 'node:dns'
-import { DecoratorHandler, getFastNow } from '../utils.js'
+import { DecoratorHandler, getFastNow, parseHeaders } from '../utils.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 import xxhash from 'xxhash-wasm'
 
@@ -484,20 +484,25 @@ export default () => (dispatch) => {
       try {
         // origin is rewritten to the resolved IP, so pin the host header to
         // the logical hostname — but never clobber an explicit user-supplied
-        // host (virtual hosting). Lowercase lookup matches the pipeline
-        // invariant (parseHeaders) and priority.js, which reads the same key.
+        // host (virtual hosting). Normalize here too because the exported DNS
+        // interceptor can be composed standalone, before the default pipeline's
+        // parseHeaders step; field names remain case-insensitive in that mode.
         // Host is a singular header, so only a single non-empty string value
         // is preserved (same rule as priority.js) — an array (duplicate Host
         // field-lines) or an empty string falls back to the origin-derived
         // host.
+        // parseHeaders owns the normalization fast path. Internally branded
+        // snapshots are reused in O(1), while standalone/untrusted inputs are
+        // copied and normalized before we mutate the result below.
+        const headers = parseHeaders(opts.headers)
+        if (typeof headers.host !== 'string' || !headers.host) {
+          headers.host = host
+        }
         return dispatch(
           {
             ...opts,
             origin: url.origin,
-            headers: {
-              ...opts.headers,
-              host: (typeof opts.headers?.host === 'string' && opts.headers.host) || host,
-            },
+            headers,
           },
           new Handler(handler, onSettle),
         )

--- a/test/dns-async-dispatch-error.js
+++ b/test/dns-async-dispatch-error.js
@@ -1,0 +1,73 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function request(dispatch, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const errors = []
+    const returned = dispatch(
+      {
+        origin: 'http://async-dispatch.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        dns: {
+          lookup(hostname, options, callback) {
+            callback(null, [{ address: '127.0.0.1', family: 4 }])
+          },
+        },
+        ...opts,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve({ errors })
+        },
+        onError(err) {
+          errors.push(err)
+          resolve({ errors })
+        },
+      },
+    )
+    Promise.resolve(returned).catch(reject)
+  })
+}
+
+test('dns: an asynchronous downstream rejection is delivered via onError', async (t) => {
+  const failure = new Error('asynchronous dispatch failure')
+  const dispatch = interceptors.dns()(async () => {
+    await Promise.resolve()
+    throw failure
+  })
+
+  const { errors } = await request(dispatch)
+
+  t.same(errors, [failure])
+})
+
+test('dns: a downstream onError followed by a synchronous throw stays once-only', async (t) => {
+  const reported = new Error('reported failure')
+  const escaped = new Error('escaped failure')
+  const dispatch = interceptors.dns()((opts, handler) => {
+    handler.onError(reported)
+    throw escaped
+  })
+
+  const { errors } = await request(dispatch)
+
+  t.same(errors, [reported])
+})
+
+test('dns: an asynchronous rejection is handled on the IP bypass path', async (t) => {
+  const failure = new Error('IP dispatch failure')
+  const dispatch = interceptors.dns()(async () => {
+    throw failure
+  })
+
+  const { errors } = await request(dispatch, { origin: 'http://127.0.0.1' })
+
+  t.same(errors, [failure])
+})

--- a/test/dns-host-header-case.js
+++ b/test/dns-host-header-case.js
@@ -1,0 +1,67 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+import { createNormalizedHeaders } from '../lib/utils.js'
+
+function resolvedHeaders(headers) {
+  let captured
+  const dispatch = interceptors.dns()((opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+
+  return new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://host-case.test:8080',
+        path: '/',
+        method: 'GET',
+        headers,
+        dns: {
+          lookup(hostname, options, callback) {
+            callback(null, [{ address: '127.0.0.1', family: 4 }])
+          },
+        },
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(captured)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('dns: a mixed-case Host override is preserved without duplication', async (t) => {
+  const headers = await resolvedHeaders({ Host: 'virtual.example' })
+
+  t.same(headers, { host: 'virtual.example' })
+})
+
+test('dns: an untrusted normalized-looking object is copied', async (t) => {
+  const input = { host: 'virtual.example', 'x-test': 'value' }
+  const headers = await resolvedHeaders(input)
+
+  t.not(headers, input)
+  t.same(headers, input)
+})
+
+test('dns: an internally normalized snapshot takes the branded fast path', async (t) => {
+  const input = createNormalizedHeaders({ host: 'virtual.example', 'x-test': 'value' })
+  const headers = await resolvedHeaders(input)
+
+  t.equal(headers, input)
+})
+
+test('dns: case-variant duplicate Host fields fall back to the logical origin', async (t) => {
+  const headers = await resolvedHeaders({ Host: 'one.example', host: 'two.example' })
+
+  t.same(headers, { host: 'host-case.test:8080' })
+})


### PR DESCRIPTION
## What changed

- Normalize standalone DNS interceptor headers before selecting the virtual Host override.
- Preserve one mixed-case Host value without duplication.
- Fail safely to the logical origin when case-variant duplicate Host fields exist.

## Why

The default pipeline lowercases headers earlier, but the exported interceptor can be composed standalone. In that mode a mixed-case Host was missed and duplicated/clobbered when DNS rewrote the origin.

## Validation

- new Host casing regressions
- DNS advanced and prior review suites (38 assertions)
- ESLint, Prettier, and diff checks