### PR TITLE
fix(types): constrain dispatcher options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ export interface BodyReadable extends Readable {
 export type URLLike = string | URL | URLObject
 
 export interface Dispatcher {
-  dispatch(opts: object, handler: DispatchHandler): void
+  dispatch(opts: DispatchOptions, handler: DispatchHandler): void
 }
 
 export interface DispatchHandler {

--- a/type-tests/dispatcher-options.ts
+++ b/type-tests/dispatcher-options.ts
@@ -1,0 +1,9 @@
+import type { Dispatcher, DispatchHandler } from '../lib/index.js'
+
+declare const dispatcher: Dispatcher
+declare const handler: DispatchHandler
+
+dispatcher.dispatch({ origin: 'https://example.test', method: 'GET' }, handler)
+
+// @ts-expect-error Dispatcher options use the public DispatchOptions contract.
+dispatcher.dispatch({ unknownOption: true }, handler)


### PR DESCRIPTION
## Why

The public `Dispatcher.dispatch` declaration accepted any `object`, even though the runtime consumes the documented `DispatchOptions` contract. Invalid option objects therefore passed TypeScript unchecked.

## Change

Type the dispatch argument as `DispatchOptions` and add strict positive/negative compilation fixtures.

## Checks

- Strict TypeScript fixture compilation
- Prettier and `git diff --check`