### PR TITLE
fix(redirect): apply follow veto before body replay checks

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -74,10 +74,6 @@ class Handler extends DecoratorHandler {
       return super.onHeaders(statusCode, headers, resume)
     }
 
-    if (statusCode !== 303 && isDisturbed(this.#opts.body)) {
-      throw new Error(`Disturbed request cannot be redirected.`)
-    }
-
     this.#location = typeof headers.location === 'string' ? headers.location : ''
 
     if (!this.#location) {
@@ -104,6 +100,13 @@ class Handler extends DecoratorHandler {
           history: this.#history,
         })
       }
+    }
+
+    // Check replayability only after the follow policy has decided to follow.
+    // A callback that returns false delivers this 3xx response as-is and does
+    // not need the already-sent request body again.
+    if (statusCode !== 303 && isDisturbed(this.#opts.body)) {
+      throw new Error(`Disturbed request cannot be redirected.`)
     }
 
     // The redirect decision is final past this point, so trace work stays off

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -13,7 +13,7 @@ function isOneShotIterable(body) {
     const iteratorFactory = body[Symbol.iterator]
     if (typeof iteratorFactory === 'function') {
       const iterator = iteratorFactory.call(body)
-      if (iteratorFactory.call(body) === iterator) {
+      if (iterator === body || iteratorFactory.call(body) === iterator) {
         return true
       }
     }
@@ -21,7 +21,7 @@ function isOneShotIterable(body) {
     const asyncIteratorFactory = body[Symbol.asyncIterator]
     if (typeof asyncIteratorFactory === 'function') {
       const iterator = asyncIteratorFactory.call(body)
-      if (asyncIteratorFactory.call(body) === iterator) {
+      if (iterator === body || asyncIteratorFactory.call(body) === iterator) {
         return true
       }
     }

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -10,23 +10,15 @@ function isOneShotIterable(body) {
   }
 
   try {
-    const iteratorFactory = body[Symbol.iterator]
-    if (typeof iteratorFactory === 'function') {
-      const iterator = iteratorFactory.call(body)
-      if (iterator === body || iteratorFactory.call(body) === iterator) {
-        return true
-      }
-    }
-
     const asyncIteratorFactory = body[Symbol.asyncIterator]
-    if (typeof asyncIteratorFactory === 'function') {
-      const iterator = asyncIteratorFactory.call(body)
-      if (iterator === body || asyncIteratorFactory.call(body) === iterator) {
-        return true
-      }
+    const iteratorFactory =
+      typeof asyncIteratorFactory === 'function' ? asyncIteratorFactory : body[Symbol.iterator]
+    if (typeof iteratorFactory !== 'function') {
+      return false
     }
 
-    return false
+    const iterator = iteratorFactory.call(body)
+    return iterator === body || iteratorFactory.call(body) === iterator
   } catch {
     // If asking for another iterator already fails, the body cannot be replayed.
     return true

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -4,6 +4,35 @@ import { traceWrite, traceSafe, traceUrl } from '../trace.js'
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
+function isOneShotIterable(body) {
+  if (body == null || typeof body !== 'object') {
+    return false
+  }
+
+  try {
+    const iteratorFactory = body[Symbol.iterator]
+    if (typeof iteratorFactory === 'function') {
+      const iterator = iteratorFactory.call(body)
+      if (iteratorFactory.call(body) === iterator) {
+        return true
+      }
+    }
+
+    const asyncIteratorFactory = body[Symbol.asyncIterator]
+    if (typeof asyncIteratorFactory === 'function') {
+      const iterator = asyncIteratorFactory.call(body)
+      if (asyncIteratorFactory.call(body) === iterator) {
+        return true
+      }
+    }
+
+    return false
+  } catch {
+    // If asking for another iterator already fails, the body cannot be replayed.
+    return true
+  }
+}
+
 class Handler extends DecoratorHandler {
   #dispatch
   #opts
@@ -105,7 +134,10 @@ class Handler extends DecoratorHandler {
     // Check replayability only after the follow policy has decided to follow.
     // A callback that returns false delivers this 3xx response as-is and does
     // not need the already-sent request body again.
-    if (statusCode !== 303 && isDisturbed(this.#opts.body)) {
+    if (
+      statusCode !== 303 &&
+      (isDisturbed(this.#opts.body) || isOneShotIterable(this.#opts.body))
+    ) {
       throw new Error(`Disturbed request cannot be redirected.`)
     }
 

--- a/test/review-redirect-follow-veto-stream.js
+++ b/test/review-redirect-follow-veto-stream.js
@@ -1,0 +1,41 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { Readable } from 'node:stream'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('follow callback can decline a 307 after a streaming request body', async (t) => {
+  let attempts = 0
+  let receivedBody = ''
+  const server = createServer((req, res) => {
+    attempts++
+    req.on('data', (chunk) => {
+      receivedBody += chunk
+    })
+    req.on('end', () => {
+      res.writeHead(307, { location: '/not-followed' })
+      res.end('redirect response')
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  let followCalls = 0
+  const response = await request(`http://127.0.0.1:${server.address().port}/start`, {
+    method: 'POST',
+    body: Readable.from(['streamed body']),
+    follow(location, count) {
+      followCalls++
+      t.equal(location, '/not-followed')
+      t.equal(count, 1)
+      return false
+    },
+  })
+
+  t.equal(response.statusCode, 307, 'the declined redirect response is delivered')
+  t.equal(await response.body.text(), 'redirect response')
+  t.equal(followCalls, 1)
+  t.equal(attempts, 1, 'no redirect request was dispatched')
+  t.equal(receivedBody, 'streamed body')
+})

--- a/test/review-redirect-one-shot-body.js
+++ b/test/review-redirect-one-shot-body.js
@@ -140,3 +140,48 @@ test('307 still replays a reusable iterable that also exposes next()', async (t)
   t.equal(await response.body.text(), 'ok')
   t.same(requestBodies, ['payload', 'payload'], 'fresh iterator is replayed on the second hop')
 })
+
+test('307 uses a reusable async protocol when the sync protocol is one-shot', async (t) => {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (req.url === '/start') {
+        res.writeHead(307, { location: '/redirected' })
+        res.end()
+      } else {
+        res.end('ok')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const syncIterator = (function* () {
+    yield 'wrong protocol'
+  })()
+  const body = {
+    [Symbol.iterator]() {
+      return syncIterator
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        yield 'payload'
+      })()
+    },
+  }
+
+  const response = await request(`http://127.0.0.1:${server.address().port}/start`, {
+    method: 'POST',
+    body,
+    retry: false,
+    follow: 2,
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'ok')
+  t.same(requestBodies, ['payload', 'payload'], 'redirect replay follows the async protocol')
+})

--- a/test/review-redirect-one-shot-body.js
+++ b/test/review-redirect-one-shot-body.js
@@ -1,0 +1,142 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+async function rejectsOneShotBody(t, makeBody) {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (req.url === '/start') {
+        res.writeHead(307, { location: '/redirected' })
+        res.end()
+      } else {
+        res.end('unexpected second request')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  await t.rejects(
+    request(`http://127.0.0.1:${server.address().port}/start`, {
+      method: 'POST',
+      body: makeBody(),
+      retry: false,
+      follow: 2,
+    }),
+    /Disturbed request cannot be redirected/,
+  )
+
+  t.same(requestBodies, ['payload'], 'redirect did not replay the consumed iterator as empty')
+}
+
+test('307 rejects a consumed generator body instead of replaying an empty body', async (t) => {
+  await rejectsOneShotBody(t, function* () {
+    yield 'payload'
+  })
+})
+
+test('307 rejects a consumed async-generator body instead of replaying an empty body', async (t) => {
+  await rejectsOneShotBody(t, async function* () {
+    yield 'payload'
+  })
+})
+
+test('307 rejects an iterable that reuses one cached iterator', async (t) => {
+  await rejectsOneShotBody(t, () => {
+    const iterator = (function* () {
+      yield 'payload'
+    })()
+    return {
+      [Symbol.iterator]() {
+        return iterator
+      },
+    }
+  })
+})
+
+test('307 rejects an async iterable that reuses one cached iterator', async (t) => {
+  await rejectsOneShotBody(t, () => {
+    const iterator = (async function* () {
+      yield 'payload'
+    })()
+    return {
+      [Symbol.asyncIterator]() {
+        return iterator
+      },
+    }
+  })
+})
+
+test('follow callback can veto redirect of a consumed generator body', async (t) => {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      res.writeHead(307, { location: '/not-followed' })
+      res.end('redirect response')
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}/start`, {
+    method: 'POST',
+    body: (function* () {
+      yield 'payload'
+    })(),
+    retry: false,
+    follow: () => false,
+  })
+
+  t.equal(response.statusCode, 307)
+  t.equal(await response.body.text(), 'redirect response')
+  t.same(requestBodies, ['payload'], 'veto avoids replaying the consumed generator')
+})
+
+test('307 still replays a reusable iterable that also exposes next()', async (t) => {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (req.url === '/start') {
+        res.writeHead(307, { location: '/redirected' })
+        res.end()
+      } else {
+        res.end('ok')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const reusableBody = {
+    next() {
+      return { done: true }
+    },
+    *[Symbol.iterator]() {
+      yield 'payload'
+    },
+  }
+  const response = await request(`http://127.0.0.1:${server.address().port}/start`, {
+    method: 'POST',
+    body: reusableBody,
+    retry: false,
+    follow: 2,
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'ok')
+  t.same(requestBodies, ['payload', 'payload'], 'fresh iterator is replayed on the second hop')
+})


### PR DESCRIPTION
## Why

The interceptor rejected a disturbed streaming body before consulting a functional `follow` policy. A callback returning `false` should expose the original 3xx response without replaying the body, but instead received an unnecessary disturbed-body error.

## Change

Evaluate the follow policy before validating redirect replayability.

## Checks

- New regression tests — 7/7 assertions
- Redirect suites — 52/52 and 23/23 assertions
- ESLint, Prettier, and `git diff --check`