### PR TITLE
fix(types): accept readonly URL-shaped origins

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,14 +2,14 @@ import type { Readable } from 'node:stream'
 import type { Priority } from '@nxtedition/scheduler'
 
 export interface URLObject {
-  origin?: string | null
-  path?: string | null
-  host?: string | null
-  hostname?: string | null
-  port?: string | number | null
-  protocol?: string | null
-  pathname?: string | null
-  search?: string | null
+  readonly origin?: string | null
+  readonly path?: string | null
+  readonly host?: string | null
+  readonly hostname?: string | null
+  readonly port?: string | number | null
+  readonly protocol?: string | null
+  readonly pathname?: string | null
+  readonly search?: string | null
 }
 
 export interface BodyReadable extends Readable {

--- a/type-tests/origin-like.ts
+++ b/type-tests/origin-like.ts
@@ -1,4 +1,4 @@
-import type { DispatchOptions } from '../lib/index.js'
+import type { DispatchOptions, URLObject } from '../lib/index.js'
 
 const options: DispatchOptions = {
   origin: [
@@ -15,4 +15,11 @@ const readonlyOrigins = [
 ] as const
 const readonlyOptions: DispatchOptions = { origin: readonlyOrigins }
 
-void [options, readonlyOptions]
+const readonlyUrlObject = {
+  protocol: 'http:',
+  hostname: 'readonly.example.test',
+  port: 8080,
+} as const
+const urlObject: URLObject = readonlyUrlObject
+
+void [options, readonlyOptions, urlObject]


### PR DESCRIPTION
## Summary

- mark URL-shaped origin input fields as readonly
- exercise direct assignment of an `as const` URL-shaped object

Follow-up to the post-merge Copilot review on #128: https://github.com/nxtedition/nxt-undici/pull/128#pullrequestreview-4674881123

## Verification

- `npx tap --disable-coverage test/public-types.js`
- `npx prettier --check lib/index.d.ts type-tests/origin-like.ts`