### PR TITLE
fix(retry): do not replay one-shot iterator bodies

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -17,6 +17,35 @@ const MAX_ERROR_BODY_SIZE = 256 * 1024
 
 function noop() {}
 
+function isOneShotIterable(body) {
+  if (body == null || typeof body !== 'object') {
+    return false
+  }
+
+  try {
+    const iteratorFactory = body[Symbol.iterator]
+    if (typeof iteratorFactory === 'function') {
+      const iterator = iteratorFactory.call(body)
+      if (iteratorFactory.call(body) === iterator) {
+        return true
+      }
+    }
+
+    const asyncIteratorFactory = body[Symbol.asyncIterator]
+    if (typeof asyncIteratorFactory === 'function') {
+      const iterator = asyncIteratorFactory.call(body)
+      if (asyncIteratorFactory.call(body) === iterator) {
+        return true
+      }
+    }
+
+    return false
+  } catch {
+    // If asking for another iterator already fails, the body cannot be replayed.
+    return true
+  }
+}
+
 // RFC 9110 §8.8.3: a strong entity-tag is a quoted opaque-tag without the
 // case-sensitive W/ prefix. Validate the complete grammar before putting a
 // server-provided value into If-Match; merely rejecting strings that start
@@ -514,6 +543,7 @@ class Handler extends DecoratorHandler {
     if (
       this.#aborted ||
       isDisturbed(this.#opts.body) ||
+      isOneShotIterable(this.#opts.body) ||
       // Once headers have been forwarded, a range resume is the only option —
       // but it is impossible when the response wasn't tracked for resumption
       // (#pos == null, e.g. a trailer response or a passed-through >= 400
@@ -558,7 +588,11 @@ class Handler extends DecoratorHandler {
       .then((shouldRetry) => {
         if (this.#aborted) {
           this.#maybeError(this.#reason)
-        } else if (!shouldRetry || isDisturbed(this.#opts.body)) {
+        } else if (
+          !shouldRetry ||
+          isDisturbed(this.#opts.body) ||
+          isOneShotIterable(this.#opts.body)
+        ) {
           this.#maybeError(err)
         } else if (!this.#headersSent) {
           this.#opts.logger?.debug({ err, retryCount: this.#retryCount }, 'retry response headers')

--- a/test/review-retry-one-shot-body.js
+++ b/test/review-retry-one-shot-body.js
@@ -1,0 +1,111 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+async function doesNotRetryOneShotBody(t, makeBody) {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (requestBodies.length === 1) {
+        res.writeHead(503)
+        res.end('unavailable')
+      } else {
+        res.end('unexpected retry')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'PUT',
+    body: makeBody(),
+    error: false,
+    retry: true,
+  })
+
+  t.equal(response.statusCode, 503, 'original response is returned instead of an empty-body retry')
+  t.equal(await response.body.text(), 'unavailable')
+  t.same(requestBodies, ['payload'], 'the consumed iterator was sent only once')
+}
+
+test('503 does not retry a consumed generator body as empty', async (t) => {
+  await doesNotRetryOneShotBody(t, function* () {
+    yield 'payload'
+  })
+})
+
+test('503 does not retry a consumed async-generator body as empty', async (t) => {
+  await doesNotRetryOneShotBody(t, async function* () {
+    yield 'payload'
+  })
+})
+
+test('503 does not retry an iterable that reuses one cached iterator', async (t) => {
+  await doesNotRetryOneShotBody(t, () => {
+    const iterator = (function* () {
+      yield 'payload'
+    })()
+    return {
+      [Symbol.iterator]() {
+        return iterator
+      },
+    }
+  })
+})
+
+test('503 does not retry an async iterable that reuses one cached iterator', async (t) => {
+  await doesNotRetryOneShotBody(t, () => {
+    const iterator = (async function* () {
+      yield 'payload'
+    })()
+    return {
+      [Symbol.asyncIterator]() {
+        return iterator
+      },
+    }
+  })
+})
+
+test('503 still retries a reusable iterable that also exposes next()', async (t) => {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (requestBodies.length === 1) {
+        res.writeHead(503)
+        res.end('unavailable')
+      } else {
+        res.end('ok')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const reusableBody = {
+    next() {
+      return { done: true }
+    },
+    *[Symbol.iterator]() {
+      yield 'payload'
+    },
+  }
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'PUT',
+    body: reusableBody,
+    retry: true,
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'ok')
+  t.same(requestBodies, ['payload', 'payload'], 'fresh iterator is replayed on retry')
+})


### PR DESCRIPTION
## Why

Generators and cached-iterator wrappers are legal request bodies, but after the first attempt they are exhausted. A retry reused the same object and silently sent an empty body.

## Change

Detect one-shot sync and async iterables by iterator identity before retrying, while retaining support for iterables that create a fresh iterator.

## Checks

- New one-shot/cached/reusable coverage — 15/15 assertions
- Retry deep suite — 79/79 assertions
- ESLint, Prettier, and `git diff --check`

## Ordering

Merge #140 first so the baseline retry fixture suite reflects strong-ETag validation.