### PR TITLE
fix(query): omit separators for empty arrays

### DIFF
--- a/lib/interceptor/query.js
+++ b/lib/interceptor/query.js
@@ -21,7 +21,14 @@ function serializePathWithQuery(url, queryParams) {
     throw new Error('Query params cannot be passed when url already contains "?" or "#".')
   }
 
-  const stringified = stringify(queryParams)
+  let stringified = stringify(queryParams)
+
+  // fast-querystring emits separators for keys whose value is an empty array,
+  // even though it emits no field for the key itself. Encoded names/values
+  // cannot contain a raw `&`, so empty segments are exactly those no-op keys.
+  if (stringified.startsWith('&') || stringified.endsWith('&') || stringified.includes('&&')) {
+    stringified = stringified.split('&').filter(Boolean).join('&')
+  }
 
   if (stringified) {
     url += '?' + stringified

--- a/test/query.js
+++ b/test/query.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { test } from 'tap'
 import { createServer } from 'node:http'
 import { request } from '../lib/index.js'
@@ -38,6 +37,42 @@ test('empty query object does not add ?', (t) => {
       str += chunk
     }
     t.equal(str, '/test')
+  })
+})
+
+test('empty query arrays do not leave stray separators', (t) => {
+  t.plan(2)
+  const server = createServer((req, res) => {
+    res.end(req.url)
+  })
+
+  t.teardown(server.close.bind(server))
+  server.listen(0, async () => {
+    const { body } = await request(`http://0.0.0.0:${server.address().port}/test`, {
+      query: {
+        first: [],
+        kept: 'value',
+        middle: [],
+        emptyValue: '',
+        last: 'two',
+        trailing: [],
+      },
+    })
+    let str = ''
+    for await (const chunk of body) {
+      str += chunk
+    }
+    t.equal(str, '/test?kept=value&emptyValue=&last=two')
+
+    const { body: emptyBody } = await request(
+      `http://0.0.0.0:${server.address().port}/only-empty`,
+      { query: { first: [], second: [] } },
+    )
+    let emptyStr = ''
+    for await (const chunk of emptyBody) {
+      emptyStr += chunk
+    }
+    t.equal(emptyStr, '/only-empty', 'all-empty arrays do not add a bare question mark')
   })
 })
 


### PR DESCRIPTION
## Why

`fast-querystring` emits bare separator segments for empty-array values. Mixed queries therefore produced malformed-looking paths such as `/?&kept=value`, and trailing empty arrays left a terminal `&`.

## Change

Remove only empty serialized segments; encoded names/values cannot contain a raw `&`, while legitimate empty-string values (`key=`) remain intact.

## Checks

- Query suite, including leading/middle/trailing/all-empty arrays and empty strings — 8/8 assertions
- ESLint, Prettier, and `git diff --check`