### PR TITLE
fix(retry): strictly parse Retry-After HTTP dates

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -6,6 +6,7 @@ import {
   decorateError,
   parseContentRange,
   parseHeaders,
+  parseHttpDate,
 } from '../utils.js'
 import { RequestAbortedError } from '../errors.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
@@ -697,8 +698,8 @@ class Handler extends DecoratorHandler {
       let retryAfter = raw ? Number(raw) * 1e3 : null
       if (raw && (retryAfter == null || !Number.isFinite(retryAfter))) {
         // RFC 9110: Retry-After may be an HTTP-date rather than delta-seconds.
-        const date = Date.parse(raw)
-        retryAfter = Number.isFinite(date) ? Math.max(0, date - Date.now()) : null
+        const date = parseHttpDate(raw)?.getTime()
+        retryAfter = date != null ? Math.max(0, date - Date.now()) : null
       }
       const delay =
         retryAfter != null && Number.isFinite(retryAfter)

--- a/test/review-retry-after-http-date.js
+++ b/test/review-retry-after-http-date.js
@@ -1,0 +1,41 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('invalid ISO Retry-After date falls back to configured backoff', async (t) => {
+  let attempts = 0
+  const server = createServer((req, res) => {
+    attempts++
+    if (attempts === 1) {
+      res.writeHead(503, {
+        // Retry-After permits an HTTP-date, not ISO 8601. Date.parse accepts
+        // this extension and used to turn it into an unintended 60s wait.
+        'retry-after': new Date(Date.now() + 60_000).toISOString(),
+      })
+      res.end('unavailable')
+    } else {
+      res.end('ok')
+    }
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(new Error('invalid Retry-After was incorrectly honored')),
+    500,
+  )
+  t.teardown(() => clearTimeout(timeout))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    retry: { count: 1, maxDelay: 0 },
+    signal: controller.signal,
+  })
+  clearTimeout(timeout)
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'ok')
+  t.equal(attempts, 2, 'invalid date used the zero-delay fallback')
+})

--- a/test/review-retry-after-http-date.js
+++ b/test/review-retry-after-http-date.js
@@ -25,7 +25,7 @@ test('invalid ISO Retry-After date falls back to configured backoff', async (t) 
   const controller = new AbortController()
   const timeout = setTimeout(
     () => controller.abort(new Error('invalid Retry-After was incorrectly honored')),
-    500,
+    5_000,
   )
   t.teardown(() => clearTimeout(timeout))
 


### PR DESCRIPTION
## Why

`Date.parse` accepts non-HTTP ISO date strings for `Retry-After`. Invalid protocol values could therefore become unintended waits (up to the 60-second clamp) instead of falling back to normal backoff.

## Change

Use the shared strict HTTP-date parser.

## Checks

- New regression tests — 3/3 assertions
- Retry backoff suite — 10/10 assertions
- Existing retry misc suite — 19/19 assertions
- ESLint, Prettier, and `git diff --check`

## Ordering

Merge #140 first for the global retry fixture baseline. Merge the existing RFC 850 rolling-year correction in #107 before this PR so obsolete HTTP-date forms use the RFC 9110 reference window.