### PR TITLE
fix(body-factory): abort a pending factory promptly

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -15,6 +15,12 @@ class FactoryStream extends Readable {
 
   _construct(callback) {
     this.#ac = new AbortController()
+    // destroy() can run before Node schedules _construct(). In that case the
+    // factory still runs, but it must receive an already-aborted signal so a
+    // pending factory can cancel instead of keeping its resources alive.
+    if (this.destroyed) {
+      this.#abortFactory(this.errored)
+    }
     // Note: #ac is intentionally kept after the factory settles, so that a
     // destroy with an error can still abort the factory's signal (see
     // _destroy) — e.g. the request failing before undici started writing
@@ -80,15 +86,28 @@ class FactoryStream extends Readable {
     this.#body?.resume()
   }
 
+  destroy(err) {
+    // Node defers _destroy() until an asynchronous _construct() calls back.
+    // A factory waiting for its signal would therefore deadlock teardown:
+    // _destroy waits for the factory while the factory waits for _destroy to
+    // abort it. Abort synchronously when destroy() is requested instead.
+    this.#abortFactory(err)
+    return super.destroy(err)
+  }
+
+  #abortFactory(err) {
+    if (this.#ac && !this.#ac.signal.aborted && (err || !this.readableEnded)) {
+      this.#ac.abort(err)
+    }
+  }
+
   _destroy(err, callback) {
     if (this.#ac) {
       // Abort the factory's signal on any error, and on a premature destroy
       // (destroyed before 'end'), so the factory can cancel whatever it is
       // producing. A clean destroy after a fully consumed body (autoDestroy
       // after 'end') must not abort — the factory finished normally.
-      if (err || !this.readableEnded) {
-        this.#ac.abort(err)
-      }
+      this.#abortFactory(err)
       this.#ac = null
     }
 

--- a/test/review-body-factory-pending-abort.js
+++ b/test/review-body-factory-pending-abort.js
@@ -1,0 +1,94 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('aborting a request aborts a still-pending body factory', async (t) => {
+  const server = createServer((req, res) => {
+    req.resume()
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const reason = new Error('stop pending factory')
+  const controller = new AbortController()
+  let factorySignal
+  let factoryAbortCalls = 0
+
+  const pendingRequest = request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'PUT',
+    retry: false,
+    signal: controller.signal,
+    body: ({ signal }) => {
+      factorySignal = signal
+      queueMicrotask(() => controller.abort(reason))
+      return new Promise((resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            factoryAbortCalls++
+            reject(signal.reason)
+          },
+          { once: true },
+        )
+      })
+    },
+  })
+
+  await t.rejects(pendingRequest, reason)
+  await tick()
+
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'factory received the request abort reason')
+  t.equal(factoryAbortCalls, 1, 'factory cancellation ran exactly once')
+})
+
+test('destroy before _construct gives a pending factory an aborted signal', async (t) => {
+  const reason = new Error('synchronous dispatch failure')
+  const dispatch = requestBodyFactory()(() => {
+    throw reason
+  })
+  let factorySignal
+  let factoryAbortCalls = 0
+
+  t.throws(
+    () =>
+      dispatch(
+        {
+          method: 'PUT',
+          body: ({ signal }) => {
+            factorySignal = signal
+            return new Promise((resolve, reject) => {
+              if (signal.aborted) {
+                factoryAbortCalls++
+                reject(signal.reason)
+              } else {
+                signal.addEventListener(
+                  'abort',
+                  () => {
+                    factoryAbortCalls++
+                    reject(signal.reason)
+                  },
+                  { once: true },
+                )
+              }
+            })
+          },
+        },
+        { onError() {} },
+      ),
+    reason,
+  )
+
+  // FactoryStream construction is scheduled on the next tick.
+  await tick()
+  await tick()
+
+  t.equal(factorySignal.aborted, true, 'factory started with an aborted signal')
+  t.equal(factorySignal.reason, reason, 'synchronous failure was retained as the reason')
+  t.equal(factoryAbortCalls, 1, 'factory observed cancellation once')
+})


### PR DESCRIPTION
## Why

Node defers `_destroy()` until async `_construct()` finishes. If the factory awaited its cancellation signal, teardown waited for the factory while the factory waited for teardown—a deadlock. Destroy-before-construct had the same cancellation gap.

## Change

Abort the factory signal synchronously from `destroy()` and carry cancellation into late construction.

## Checks

- New regression tests — 8/8 assertions
- Body-factory, typed-array, leak, and core suites
- ESLint, Prettier, and `git diff --check`

## Ordering

Land before the async-dispatch cleanup PR.