### PR TITLE
fix(body-factory): clean up rejected async dispatches

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -184,7 +184,14 @@ export default () => (dispatch) => (opts, handler) => {
 
   const body = new FactoryStream(opts.body).on('error', noop)
   try {
-    return dispatch({ ...opts, body }, new Handler(handler, body))
+    const result = dispatch({ ...opts, body }, new Handler(handler, body))
+    if (result != null && typeof result.catch === 'function') {
+      // DispatchFn permits Promise<void>. A rejecting async dispatcher may not
+      // also report the failure through handler.onError, so attach cleanup to
+      // the original promise while returning it unchanged to the caller.
+      result.catch((err) => body.destroy(err))
+    }
+    return result
   } catch (err) {
     body.destroy(err)
     throw err

--- a/test/review-body-factory-async-dispatch.js
+++ b/test/review-body-factory-async-dispatch.js
@@ -1,0 +1,33 @@
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('async dispatch rejection destroys its factory body', async (t) => {
+  const reason = new Error('async dispatch failed')
+  const dispatch = requestBodyFactory()(async () => {
+    throw reason
+  })
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  await t.rejects(result, reason, 'dispatch rejection is preserved')
+  // Factory construction and deferred _destroy each run on a later tick.
+  await tick()
+  await tick()
+
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'dispatch rejection is the cancellation reason')
+})


### PR DESCRIPTION
## Why

A promise-returning inner dispatcher can reject without calling `handler.onError`. The factory body and its cancellation signal were then left alive.

## Change

Attach cleanup to the returned promise while preserving and returning the original rejection.

## Checks

- New regression tests — 4/4 assertions
- Existing typed-array and leak suites
- ESLint, Prettier, and `git diff --check`

## Ordering

Land after the pending-factory abort PR.