### PR TITLE
fix(retry): honor callbacks in object retry options

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -533,9 +533,24 @@ class Handler extends DecoratorHandler {
 
     let retryPromise
     try {
-      if (typeof this.#opts.retry === 'function') {
+      const retryOpts = this.#opts.retry
+      const isObjectRetry = retryOpts !== null && typeof retryOpts === 'object'
+      const retry = typeof retryOpts === 'function' ? retryOpts : isObjectRetry && retryOpts.retry
+
+      // Object-form retry options can combine a strategy with a hard attempt
+      // cap. Apply the cap before invoking the strategy; otherwise
+      // `{ count: 2, retry: () => true }` retries forever and the `count`
+      // option is silently ignored. A bare retry function retains its
+      // existing strategy-owned count semantics.
+      if (
+        typeof retry === 'function' &&
+        isObjectRetry &&
+        this.#retryCount >= (retryOpts.count ?? 8)
+      ) {
+        retryPromise = Promise.resolve(false)
+      } else if (typeof retry === 'function') {
         retryPromise = Promise.resolve(
-          this.#opts.retry(
+          retry(
             decorateError(err, this.#opts, {
               statusCode: this.#statusCode || undefined,
               headers: this.#headers,

--- a/test/review-retry-options-callback.js
+++ b/test/review-retry-options-callback.js
@@ -1,0 +1,90 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function request(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(status) {
+        statusCode = status
+        return true
+      },
+      onData(chunk) {
+        chunks.push(chunk)
+        return true
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+function respond(handler, statusCode, body) {
+  handler.onConnect(() => {})
+  handler.onHeaders(statusCode, { 'content-length': String(Buffer.byteLength(body)) }, () => {})
+  handler.onData(Buffer.from(body))
+  handler.onComplete({})
+}
+
+test('object-form retry strategy can veto the default retry decision', async (t) => {
+  let attempts = 0
+  let strategyCalls = 0
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    respond(handler, attempts === 1 ? 503 : 200, attempts === 1 ? 'unavailable' : 'ok')
+  }, interceptors.responseRetry())
+
+  const result = await request(dispatch, {
+    origin: 'http://example.test',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    retry: {
+      count: 2,
+      retry(err, retryCount, opts, defaultRetry) {
+        strategyCalls++
+        t.equal(err.statusCode, 503)
+        t.equal(retryCount, 0)
+        t.equal(opts.retry.count, 2)
+        t.type(defaultRetry, 'function')
+        return false
+      },
+    },
+  })
+
+  t.equal(strategyCalls, 1, 'the nested retry strategy was called')
+  t.equal(attempts, 1, 'veto prevented the default 503 retry')
+  t.same(result, { statusCode: 503, body: 'unavailable' })
+})
+
+test('object-form retry count caps a strategy that always retries', async (t) => {
+  let attempts = 0
+  let strategyCalls = 0
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    respond(handler, 500, 'failed')
+  }, interceptors.responseRetry())
+
+  const result = await request(dispatch, {
+    origin: 'http://example.test',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    retry: {
+      count: 2,
+      retry() {
+        strategyCalls++
+        return true
+      },
+    },
+  })
+
+  t.equal(attempts, 3, 'initial attempt plus two retries')
+  t.equal(strategyCalls, 2, 'strategy is not called after the configured cap')
+  t.same(result, { statusCode: 500, body: 'failed' })
+})


### PR DESCRIPTION
## Why

`RetryOptions` types allow `{ count, retry() }`, but the interceptor only invoked a callback when `opts.retry` itself was a function. Nested strategies were silently ignored, and an always-true nested strategy had no count cap.

## Change

Invoke `RetryOptions.retry` and apply the object's retry count before calling it.

## Checks

- New regression tests — 10/10 assertions
- Retry deep/backoff/lookup/abort/ETag/large-body/resume/stall suites
- ESLint, Prettier, and `git diff --check`