### PR TITLE
fix(proxy): escape Forwarded host values

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -308,7 +308,7 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
           socket.localAddress && `by=${printIp(socket.localAddress, socket.localPort)}`,
           socket.remoteAddress && `for=${printIp(socket.remoteAddress, socket.remotePort)}`,
           `proto=${socket.encrypted ? 'https' : 'http'}`,
-          forwardedHost && `host="${forwardedHost}"`,
+          forwardedHost && `host=${quoteForwardedString(forwardedHost)}`,
         ]
           .filter(Boolean)
           .join(';'),
@@ -349,6 +349,18 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   }
 
   return acc
+}
+
+/**
+ * Forwarded's host parameter is a quoted-string because authorities commonly
+ * contain `:`. Escape quoted-pair characters so an untrusted Host value cannot
+ * close the string and inject a forged `for`, `by`, or `proto` parameter.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function quoteForwardedString(value) {
+  return `"${value.replace(/["\\]/g, '\\$&')}"`
 }
 
 /**

--- a/test/proxy-forwarded-host-escaping.js
+++ b/test/proxy-forwarded-host-escaping.js
@@ -1,0 +1,59 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function forwardedHeader(headers) {
+  let forwarded
+  const base = (opts, handler) => {
+    forwarded = opts.headers.forwarded
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }
+  const dispatch = compose(base, interceptors.proxy())
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers,
+      proxy: {
+        socket: {
+          localAddress: '192.0.2.1',
+          encrypted: false,
+        },
+      },
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return forwarded
+}
+
+test('proxy: Forwarded escapes quote and backslash in Host', (t) => {
+  const host = String.raw`victim";for=spoofed\suffix`
+
+  t.equal(
+    forwardedHeader({ host }),
+    String.raw`by=192.0.2.1;proto=http;host="victim\";for=spoofed\\suffix"`,
+  )
+  t.end()
+})
+
+test('proxy: Forwarded escapes quote and backslash in :authority', (t) => {
+  const authority = String.raw`victim";proto=https\suffix`
+
+  t.equal(
+    forwardedHeader({ ':authority': authority }),
+    String.raw`by=192.0.2.1;proto=http;host="victim\";proto=https\\suffix"`,
+  )
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Quote Host and `:authority` values with RFC quoted-pair escaping before appending `Forwarded`.
- Add quote/backslash injection regressions for both authority sources.

## Why

Untrusted authority text was inserted between raw double quotes. A quote or backslash could terminate the value and inject forged `for`, `by`, or `proto` parameters into proxy provenance.

## Validation

- new Forwarded escaping regressions
- proxy advanced suite (51 assertions)
- ESLint, Prettier, and diff checks