### PR TITLE
test(types): cover EventEmitter signal entry points

### DIFF
--- a/type-tests/event-emitter-signal.ts
+++ b/type-tests/event-emitter-signal.ts
@@ -1,6 +1,12 @@
 import { EventEmitter } from 'node:events'
-import type { RequestOptions } from '../lib/index.js'
+import type { DispatchOptions, LookupFn, RequestOptions } from '../lib/index.js'
 
-const options: RequestOptions = { signal: new EventEmitter() }
+const signal = new EventEmitter()
+const requestOptions: RequestOptions = { signal }
+const dispatchOptions: DispatchOptions = { signal }
+const lookup: LookupFn = (_origin, _options, callback) => {
+  callback(null, 'http://resolved.example.test')
+}
+lookup('http://service.example.test', { signal }, () => {})
 
-void options
+void [requestOptions, dispatchOptions]


### PR DESCRIPTION
## Summary

- assert `EventEmitter` signals are accepted by `DispatchOptions`
- call a typed `LookupFn` with an `EventEmitter` signal
- retain the existing `RequestOptions` signal assertion

## Why

This follows up on Copilot review thread `PRRT_kwDOKihlYM6QAmOu` from PR #129. The type change covered all three entry points, but its fixture only protected `RequestOptions`.

## Validation

- `node test/public-types.js`
- `npm exec -- prettier --check type-tests/event-emitter-signal.ts`
- pre-commit lint-staged checks
