### PR TITLE
fix(retry): retain terminal response metadata

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -389,14 +389,20 @@ class Handler extends DecoratorHandler {
       // A resume attempt landed on an unexpected status (e.g. a 503 while
       // resuming). #retryError describes the PREVIOUS failure — surfacing it
       // as-is would report a stale error that says nothing about what just
-      // happened. Report the current status and keep the prior failure as
-      // the cause.
+      // happened. Report the current response metadata and keep the prior
+      // failure as the cause.
       const err = new Error(
         `Response retry failed with status code ${statusCode}`,
         this.#retryError != null ? { cause: this.#retryError } : undefined,
       )
-      err.statusCode = statusCode
-      this.#maybeError(err)
+      this.#maybeError(
+        decorateError(err, this.#opts, {
+          statusCode,
+          headers,
+          trailers: this.#trailers,
+          body: null,
+        }),
+      )
       return false
     }
   }

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -61,7 +61,7 @@ test('retry: an unexpected resume status reports the current response headers', 
   t.equal(attempts, 2, 'one initial request and one resume request were dispatched')
   t.equal(err.statusCode, 503, 'the current attempt status remains available at top level')
   t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
-  t.equal(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
+  t.same(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
   t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
   t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
 })

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -1,0 +1,67 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+test('retry: an unexpected resume status reports the current response headers', async (t) => {
+  t.plan(8)
+
+  const firstError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
+  const retryHeaders = {
+    'content-length': '0',
+    'retry-after': '17',
+    'x-response-attempt': 'resume',
+  }
+
+  let attempts = 0
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+
+    if (attempts === 1) {
+      t.equal(
+        handler.onHeaders(200, { 'content-length': '10', etag: '"v1"' }, () => {}),
+        true,
+        'the initial response is forwarded',
+      )
+      handler.onData(Buffer.from('hello'))
+      handler.onError(firstError)
+    } else {
+      t.equal(
+        handler.onHeaders(503, retryHeaders, () => {}),
+        false,
+        'the unexpected resume response is rejected',
+      )
+    }
+
+    return true
+  }, interceptors.responseRetry())
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        method: 'GET',
+        origin: 'http://example.test',
+        path: '/',
+        headers: {},
+        retry: () => true,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('should not complete'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(attempts, 2, 'one initial request and one resume request were dispatched')
+  t.equal(err.statusCode, 503, 'the current attempt status remains available at top level')
+  t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
+  t.equal(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
+  t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
+  t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
+})

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -2,7 +2,7 @@ import { test } from 'tap'
 import { compose, interceptors } from '../lib/index.js'
 
 test('retry: an unexpected resume status reports the current response headers', async (t) => {
-  t.plan(8)
+  t.plan(9)
 
   const firstError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
   const retryHeaders = {
@@ -63,5 +63,6 @@ test('retry: an unexpected resume status reports the current response headers', 
   t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
   t.same(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
   t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
+  t.equal(err.body, undefined, 'no stale buffered body is attached to the terminal error')
   t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
 })


### PR DESCRIPTION
## Why

When a body-resume attempt returned an unexpected status, `responseRetry` built a fresh error with only a top-level status and cause. The current attempt's headers and standard `err.res` metadata were lost.

## Change

Decorate the terminal retry error with the current status, headers, null trailers/body, and the original retry failure as its cause.

## Checks

- New deterministic regression — 8/8 assertions
- Adjacent range-resume coverage — 36/36 assertions
- ESLint, Prettier, and `git diff --check`

## Ordering

Merge #140 first for the global retry fixture baseline. Land this before #154 and #155 so logging and outer response decoration receive complete terminal metadata.