### PR TITLE
fix(lookup): handle async dispatch failures

### DIFF
--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -79,7 +79,12 @@ export default () => (dispatch) => async (opts, handler) => {
     }
 
     dispatched = true
-    return dispatch({ ...opts, origin }, wrapped)
+    // DispatchFn explicitly permits a Promise return. Await it inside this
+    // try/catch so an asynchronous downstream failure follows the same
+    // handler.onError path as a synchronous throw; request() intentionally
+    // ignores the dispatch return value and would otherwise hang while the
+    // rejection becomes unhandled.
+    return await dispatch({ ...opts, origin }, wrapped)
   } catch (err) {
     // The try also covers the inner dispatch call — a sync throw escaping the
     // inner chain is not a lookup failure and must not be attributed to one.

--- a/test/lookup-async-dispatch-error.js
+++ b/test/lookup-async-dispatch-error.js
@@ -1,0 +1,57 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function handler(onError) {
+  return {
+    onConnect() {},
+    onHeaders() {
+      return true
+    },
+    onData() {},
+    onComplete() {},
+    onError,
+  }
+}
+
+const opts = {
+  origin: 'http://service.test',
+  path: '/',
+  method: 'GET',
+  headers: {},
+  lookup(origin, options, callback) {
+    callback(null, 'http://resolved.test')
+  },
+}
+
+test('lookup: an asynchronous downstream rejection is delivered via onError', async (t) => {
+  const failure = new Error('asynchronous dispatch failure')
+  const dispatch = interceptors.lookup()(async () => {
+    await Promise.resolve()
+    throw failure
+  })
+
+  const errors = []
+  await dispatch(
+    opts,
+    handler((err) => errors.push(err)),
+  )
+
+  t.same(errors, [failure])
+})
+
+test('lookup: a downstream onError followed by rejection stays once-only', async (t) => {
+  const reported = new Error('reported failure')
+  const escaped = new Error('escaped failure')
+  const dispatch = interceptors.lookup()(async (opts, wrapped) => {
+    wrapped.onError(reported)
+    throw escaped
+  })
+
+  const errors = []
+  await dispatch(
+    opts,
+    handler((err) => errors.push(err)),
+  )
+
+  t.same(errors, [reported])
+})


### PR DESCRIPTION
## What changed

- Await Promise-returning downstream dispatches inside lookup's guarded try/catch.
- Preserve once-only delivery when downstream reports an error and then rejects.
- Add focused rejection and exactly-once regressions.

## Why

Returning a promise from inside `try` does not catch its later rejection. Public request ignored that returned promise, so the request could hang with an unhandled rejection instead of receiving `onError`.

## Validation

- new async-dispatch regressions
- lookup and trace suites (35 assertions)
- ESLint, Prettier, and diff checks