### PR TITLE
fix(response-error): preserve the terminal retry status

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -99,18 +99,28 @@ class Handler extends DecoratorHandler {
       return
     }
 
+    // An inner response interceptor may already have decorated the error with
+    // metadata for a response that this outer handler never saw (for example,
+    // the failed range-resume attempt hidden by response-retry). Keep that
+    // response as a unit instead of replacing it with stale captured metadata.
+    if (err?.res != null) {
+      super.onError(err)
+      return
+    }
+
     // An inner response decorator can know more than this outer handler. In
     // particular, response-retry hides a failed body-resume response's headers
     // after the original response headers have already been exposed, and puts
     // the resume attempt's status on the terminal error. Do not overwrite that
-    // current status with the earlier response status observed here.
-    const statusCode = err?.statusCode ?? (this.#statusCode || undefined)
+    // current status with the earlier response status observed here, or pair
+    // that status with headers/trailers from the earlier response.
+    const hasInnerStatus = err?.statusCode != null
 
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode,
-        headers: this.#headers,
-        trailers: this.#trailers,
+        statusCode: hasInnerStatus ? err.statusCode : this.#statusCode || undefined,
+        headers: hasInnerStatus ? null : this.#headers,
+        trailers: hasInnerStatus ? null : this.#trailers,
         body: null,
       }),
     )

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -103,7 +103,7 @@ class Handler extends DecoratorHandler {
     // metadata for a response that this outer handler never saw (for example,
     // the failed range-resume attempt hidden by response-retry). Keep that
     // response as a unit instead of replacing it with stale captured metadata.
-    if (err?.res != null) {
+    if (err?.res != null && typeof err.res === 'object') {
       err.statusCode ??= err.res.statusCode
       err.req ??= {
         path: this.#opts.path,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -99,9 +99,16 @@ class Handler extends DecoratorHandler {
       return
     }
 
+    // An inner response decorator can know more than this outer handler. In
+    // particular, response-retry hides a failed body-resume response's headers
+    // after the original response headers have already been exposed, and puts
+    // the resume attempt's status on the terminal error. Do not overwrite that
+    // current status with the earlier response status observed here.
+    const statusCode = err?.statusCode ?? (this.#statusCode || undefined)
+
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode: this.#statusCode || undefined,
+        statusCode,
         headers: this.#headers,
         trailers: this.#trailers,
         body: null,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -104,6 +104,13 @@ class Handler extends DecoratorHandler {
     // the failed range-resume attempt hidden by response-retry). Keep that
     // response as a unit instead of replacing it with stale captured metadata.
     if (err?.res != null) {
+      err.statusCode ??= err.res.statusCode
+      err.req ??= {
+        path: this.#opts.path,
+        origin: this.#opts.origin,
+        method: this.#opts.method,
+        headers: this.#opts.headers,
+      }
       super.onError(err)
       return
     }
@@ -114,13 +121,13 @@ class Handler extends DecoratorHandler {
     // the resume attempt's status on the terminal error. Do not overwrite that
     // current status with the earlier response status observed here, or pair
     // that status with headers/trailers from the earlier response.
-    const hasInnerStatus = err?.statusCode != null
+    const hasDifferentStatus = err?.statusCode != null && err.statusCode !== this.#statusCode
 
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode: hasInnerStatus ? err.statusCode : this.#statusCode || undefined,
-        headers: hasInnerStatus ? null : this.#headers,
-        trailers: hasInnerStatus ? null : this.#trailers,
+        statusCode: err?.statusCode ?? (this.#statusCode || undefined),
+        headers: hasDifferentStatus ? null : this.#headers,
+        trailers: hasDifferentStatus ? null : this.#trailers,
         body: null,
       }),
     )

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -1,0 +1,61 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+test('response error preserves the terminal body-resume status', async (t) => {
+  let attempts = 0
+  const firstError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })
+
+  const dispatch = compose(
+    (opts, handler) => {
+      attempts++
+      handler.onConnect(() => {})
+
+      if (attempts === 1) {
+        handler.onHeaders(
+          200,
+          { 'content-length': '10', etag: '"same"', 'x-attempt': 'first' },
+          () => {},
+        )
+        handler.onData(Buffer.from('hello'))
+        handler.onError(firstError)
+      } else {
+        // response-retry does not expose these resume headers after the first
+        // response's headers have reached the caller. It instead reports this
+        // attempt's status on the terminal error.
+        handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
+        handler.onComplete([])
+      }
+    },
+    interceptors.responseRetry(),
+    interceptors.responseError(),
+  )
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry: () => true,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('request unexpectedly completed'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
+  t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
+  t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
+  t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
+  t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -56,7 +56,11 @@ test('response error preserves the terminal body-resume status', async (t) => {
   t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
   t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
   t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
-  t.equal(err.res.headers, null, 'does not pair terminal status with earlier response headers')
+  t.same(
+    err.res.headers,
+    { 'x-attempt': 'second' },
+    'pairs the terminal status with the terminal attempt headers',
+  )
   t.equal(err.res.trailers, null, 'does not pair terminal status with earlier response trailers')
   t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
   t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -146,3 +146,33 @@ test('response error keeps captured metadata when the inner status matches', asy
   t.equal(err.statusCode, 503, 'keeps the matching terminal status')
   t.equal(err.res.headers, headers, 'keeps headers captured for that status')
 })
+
+test('response error tolerates primitive inner response metadata', async (t) => {
+  const innerError = Object.assign(new Error('network failed'), { res: 'unexpected' })
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, innerError, 'forwards the original error')
+  t.same(err.res, { statusCode: undefined, headers: undefined, trailers: undefined })
+  t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -177,6 +177,6 @@ test('response error tolerates primitive inner response metadata', async (t) => 
   })
 
   t.equal(err, innerError, 'forwards the original error')
-  t.same(err.res, { statusCode: undefined, headers: undefined, trailers: undefined })
+  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: undefined })
   t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -56,6 +56,51 @@ test('response error preserves the terminal body-resume status', async (t) => {
   t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
   t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
   t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
+  t.equal(err.res.headers, null, 'does not pair terminal status with earlier response headers')
+  t.equal(err.res.trailers, null, 'does not pair terminal status with earlier response trailers')
   t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
   t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')
+})
+
+test('response error preserves inner response metadata as a unit', async (t) => {
+  const response = {
+    statusCode: 503,
+    headers: { 'x-attempt': 'second' },
+    trailers: { 'x-terminal': 'yes' },
+  }
+  const innerError = Object.assign(new Error('terminal response failed'), {
+    statusCode: 503,
+    res: response,
+  })
+
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'x-attempt': 'first' }, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, innerError, 'forwards the inner error')
+  t.equal(err.res, response, 'keeps the inner response metadata object intact')
+  t.same(err.res.headers, { 'x-attempt': 'second' }, 'keeps the terminal response headers')
+  t.same(err.res.trailers, { 'x-terminal': 'yes' }, 'keeps the terminal response trailers')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -179,6 +179,6 @@ test('response error tolerates primitive inner response metadata', async (t) => 
   })
 
   t.equal(err, innerError, 'forwards the original error')
-  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: undefined })
+  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: null })
   t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -69,7 +69,6 @@ test('response error preserves inner response metadata as a unit', async (t) => 
     trailers: { 'x-terminal': 'yes' },
   }
   const innerError = Object.assign(new Error('terminal response failed'), {
-    statusCode: 503,
     res: response,
   })
 
@@ -101,6 +100,49 @@ test('response error preserves inner response metadata as a unit', async (t) => 
 
   t.equal(err, innerError, 'forwards the inner error')
   t.equal(err.res, response, 'keeps the inner response metadata object intact')
+  t.equal(err.statusCode, 503, 'backfills the top-level status from inner response metadata')
+  t.same(
+    err.req,
+    {
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      headers: {},
+    },
+    'adds request metadata without replacing the inner response',
+  )
   t.same(err.res.headers, { 'x-attempt': 'second' }, 'keeps the terminal response headers')
   t.same(err.res.trailers, { 'x-terminal': 'yes' }, 'keeps the terminal response trailers')
+})
+
+test('response error keeps captured metadata when the inner status matches', async (t) => {
+  const headers = { 'content-type': 'text/plain', 'x-attempt': 'terminal' }
+  const innerError = Object.assign(new Error('response interrupted'), { statusCode: 503 })
+
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(503, headers, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err.statusCode, 503, 'keeps the matching terminal status')
+  t.equal(err.res.headers, headers, 'keeps headers captured for that status')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -22,8 +22,10 @@ test('response error preserves the terminal body-resume status', async (t) => {
         // response-retry does not expose these resume headers after the first
         // response's headers have reached the caller. It instead reports this
         // attempt's status on the terminal error.
-        handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
-        handler.onComplete([])
+        const shouldContinue = handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
+        if (shouldContinue !== false) {
+          handler.onComplete([])
+        }
       }
     },
     interceptors.responseRetry(),


### PR DESCRIPTION
## Why

`responseError` sits outside `responseRetry`. When a body-resume attempt failed with 503 after an earlier 200 was exposed, it overwrote the retry error's current status with the stale 200.

## Change

Prefer status metadata carried by the inner terminal error while retaining the original cause and decoration.

## Checks

- New composition regression — 5/5 assertions
- Response-error suites — 26 assertions
- Retry resume/deep suites — 108 assertions
- ESLint, Prettier, and `git diff --check`

## Ordering

Land #156 first so the retry error carries complete terminal response metadata.