### PR TITLE
fix(retry): deliver explicit falsy abort reasons

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -464,7 +464,7 @@ class Handler extends DecoratorHandler {
   }
 
   #maybeError(err) {
-    if (!err && this.#aborted) {
+    if (err == null && this.#aborted) {
       // Downstream aborted (e.g. during the backoff wait between attempts).
       // The replay branches below are suppressed by the aborted
       // DecoratorHandler, so without this no terminal event would ever reach
@@ -476,7 +476,7 @@ class Handler extends DecoratorHandler {
       err = this.#reason ?? new RequestAbortedError()
     }
 
-    if (err) {
+    if (err != null) {
       if (!this.#errorSent) {
         this.#errorSent = true
         super.onError(err)
@@ -606,7 +606,7 @@ class Handler extends DecoratorHandler {
       .catch((err) => {
         // When the downstream abort cancelled the backoff timer, the timer's
         // own AbortError rejection is just plumbing — deliver the recorded
-        // abort reason instead (falsy reasons are normalized in #maybeError).
+        // abort reason instead (including a caller-provided falsy reason).
         this.#maybeError(this.#aborted ? this.#reason : err)
       })
   }

--- a/test/review-retry-falsy-abort-reason.js
+++ b/test/review-retry-falsy-abort-reason.js
@@ -1,0 +1,50 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+for (const reason of [false, 0, '']) {
+  test(`retry delivers onError after abort(${JSON.stringify(reason)})`, async (t) => {
+    let abortRequest
+    let attempts = 0
+    const dispatch = compose((opts, handler) => {
+      attempts++
+      handler.onConnect(() => {})
+      handler.onHeaders(503, { 'retry-after': '30' }, () => {})
+      handler.onComplete({})
+    }, interceptors.responseRetry())
+
+    const error = new Promise((resolve, reject) => {
+      dispatch(
+        {
+          origin: 'http://example.test',
+          path: '/',
+          method: 'GET',
+          headers: {},
+          retry: { count: 1 },
+        },
+        {
+          onConnect(abort) {
+            abortRequest = abort
+          },
+          onHeaders() {
+            reject(new Error('aborted response must not be replayed'))
+          },
+          onData() {},
+          onComplete() {
+            reject(new Error('aborted response must not complete'))
+          },
+          onError: resolve,
+        },
+      )
+      abortRequest(reason)
+    })
+
+    let timeoutId
+    const timeout = new Promise((resolve, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('retry did not deliver a terminal error')), 500)
+    })
+    const delivered = await Promise.race([error, timeout]).finally(() => clearTimeout(timeoutId))
+
+    t.equal(delivered, reason, 'the original abort reason is preserved')
+    t.equal(attempts, 1, 'abort did not start another attempt')
+  })
+}

--- a/test/review-retry-falsy-abort-reason.js
+++ b/test/review-retry-falsy-abort-reason.js
@@ -35,12 +35,17 @@ for (const reason of [false, 0, '']) {
           onError: resolve,
         },
       )
-      abortRequest(reason)
+      // Let the retry promise enter its backoff wait before aborting so this
+      // deterministically exercises cancellation during the wait.
+      setImmediate(() => abortRequest(reason))
     })
 
     let timeoutId
     const timeout = new Promise((resolve, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('retry did not deliver a terminal error')), 500)
+      timeoutId = setTimeout(
+        () => reject(new Error('retry did not deliver a terminal error')),
+        2_000,
+      )
     })
     const delivered = await Promise.race([error, timeout]).finally(() => clearTimeout(timeoutId))
 


### PR DESCRIPTION
## Why

During retry backoff, explicit abort reasons such as `false`, `0`, and `""` were treated as absence of an error. Raw composed requests could then receive no terminal callback.

## Change

Use null-aware terminal checks so explicit falsy reasons are delivered unchanged; only nullish reasons receive `RequestAbortedError`.

## Checks

- New regression tests — 6/6 assertions
- Existing retry-abort suite — 10/10 assertions
- ESLint, Prettier, and `git diff --check`