### PR TITLE
fix(retry): normalize object headers before range resume

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -572,15 +572,13 @@ class Handler extends DecoratorHandler {
           assert(this.#end == null || (Number.isFinite(this.#end) && this.#end > 0))
 
           // Direct dispatch()/compose() callers may pass undici's legal flat
-          // [name, value, ...] array headers; spreading that form would send
-          // garbage numeric header names ('0', '1', ...) on the wire instead
-          // of the real ones. Normalize to an object first (same as
-          // redirect.js does).
+          // [name, value, ...] array headers or an object with mixed-case
+          // names. Normalize either form before replacing Range/If-Match. A
+          // shallow object copy would retain e.g. `Range` alongside the new
+          // `range`, sending conflicting duplicate fields on the wire.
           this.#opts = {
             ...this.#opts,
-            headers: Array.isArray(this.#opts.headers)
-              ? parseHeaders(this.#opts.headers)
-              : { ...this.#opts.headers },
+            headers: parseHeaders(this.#opts.headers),
           }
           // A pos 0 resume is allowed without an etag (nothing was forwarded
           // yet, so nothing can tear) — but then there is no etag to validate

--- a/test/review-retry-object-header-case.js
+++ b/test/review-retry-object-header-case.js
@@ -1,0 +1,61 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+test('range resume replaces mixed-case Range and If-Match headers', async (t) => {
+  let attempts = 0
+  let retryHeaders
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+
+    if (attempts === 1) {
+      handler.onHeaders(200, { 'content-length': '6', etag: '"current"' }, () => {})
+      handler.onData(Buffer.from('abc'))
+      const error = new Error('connection reset')
+      error.code = 'ECONNRESET'
+      handler.onError(error)
+    } else {
+      retryHeaders = opts.headers
+      handler.onHeaders(206, { 'content-range': 'bytes 3-5/6', etag: '"current"' }, () => {})
+      handler.onData(Buffer.from('def'))
+      handler.onComplete({})
+    }
+  }, interceptors.responseRetry())
+
+  const chunks = []
+  await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {
+          Range: 'bytes=0-5',
+          'If-Match': '"stale"',
+          'X-Test': 'preserved',
+        },
+        retry: () => true,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData(chunk) {
+          chunks.push(chunk)
+          return true
+        },
+        onComplete: resolve,
+        onError: reject,
+      },
+    )
+  })
+
+  t.equal(attempts, 2)
+  t.equal(retryHeaders.range, 'bytes=3-5', 'resume range replaces the caller range')
+  t.equal(retryHeaders['if-match'], '"current"', 'resume validator replaces the stale one')
+  t.equal(retryHeaders['x-test'], 'preserved', 'unrelated header is normalized and retained')
+  t.notOk('Range' in retryHeaders, 'mixed-case Range is not duplicated')
+  t.notOk('If-Match' in retryHeaders, 'mixed-case If-Match is not duplicated')
+  t.equal(Buffer.concat(chunks).toString(), 'abcdef')
+})


### PR DESCRIPTION
## Why

Range resume normalized flat header arrays but copied object headers verbatim. Mixed-case `Range` or `If-Match` keys could survive beside newly-added lowercase keys, producing conflicting request headers.

## Change

Normalize every header input through the shared parser before replacing resume headers.

## Checks

- New regression tests — 7/7 assertions
- Existing retry resume-edge suite — 29/29 assertions
- ESLint, Prettier, and `git diff --check`