### PR TITLE
fix(lookup): ignore callback return handles

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -135,7 +135,7 @@ export type LookupFn = (
   origin: string | URLLike | Array<string | URLLike>,
   opts: { signal?: AbortSignal },
   callback: (err: Error | null, address: string | null) => void,
-) => void | Promise<string>
+) => void | string | Promise<void | string>
 
 export interface ProxyOptions {
   httpVersion?: string

--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -69,9 +69,9 @@ export default () => (dispatch) => async (opts, handler) => {
         // like the async-callback shape's — only the sync callback path is
         // suppressed as noise.
         Promise.resolve(thenable).then((val) => {
-          // An async callback-style lookup returns Promise<void>. Its promise
-          // may settle before the callback fires, so only the Promise<string>
-          // shape may take control of the lookup result.
+          // An async callback-style lookup may return a thenable that fulfills
+          // with void before the callback fires, so only a string fulfillment
+          // may take control of the lookup result.
           if (typeof val === 'string') {
             resolvedAsync = true
             resolve(val)

--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -69,8 +69,13 @@ export default () => (dispatch) => async (opts, handler) => {
         // like the async-callback shape's — only the sync callback path is
         // suppressed as noise.
         Promise.resolve(thenable).then((val) => {
-          resolvedAsync = true
-          resolve(val)
+          // An async callback-style lookup returns Promise<void>. Its promise
+          // may settle before the callback fires, so only the Promise<string>
+          // shape may take control of the lookup result.
+          if (typeof val === 'string') {
+            resolvedAsync = true
+            resolve(val)
+          }
         }, reject)
       }
     })

--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -58,7 +58,12 @@ export default () => (dispatch) => async (opts, handler) => {
       })
       sync = false
 
-      if (thenable != null) {
+      if (typeof thenable === 'string') {
+        // Keep the established synchronous shorthand used by standalone
+        // compositions, but do not treat arbitrary callback return values
+        // (timer/request/cancellation handles) as resolved origins.
+        resolve(thenable)
+      } else if (typeof thenable?.then === 'function') {
         // A promise-returning lookup is always asynchronous (`.then` callbacks
         // never run on the current stack), so its success doc must be emitted
         // like the async-callback shape's — only the sync callback path is

--- a/test/lookup-callback-return-handle.js
+++ b/test/lookup-callback-return-handle.js
@@ -49,6 +49,17 @@ test('lookup: the synchronous string return shorthand remains supported', async 
   t.equal(await resolveOrigin(() => target), target)
 })
 
+test('lookup: a non-Promise thenable remains supported', async (t) => {
+  const target = 'http://thenable-result.test'
+  const thenable = {
+    then(resolve) {
+      setImmediate(resolve, target)
+    },
+  }
+
+  t.equal(await resolveOrigin(() => thenable), target)
+})
+
 test('lookup: an async callback lookup may return Promise<void>', async (t) => {
   const target = 'http://async-callback-result.test'
   const origin = await resolveOrigin(async (_value, _options, callback) => {
@@ -57,4 +68,24 @@ test('lookup: an async callback lookup may return Promise<void>', async (t) => {
   })
 
   t.equal(origin, target)
+})
+
+test('lookup: Promise<void> may settle before a delayed callback succeeds', async (t) => {
+  const target = 'http://delayed-callback-result.test'
+  const origin = await resolveOrigin(async (_value, _options, callback) => {
+    setImmediate(callback, null, target)
+  })
+
+  t.equal(origin, target)
+})
+
+test('lookup: Promise<void> may settle before a delayed callback fails', async (t) => {
+  const error = new Error('delayed lookup failure')
+
+  await t.rejects(
+    resolveOrigin(async (_value, _options, callback) => {
+      setImmediate(callback, error)
+    }),
+    error,
+  )
 })

--- a/test/lookup-callback-return-handle.js
+++ b/test/lookup-callback-return-handle.js
@@ -1,0 +1,60 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function resolveOrigin(lookup) {
+  let resolvedOrigin
+  const dispatch = interceptors.lookup()((opts, handler) => {
+    resolvedOrigin = opts.origin
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+
+  return new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://service.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        lookup,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(resolvedOrigin)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('lookup: an incidental callback return handle is not used as the origin', async (t) => {
+  const target = 'http://callback-result.test'
+  const origin = await resolveOrigin((_value, _options, callback) => {
+    return setImmediate(callback, null, target)
+  })
+
+  t.equal(origin, target)
+})
+
+test('lookup: the synchronous string return shorthand remains supported', async (t) => {
+  const target = 'http://synchronous-result.test'
+
+  t.equal(await resolveOrigin(() => target), target)
+})
+
+test('lookup: an async callback lookup may return Promise<void>', async (t) => {
+  const target = 'http://async-callback-result.test'
+  const origin = await resolveOrigin(async (_value, _options, callback) => {
+    await Promise.resolve()
+    callback(null, target)
+  })
+
+  t.equal(origin, target)
+})


### PR DESCRIPTION
## What changed

- Treat only strings as synchronous lookup shorthand and only true thenables as promise results.
- Ignore timer/request/cancellation handles returned by callback-style lookup functions.
- Align `LookupFn` with sync strings and callback-style `Promise<void>`.
- Add Immediate-handle, sync-string, and async-callback regressions.

## Why

Every non-null callback return was wrapped with `Promise.resolve`, so an incidental handle could win the callback race and be dispatched as the resolved origin.

## Validation

- new callback-return regressions
- lookup and trace suites (36 assertions)
- ESLint, Prettier, and diff checks