### PR TITLE
fix(log): report the terminal retry status

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -300,6 +300,15 @@ class Handler extends DecoratorHandler {
   onError(err) {
     this.#timing.end = performance.now() - this.#created
 
+    // Retry/response decorators can surface an error for a later attempt
+    // after this handler observed headers from an earlier one. Prefer the
+    // status attached to the terminal error so both the failure log and the
+    // request trace describe the attempt that actually failed. The retained
+    // headers remain those exposed for the logical response.
+    if (err?.statusCode != null) {
+      this.#statusCode = err.statusCode
+    }
+
     if (this.#logger) {
       const data = {
         ures: {

--- a/test/log-advanced.js
+++ b/test/log-advanced.js
@@ -411,3 +411,83 @@ test('log: onUpgrade logs the upgrade response and forwards socket to handler', 
   )
   t.ok(true, 'onUpgrade forwarded to user handler')
 })
+
+test('log: a terminal retry status overrides a stale response status', async (t) => {
+  let attempts = 0
+  let failed
+  const docs = []
+  const trace = {
+    write(data, op) {
+      docs.push({ ...data, op })
+    },
+  }
+  const logger = {
+    child() {
+      return this
+    },
+    debug() {},
+    warn() {},
+    error(data, message) {
+      if (message === 'upstream request failed') {
+        failed = data
+      }
+    },
+  }
+  const dispatch = compose(
+    (opts, handler) => {
+      attempts++
+      handler.onConnect(() => {})
+
+      if (attempts === 1) {
+        handler.onHeaders(
+          200,
+          { etag: '"same"', 'content-length': '10', 'x-attempt': 'first' },
+          () => {},
+        )
+        handler.onData(Buffer.from('hello'))
+        handler.onError(Object.assign(new Error('connection reset'), { code: 'ECONNRESET' }))
+      } else {
+        // response-retry hides a body-resume response's headers from outer
+        // handlers and reports its status on the terminal error instead.
+        handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
+      }
+    },
+    interceptors.responseRetry(),
+    interceptors.log(),
+  )
+
+  await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry: () => true,
+        logger,
+        trace,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('request unexpectedly completed'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(attempts, 2, 'made the original request and one body-resume attempt')
+  t.equal(failed?.ures.statusCode, 503, 'logs the status that caused the terminal error')
+  t.equal(
+    failed?.ures.headers?.['x-attempt'],
+    'first',
+    'keeps the headers exposed for the logical response',
+  )
+  const end = docs.find((doc) => doc.op === 'undici:request' && doc.phase === 'end')
+  t.equal(end?.statusCode, 503, 'request end trace uses the terminal error status')
+})


### PR DESCRIPTION
## Why

A body-resume retry can fail with a later status after the original response headers were exposed. The log handler retained the earlier 200, so both failure logs and `undici:request` end traces misreported the terminal 503.

## Change

Adopt a status attached to the terminal error before logging and trace finalization. Retain the original headers because those are the headers exposed for the logical response.

## Checks

- Real response-retry composition regression
- Log/trace focused suites — 171 assertions
- ESLint, Prettier, and `git diff --check`

## Ordering

Land #156 first so the retry error carries complete terminal response metadata.