### PR TITLE
fix(body-factory): complete already-ended streams

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -7,6 +7,8 @@ class FactoryStream extends Readable {
   #factory
   #ac
   #body
+  #removeBodyListeners = noop
+  #cleanupFinished = noop
 
   constructor(factory) {
     super()
@@ -59,27 +61,36 @@ class FactoryStream extends Readable {
           }
 
           if (this.#body != null) {
-            this.#body
-              .on('data', (data) => {
-                // `?.`: a 'data' event can still be queued when _destroy() has
-                // already nulled #body, and `_read` guards the same way.
-                if (!this.push(data)) {
-                  this.#body?.pause()
-                }
-              })
-              .on('end', () => {
-                this.push(null)
-              })
+            const bodyStream = this.#body
+            const onData = (data) => {
+              // `?.`: a 'data' event can still be queued when _destroy() has
+              // already nulled #body, and `_read` guards the same way.
+              if (!this.push(data)) {
+                this.#body?.pause()
+              }
+            }
+            const onEnd = () => this.push(null)
+
+            // Register our end handler before finished(): it must push the
+            // outer EOF before finished's terminal callback removes listeners.
+            bodyStream.on('end', onEnd)
+
             // `finished` (not a bare 'error' listener) so a premature close —
             // the inner body destroyed without emitting 'end' or 'error', which
             // surfaces only as 'close' — becomes ERR_STREAM_PREMATURE_CLOSE and
             // fails the request, instead of hanging forever with no terminal
             // push(null). writable:false: these inner bodies are read-only.
-            finished(this.#body, { writable: false }, (err) => {
+            this.#cleanupFinished = finished(bodyStream, { writable: false }, (err) => {
               if (err) {
                 this.destroy(err)
               }
             })
+
+            bodyStream.on('data', onData)
+            this.#removeBodyListeners = () => {
+              bodyStream.removeListener('data', onData)
+              bodyStream.removeListener('end', onEnd)
+            }
           }
 
           callback(null)
@@ -120,10 +131,26 @@ class FactoryStream extends Readable {
       this.#ac = null
     }
 
+    this.#removeBodyListeners()
+    this.#removeBodyListeners = noop
+
     if (this.#body) {
-      this.#body.destroy(err)
+      const bodyStream = this.#body
+      const cleanupFinished = this.#cleanupFinished
+      // Keep finished's error listener installed until destroy() has emitted
+      // the inner stream's terminal events. Removing it first would turn a
+      // propagated body error into an uncaught second 'error' emission.
+      if (bodyStream.closed) {
+        cleanupFinished()
+      } else {
+        bodyStream.once('close', cleanupFinished)
+        bodyStream.destroy(err)
+      }
       this.#body = null
+    } else {
+      this.#cleanupFinished()
     }
+    this.#cleanupFinished = noop
 
     callback(err)
   }

--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -44,7 +44,16 @@ class FactoryStream extends Readable {
             this.push(body)
             this.push(null)
           } else if (isStream(body)) {
-            this.#body = body
+            // A factory may resolve after its stream has already emitted
+            // 'end'. Attaching an end listener at that point can never
+            // complete this wrapper. Treat a cleanly exhausted result as an
+            // empty body; a stream closed before end still goes through
+            // finished() below and reports ERR_STREAM_PREMATURE_CLOSE.
+            if (body.readableEnded) {
+              this.push(null)
+            } else {
+              this.#body = body
+            }
           } else {
             this.#body = Readable.from(body)
           }

--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -184,7 +184,14 @@ export default () => (dispatch) => (opts, handler) => {
 
   const body = new FactoryStream(opts.body).on('error', noop)
   try {
-    return dispatch({ ...opts, body }, new Handler(handler, body))
+    const result = dispatch({ ...opts, body }, new Handler(handler, body))
+    if (result != null && typeof result.catch === 'function') {
+      // DispatchFn permits Promise<void>. A rejecting async dispatcher may not
+      // also report the failure through handler.onError, so attach cleanup to
+      // the original promise while returning it unchanged to the caller.
+      result.catch((err) => body.destroy(err))
+    }
+    return result
   } catch (err) {
     body.destroy(err)
     throw err

--- a/test/review-body-factory-async-dispatch.js
+++ b/test/review-body-factory-async-dispatch.js
@@ -1,0 +1,33 @@
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('async dispatch rejection destroys its factory body', async (t) => {
+  const reason = new Error('async dispatch failed')
+  const dispatch = requestBodyFactory()(async () => {
+    throw reason
+  })
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  await t.rejects(result, reason, 'dispatch rejection is preserved')
+  // Factory construction and deferred _destroy each run on a later tick.
+  await tick()
+  await tick()
+
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'dispatch rejection is the cancellation reason')
+})

--- a/test/review-body-factory-ended-stream.js
+++ b/test/review-body-factory-ended-stream.js
@@ -1,0 +1,43 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { Readable } from 'node:stream'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('factory result that already ended completes as an empty body', async (t) => {
+  let requestBody = ''
+  const server = createServer((req, res) => {
+    req.on('data', (chunk) => {
+      requestBody += chunk
+    })
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(new Error('ended factory stream left the request hanging')),
+    500,
+  )
+  t.teardown(() => clearTimeout(timeout))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'POST',
+    retry: false,
+    signal: controller.signal,
+    body: async () => {
+      const ended = Readable.from(['already consumed'])
+      for await (const chunk of ended) {
+        // Exhaust the stream before the factory resolves.
+        void chunk
+      }
+      return ended
+    },
+  })
+  clearTimeout(timeout)
+
+  t.equal(await response.body.text(), 'ok')
+  t.equal(requestBody, '', 'the exhausted stream contributes no body bytes')
+})

--- a/test/review-body-factory-listener-cleanup.js
+++ b/test/review-body-factory-listener-cleanup.js
@@ -1,0 +1,36 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+const observedEvents = ['data', 'end', 'error', 'close', 'finish']
+
+function listenerCounts(stream) {
+  return Object.fromEntries(observedEvents.map((event) => [event, stream.listenerCount(event)]))
+}
+
+test('completed factory body does not retain forwarding or finished listeners', async (t) => {
+  const server = createServer((req, res) => {
+    req.resume()
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const inner = new PassThrough()
+  const before = listenerCounts(inner)
+  const responsePromise = request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'POST',
+    body: () => inner,
+  })
+  inner.end('request body')
+
+  const response = await responsePromise
+  await response.body.text()
+  await tick()
+
+  t.same(listenerCounts(inner), before, 'all factory-added listeners were removed')
+})


### PR DESCRIPTION
## Why

An async factory may resolve with a stream whose `end` event already fired. Attaching a new end listener can never complete the wrapper, so the request hangs.

## Change

Treat a cleanly exhausted stream as an empty completed body while preserving premature-close errors.

## Checks

- New regression tests — 2/2 assertions
- Body-factory, typed-array, and core suites
- ESLint, Prettier, and `git diff --check`