### PR TITLE
test(types): add public declaration runner

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,7 +63,7 @@ export type { TraceWriter } from '@nxtedition/trace'
 import type { TraceWriter } from '@nxtedition/trace'
 
 export type BodyFactoryResult =
-  Readable | Uint8Array | string | Iterable<unknown> | AsyncIterable<unknown>
+  Readable | ArrayBuffer | ArrayBufferView | string | Iterable<unknown> | AsyncIterable<unknown>
 
 /** Called with an options object (not a bare signal); the signal aborts when the
  *  request is destroyed before the factory resolves. May be async. */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,6 +83,8 @@ export interface DispatchOptions {
   reset?: boolean | null
   blocking?: boolean | null
   timeout?: number | { headers?: number | null; body?: number | null } | null
+  /** Alias for `headersTimeout`. */
+  headerTimeout?: number | null
   headersTimeout?: number | null
   bodyTimeout?: number | null
   idempotent?: boolean | null
@@ -99,8 +101,11 @@ export interface DispatchOptions {
   /** Alias for `follow`; ignored when `follow` is also set. */
   redirect?: number | FollowFn | boolean | null
   error?: boolean | null
+  /** Alias for `error`; ignored when `error` is also set. */
+  throwOnError?: boolean | null
   verify?: VerifyOptions | boolean | null
   logger?: LoggerLike | null
+  userAgent?: string | null
   /** Per-request trace writer: undefined falls back to the per-thread writer
    *  installed via @nxtedition/trace's installTrace(), null disables tracing
    *  for this request. */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,6 +23,7 @@ export interface BodyReadable extends Readable {
 export type URLLike = string | URL | URLObject
 export type HeaderInput =
   Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
+export type OriginLike = URLLike | readonly URLLike[]
 
 export interface Dispatcher {
   dispatch(opts: object, handler: DispatchHandler): void
@@ -75,7 +76,7 @@ export type BodyFactory = (opts: {
 
 export interface DispatchOptions {
   id?: string | null
-  origin?: string | null
+  origin?: OriginLike | null
   path?: string | null
   method?: string | null
   body?: Readable | Uint8Array | string | BodyFactory | null
@@ -134,7 +135,7 @@ export type RetryFn = (
 export type FollowFn = (location: string, count: number, opts: DispatchOptions) => boolean
 
 export type LookupFn = (
-  origin: string | URLLike | Array<string | URLLike>,
+  origin: OriginLike,
   opts: { signal?: AbortSignal },
   callback: (err: Error | null, address: string | null) => void,
 ) => void | Promise<string>

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -182,6 +182,8 @@ export interface LogInterceptorOptions {
 }
 
 export interface PressureInterceptorOptions {
+  /** Trace writer for pressure episode documents; null disables tracing. */
+  trace?: TraceWriter | null
   /** Sampling interval for the internal EWMA loop, in ms (default 200).
    *  Set to 0 to disable the internal timer and drive sampling yourself via
    *  `sample()` from a loop you already run. */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -301,7 +301,7 @@ export interface CacheStore {
  *  upgrade attempt rejects with InvalidArgumentError — use dispatch() instead. */
 export interface RequestOptions extends Omit<DispatchOptions, 'upgrade'> {
   url?: URLLike | null
-  dispatch?: DispatchFn | null
+  dispatch?: DispatchFn | Dispatcher | null
   dispatcher?: Dispatcher | null
   /** highWaterMark for the response body readable (non-negative number). */
   highWaterMark?: number | null

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'node:stream'
+import type { EventEmitter } from 'node:events'
 import type { Priority } from '@nxtedition/scheduler'
 
 export interface URLObject {
@@ -24,6 +25,7 @@ export type URLLike = string | URL | URLObject
 export type HeaderInput =
   Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
 export type OriginLike = URLLike | readonly URLLike[]
+export type RequestSignal = AbortSignal | EventEmitter
 
 export interface Dispatcher {
   dispatch(opts: object, handler: DispatchHandler): void
@@ -82,7 +84,7 @@ export interface DispatchOptions {
   body?: Readable | Uint8Array | string | BodyFactory | null
   query?: Record<string, unknown> | null
   headers?: HeaderInput | null
-  signal?: AbortSignal | null
+  signal?: RequestSignal | null
   reset?: boolean | null
   blocking?: boolean | null
   timeout?: number | { headers?: number | null; body?: number | null } | null
@@ -136,7 +138,7 @@ export type FollowFn = (location: string, count: number, opts: DispatchOptions) 
 
 export type LookupFn = (
   origin: OriginLike,
-  opts: { signal?: AbortSignal },
+  opts: { signal?: RequestSignal },
   callback: (err: Error | null, address: string | null) => void,
 ) => void | Promise<string>
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,13 @@ export interface BodyReadable extends Readable {
   json(): Promise<unknown>
   arrayBuffer(): Promise<ArrayBuffer>
   blob(): Promise<Blob>
+  bytes(): Promise<Uint8Array>
+  /** Not implemented by @nxtedition/undici's BodyReadable; always rejects. */
+  formData(): Promise<never>
   dump(): Promise<void>
+  readonly bodyUsed: boolean
+  /** The Node.js BodyReadable does not expose a Fetch ReadableStream body. */
+  readonly body?: never
 }
 
 export type URLLike = string | URL | URLObject

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,14 +2,14 @@ import type { Readable } from 'node:stream'
 import type { Priority } from '@nxtedition/scheduler'
 
 export interface URLObject {
-  origin?: string | null
-  path?: string | null
-  host?: string | null
-  hostname?: string | null
-  port?: string | number | null
-  protocol?: string | null
-  pathname?: string | null
-  search?: string | null
+  readonly origin?: string | null
+  readonly path?: string | null
+  readonly host?: string | null
+  readonly hostname?: string | null
+  readonly port?: string | number | null
+  readonly protocol?: string | null
+  readonly pathname?: string | null
+  readonly search?: string | null
 }
 
 export interface BodyReadable extends Readable {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ export interface BodyReadable extends Readable {
 export type URLLike = string | URL | URLObject
 
 export interface Dispatcher {
-  dispatch(opts: object, handler: DispatchHandler): void
+  dispatch(opts: DispatchOptions, handler: DispatchHandler): void
 }
 
 export interface DispatchHandler {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -21,6 +21,8 @@ export interface BodyReadable extends Readable {
 }
 
 export type URLLike = string | URL | URLObject
+export type HeaderInput =
+  Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
 
 export interface Dispatcher {
   dispatch(opts: object, handler: DispatchHandler): void
@@ -78,7 +80,7 @@ export interface DispatchOptions {
   method?: string | null
   body?: Readable | Uint8Array | string | BodyFactory | null
   query?: Record<string, unknown> | null
-  headers?: Record<string, string | string[] | null | undefined> | null
+  headers?: HeaderInput | null
   signal?: AbortSignal | null
   reset?: boolean | null
   blocking?: boolean | null
@@ -330,9 +332,7 @@ export function compose(
 ): DispatchFn
 
 export function parseHeaders(
-  headers:
-    | Record<string, string | string[] | null | undefined>
-    | (Buffer | string | (Buffer | string)[])[],
+  headers?: HeaderInput | null,
   obj?: Record<string, string | string[]>,
 ): Record<string, string | string[]>
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "eslint",
       "prettier --write"
     ],
-    "*.{md,ts}": "prettier --write"
+    "*.md": "prettier --write",
+    "*.{ts,d.ts}": "prettier --write"
   },
   "prettier": {
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prettier": "^3.9.5",
     "send": "^1.2.1",
     "tap": "^21.7.4",
+    "typescript": "^5.9.3",
     "undici-types": "^8.7.0"
   },
   "scripts": {
@@ -40,10 +41,11 @@
     "test:coverage": "tap test --coverage-report=text --coverage-report=html"
   },
   "lint-staged": {
-    "*.{js,jsx,md,ts}": [
+    "*.{js,jsx}": [
       "eslint",
       "prettier --write"
-    ]
+    ],
+    "*.{md,ts}": "prettier --write"
   },
   "prettier": {
     "printWidth": 100,

--- a/test/public-types.js
+++ b/test/public-types.js
@@ -20,15 +20,21 @@ function findTypeScriptFiles(directory) {
     return []
   }
 
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name)
+  return readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => {
+      if (left.name < right.name) return -1
+      if (left.name > right.name) return 1
+      return 0
+    })
+    .flatMap((entry) => {
+      const path = join(directory, entry.name)
 
-    if (entry.isDirectory()) {
-      return findTypeScriptFiles(path)
-    }
+      if (entry.isDirectory()) {
+        return findTypeScriptFiles(path)
+      }
 
-    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : []
-  })
+      return entry.isFile() && entry.name.endsWith('.ts') ? [path] : []
+    })
 }
 
 const inputs = [

--- a/test/public-types.js
+++ b/test/public-types.js
@@ -7,7 +7,8 @@ import { test } from 'tap'
 
 const require = createRequire(import.meta.url)
 const tsc = require.resolve('typescript/bin/tsc')
-const root = fileURLToPath(new URL('..', import.meta.url))
+const testDirectory = dirname(fileURLToPath(import.meta.url))
+const root = resolve(testDirectory, '..')
 const undiciPackagePath = require.resolve('@nxtedition/undici/package.json')
 const undiciPackage = require(undiciPackagePath)
 const undiciTypes = undiciPackage.types ?? undiciPackage.typings

--- a/test/public-types.js
+++ b/test/public-types.js
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'tap'
+
+const require = createRequire(import.meta.url)
+const tsc = require.resolve('typescript/bin/tsc')
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+function findTypeScriptFiles(directory) {
+  if (!existsSync(directory)) {
+    return []
+  }
+
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return findTypeScriptFiles(path)
+    }
+
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : []
+  })
+}
+
+const inputs = [
+  join(root, 'test/type-stubs/upstream-undici.d.ts'),
+  join(root, 'lib/index.d.ts'),
+  ...findTypeScriptFiles(join(root, 'type-tests')),
+]
+
+test('public declarations compile', (t) => {
+  execFileSync(
+    process.execPath,
+    [
+      tsc,
+      '--noEmit',
+      '--strict',
+      '--target',
+      'ES2022',
+      '--module',
+      'NodeNext',
+      '--moduleResolution',
+      'NodeNext',
+      ...inputs,
+    ],
+    { cwd: root, stdio: 'inherit' },
+  )
+  t.pass('public declarations compiled')
+  t.end()
+})

--- a/test/public-types.js
+++ b/test/public-types.js
@@ -1,13 +1,18 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { test } from 'tap'
 
 const require = createRequire(import.meta.url)
 const tsc = require.resolve('typescript/bin/tsc')
 const root = fileURLToPath(new URL('..', import.meta.url))
+const undiciPackagePath = require.resolve('@nxtedition/undici/package.json')
+const undiciPackage = require(undiciPackagePath)
+const undiciTypes = undiciPackage.types ?? undiciPackage.typings
+const needsUndiciTypeStub =
+  typeof undiciTypes !== 'string' || !existsSync(resolve(dirname(undiciPackagePath), undiciTypes))
 
 function findTypeScriptFiles(directory) {
   if (!existsSync(directory)) {
@@ -26,7 +31,7 @@ function findTypeScriptFiles(directory) {
 }
 
 const inputs = [
-  join(root, 'test/type-stubs/upstream-undici.d.ts'),
+  ...(needsUndiciTypeStub ? [join(root, 'test/type-stubs/upstream-undici.d.ts')] : []),
   join(root, 'lib/index.d.ts'),
   ...findTypeScriptFiles(join(root, 'type-tests')),
 ]

--- a/test/type-stubs/upstream-undici.d.ts
+++ b/test/type-stubs/upstream-undici.d.ts
@@ -1,0 +1,10 @@
+// @nxtedition/undici@11.1.9 declares a missing index.d.ts in its package
+// metadata. Model the runtime exports used by this package so lib/index.d.ts
+// can still be checked without suppressing declaration-file errors globally.
+declare module '@nxtedition/undici' {
+  export const Client: typeof import('undici-types').Client
+  export const Pool: typeof import('undici-types').Pool
+  export const Agent: typeof import('undici-types').Agent
+  export const getGlobalDispatcher: typeof import('undici-types').getGlobalDispatcher
+  export const setGlobalDispatcher: typeof import('undici-types').setGlobalDispatcher
+}

--- a/type-tests/body-factory-binary.ts
+++ b/type-tests/body-factory-binary.ts
@@ -1,0 +1,7 @@
+import type { BodyFactory } from '../lib/index.js'
+
+const arrayBufferFactory: BodyFactory = () => new ArrayBuffer(8)
+const dataViewFactory: BodyFactory = () => new DataView(new ArrayBuffer(8))
+const typedArrayFactory: BodyFactory = () => new Uint16Array(4)
+
+void [arrayBufferFactory, dataViewFactory, typedArrayFactory]

--- a/type-tests/body-readable.ts
+++ b/type-tests/body-readable.ts
@@ -1,0 +1,13 @@
+import type { BodyReadable } from '../lib/index.js'
+
+async function consume(body: BodyReadable) {
+  const bytes: Uint8Array = await body.bytes()
+  const used: boolean = body.bodyUsed
+  // These deliberately mirror @nxtedition/undici's runtime: BodyReadable has
+  // no Fetch ReadableStream getter and formData() always rejects as unsupported.
+  const unsupportedBody: undefined = body.body
+  const unsupportedFormData: Promise<never> = body.formData()
+  return { bytes, used, unsupportedBody, unsupportedFormData }
+}
+
+void consume

--- a/type-tests/dispatcher-options.ts
+++ b/type-tests/dispatcher-options.ts
@@ -1,0 +1,9 @@
+import type { Dispatcher, DispatchHandler } from '../lib/index.js'
+
+declare const dispatcher: Dispatcher
+declare const handler: DispatchHandler
+
+dispatcher.dispatch({ origin: 'https://example.test', method: 'GET' }, handler)
+
+// @ts-expect-error Dispatcher options use the public DispatchOptions contract.
+dispatcher.dispatch({ unknownOption: true }, handler)

--- a/type-tests/event-emitter-signal.ts
+++ b/type-tests/event-emitter-signal.ts
@@ -1,0 +1,6 @@
+import { EventEmitter } from 'node:events'
+import type { RequestOptions } from '../lib/index.js'
+
+const options: RequestOptions = { signal: new EventEmitter() }
+
+void options

--- a/type-tests/header-input.ts
+++ b/type-tests/header-input.ts
@@ -5,4 +5,5 @@ const options: DispatchOptions = { headers }
 
 parseHeaders()
 parseHeaders(null)
+parseHeaders(headers)
 void options

--- a/type-tests/header-input.ts
+++ b/type-tests/header-input.ts
@@ -1,0 +1,8 @@
+import { parseHeaders, type DispatchOptions, type HeaderInput } from '../lib/index.js'
+
+const headers: HeaderInput = ['x-first', 'one', Buffer.from('x-second'), Buffer.from('two')]
+const options: DispatchOptions = { headers }
+
+parseHeaders()
+parseHeaders(null)
+void options

--- a/type-tests/origin-like.ts
+++ b/type-tests/origin-like.ts
@@ -1,4 +1,4 @@
-import type { DispatchOptions } from '../lib/index.js'
+import type { DispatchOptions, URLObject } from '../lib/index.js'
 
 const options: DispatchOptions = {
   origin: [
@@ -15,4 +15,11 @@ const readonlyOrigins = [
 ] as const
 const readonlyOptions: DispatchOptions = { origin: readonlyOrigins }
 
-void [options, readonlyOptions]
+const readonlyUrlObject = {
+  protocol: 'http:',
+  hostname: 'readonly.example.test',
+  port: 8080,
+} as const
+const urlObject: URLObject = readonlyUrlObject
+
+void [options, readonlyOptions, urlObject]

--- a/type-tests/origin-like.ts
+++ b/type-tests/origin-like.ts
@@ -1,0 +1,18 @@
+import type { DispatchOptions } from '../lib/index.js'
+
+const options: DispatchOptions = {
+  origin: [
+    'http://one.example.test',
+    new URL('http://two.example.test'),
+    { protocol: 'http:', hostname: 'three.example.test' },
+  ],
+}
+
+const readonlyOrigins = [
+  'http://one.example.test',
+  new URL('http://two.example.test'),
+  { protocol: 'http:', hostname: 'three.example.test' },
+] as const
+const readonlyOptions: DispatchOptions = { origin: readonlyOrigins }
+
+void [options, readonlyOptions]

--- a/type-tests/pressure-trace.ts
+++ b/type-tests/pressure-trace.ts
@@ -1,0 +1,7 @@
+import { interceptors, type TraceWriter } from '../lib/index.js'
+
+const trace: TraceWriter = { write: null }
+const pressure = interceptors.pressure({ trace })
+const disabledPressure = interceptors.pressure({ trace: null })
+pressure.close()
+disabledPressure.close()

--- a/type-tests/request-dispatcher-alias.ts
+++ b/type-tests/request-dispatcher-alias.ts
@@ -1,0 +1,8 @@
+import type { Dispatcher, RequestOptions } from '../lib/index.js'
+
+const dispatcher: Dispatcher = {
+  dispatch() {},
+}
+const options: RequestOptions = { dispatch: dispatcher }
+
+void options

--- a/type-tests/request-runtime-options.ts
+++ b/type-tests/request-runtime-options.ts
@@ -1,0 +1,9 @@
+import type { RequestOptions } from '../lib/index.js'
+
+const options: RequestOptions = {
+  headerTimeout: 1000,
+  throwOnError: false,
+  userAgent: 'type-test/1.0',
+}
+
+void options


### PR DESCRIPTION
## Summary

- add a recursive, cross-platform public declaration fixture runner
- compile `lib/index.d.ts` even when `type-tests/` is absent
- make TypeScript a direct development dependency and show compiler failures in CI
- keep TypeScript fixtures out of ESLint while continuing to format them

## Why

The type-focused pull requests each carried a copy of a brittle runner that relied on a transitive TypeScript install, recursive `readdir`, `skipLibCheck`, and piped compiler output. Centralizing the corrected harness gives those PRs one stable base and ensures declaration errors are actually checked.

`@nxtedition/undici@11.1.9` advertises an `index.d.ts` that is absent from its package tarball, so the test includes a narrow declaration stub for the five runtime exports re-exported by this package.

## Validation

- `node test/public-types.js`
- `npm exec -- eslint test/public-types.js`
- `npm exec -- prettier --check package.json test/public-types.js test/type-stubs/upstream-undici.d.ts`
- `npx lint-staged`
