### PR TITLE
test(types): use resolver address fixture

### DIFF
--- a/type-tests/event-emitter-signal.ts
+++ b/type-tests/event-emitter-signal.ts
@@ -5,7 +5,7 @@ const signal = new EventEmitter()
 const requestOptions: RequestOptions = { signal }
 const dispatchOptions: DispatchOptions = { signal }
 const lookup: LookupFn = (_origin, _options, callback) => {
-  callback(null, 'http://resolved.example.test')
+  callback(null, '127.0.0.1')
 }
 lookup('http://service.example.test', { signal }, () => {})
 


### PR DESCRIPTION
## Summary

Use an address value (`127.0.0.1`) in the `LookupFn` type fixture instead of a URL. The lookup callback contract returns an address, and the broader EventEmitter signal coverage from the earlier stacked PR is already present on `main` via #164.

## Context

This PR was rebased after #164 and now contains only the remaining Copilot-requested fixture correction. It is stacked on #165 for the current review batch.

## Verification

- public declaration runner passes
- Prettier and diff checks pass
- ESLint reports only that the standalone type fixture is outside its configured file set