### PR TITLE
fix(proxy): handle case-variant duplicate fields

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -150,6 +150,20 @@ export function isHopByHop(key) {
   }
 }
 
+function joinNonEmptyHeaderValues(value) {
+  if (!Array.isArray(value)) {
+    return value
+  }
+
+  let joined = ''
+  for (const part of value) {
+    if (part !== '') {
+      joined = joined ? `${joined}, ${part}` : part
+    }
+  }
+  return joined
+}
+
 // Removes hop-by-hop and pseudo headers.
 // Updates via and forwarded headers.
 // Only hop-by-hop headers may be set using the Connection general header.
@@ -178,11 +192,15 @@ export function isHopByHop(key) {
  */
 function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, fn, acc) {
   let via = ''
+  let viaSeen = false
   let forwarded = ''
+  let forwardedSeen = false
   let host = ''
+  let hostSeen = false
   let authority = ''
   /** @type {string | string[]} */
   let connection = ''
+  let connectionSeen = false
 
   // Iterate via Object.keys (computed once and reused by both passes) rather
   // than Object.entries: the latter allocates an outer array plus one
@@ -191,12 +209,13 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   // array we reuse, cutting per-call allocation by ~4-6x.
   const keys = Object.keys(headers)
 
-  // Object keys are unique, so each special is seen at most once; a repeated
-  // field-line instead surfaces as an array value (parseHeaders collects them).
-  // RFC 9110 §5.3 only permits repeats for list-valued fields (ABNF `#`), where
-  // the parts are semantically one comma-separated value — those we combine.
-  // Singular fields with more than one value are a protocol error — those we
-  // reject.
+  // A repeated field-line normally surfaces as an array value (parseHeaders
+  // collects them). Standalone interceptor composition can additionally
+  // receive case-variant object keys (`Via` plus `via`), which are the same
+  // field because names are case-insensitive. RFC 9110 §5.3 only permits
+  // repeats for list-valued fields (ABNF `#`), where the parts are semantically
+  // one comma-separated value — those we combine. Singular fields with more
+  // than one value are a protocol error — those we reject.
   //
   // Field names are case-insensitive (RFC 7230). The production path lowercases
   // keys (parseHeaders) before this runs, but the standalone interceptors.proxy()
@@ -209,23 +228,43 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     if (len === 3 && eqiLower(key, 'via')) {
       // Via is list-valued (RFC 9110 §7.6.3): combine repeated field-lines.
       const v = headers[key]
-      via = Array.isArray(v) ? v.join(', ') : v
+      const value = joinNonEmptyHeaderValues(v)
+      if (value) {
+        via = viaSeen ? `${via}, ${value}` : value
+        viaSeen = true
+      }
     } else if (len === 4 && eqiLower(key, 'host')) {
       // Host is singular (RFC 9110 §7.2, RFC 7230 §5.4): more than one is a
       // protocol error, so reject rather than combine.
       const v = headers[key]
-      if (Array.isArray(v)) {
+      if (hostSeen || Array.isArray(v)) {
         throw new createError.BadGateway()
       }
       host = v
+      hostSeen = true
     } else if (len === 9 && eqiLower(key, 'forwarded')) {
       // Forwarded is list-valued (RFC 7239 §4): combine repeated field-lines.
       const v = headers[key]
-      forwarded = Array.isArray(v) ? v.join(', ') : v
+      const value = joinNonEmptyHeaderValues(v)
+      if (value) {
+        forwarded = forwardedSeen ? `${forwarded}, ${value}` : value
+        forwardedSeen = true
+      }
     } else if (len === 10 && eqiLower(key, 'connection')) {
       // Connection is list-valued (RFC 9110 §7.6.1): captured raw and tokenised
-      // below — combining then re-splitting would be wasteful.
-      connection = headers[key]
+      // below. Preserve every case-variant key just like parseHeaders preserves
+      // repeated field-lines; otherwise a later `connection` key can overwrite
+      // an earlier `Connection: x-secret` and let x-secret leak to the next hop.
+      const v = headers[key]
+      if (connectionSeen) {
+        connection = [
+          ...(Array.isArray(connection) ? connection : [connection]),
+          ...(Array.isArray(v) ? v : [v]),
+        ]
+      } else {
+        connection = v
+        connectionSeen = true
+      }
     } else if (len === 10 && key === ':authority') {
       // :authority is singular (RFC 9113 §8.3.1): reject more than one. Pseudo
       // headers are always lowercase, so an exact compare is correct here.

--- a/test/proxy-case-variant-duplicates.js
+++ b/test/proxy-case-variant-duplicates.js
@@ -1,0 +1,122 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function requestHeaders(headers, proxy = {}) {
+  let captured
+  const base = (opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }
+  const dispatch = compose(base, interceptors.proxy())
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers, proxy },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError() {},
+    },
+  )
+  return captured
+}
+
+function responseError(headers, proxy) {
+  const base = (opts, handler) => {
+    handler.onConnect(() => {})
+    try {
+      handler.onHeaders(200, headers, () => {})
+      handler.onComplete([])
+    } catch (err) {
+      handler.onError(err)
+    }
+  }
+  const dispatch = compose(base, interceptors.proxy())
+  return new Promise((resolve, reject) => {
+    dispatch(
+      { origin: 'http://upstream.test', path: '/', method: 'GET', headers: {}, proxy },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(null)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('proxy: case-variant Connection fields all nominate headers for removal', (t) => {
+  const headers = requestHeaders({
+    Connection: 'x-secret',
+    connection: 'keep-alive',
+    'x-secret': 'must not leak',
+    'x-keep': 'preserved',
+  })
+
+  t.notOk('x-secret' in headers)
+  t.equal(headers['x-keep'], 'preserved')
+  t.end()
+})
+
+test('proxy: a case-variant Via field cannot hide a proxy loop', async (t) => {
+  const err = await responseError(
+    { Via: 'HTTP/1.1 myproxy', via: 'HTTP/1.1 benign' },
+    { name: 'myproxy' },
+  ).then(
+    () => null,
+    (err) => err,
+  )
+
+  t.equal(err?.statusCode, 508)
+})
+
+test('proxy: empty case-variant Via values do not add separators', (t) => {
+  const headers = requestHeaders({ Via: '', via: 'HTTP/1.1 upstream' }, { name: 'edge' })
+
+  t.equal(headers.via, 'HTTP/1.1 upstream, HTTP/1.1 edge')
+  t.end()
+})
+
+test('proxy: case-variant duplicate Host fields are rejected', (t) => {
+  t.throws(() => requestHeaders({ Host: 'one.test', host: 'two.test' }), { statusCode: 502 })
+  t.end()
+})
+
+test('proxy: case-variant Forwarded fields are both retained when appending', (t) => {
+  const headers = requestHeaders(
+    { Forwarded: 'for=192.0.2.1', forwarded: 'for=192.0.2.2' },
+    {
+      socket: {
+        localAddress: '192.0.2.10',
+        remoteAddress: '192.0.2.20',
+      },
+    },
+  )
+
+  t.match(headers.forwarded, /for=192\.0\.2\.1, for=192\.0\.2\.2, by=192\.0\.2\.10/)
+  t.end()
+})
+
+test('proxy: empty case-variant Forwarded values do not add separators', (t) => {
+  const headers = requestHeaders(
+    { Forwarded: 'for=192.0.2.1', forwarded: '' },
+    {
+      socket: {
+        localAddress: '192.0.2.10',
+        remoteAddress: '192.0.2.20',
+      },
+    },
+  )
+
+  t.match(headers.forwarded, /^for=192\.0\.2\.1, by=192\.0\.2\.10/)
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Combine case-variant duplicates for list-valued Via, Forwarded, and Connection fields.
- Reject duplicate Host fields regardless of casing.
- Preserve all Connection-nominated removals and all Via loop evidence.
- Add four standalone-composition regressions.

## Why

HTTP field names are case-insensitive, but standalone object headers can contain both `Header` and `header`. Later keys overwrote earlier proxy state, allowing hop-by-hop leaks, hidden loops, duplicate Host bypass, and lost provenance.

## Validation

- new duplicate-field regressions
- proxy advanced and redirect/proxy suites (66 assertions)
- ESLint, Prettier, and diff checks