### PR TITLE
test(response-error): expect null reset trailers

### DIFF
--- a/test/response-error-reset-trailers.js
+++ b/test/response-error-reset-trailers.js
@@ -26,6 +26,6 @@ test('response-error does not leak trailers across reconnects', (t) => {
 
   t.equal(errors.length, 2)
   t.strictSame(errors[0].res.trailers, { 'x-first-trailer': 'present' })
-  t.equal(errors[1].res.trailers, undefined)
+  t.equal(errors[1].res.trailers, null, 'reset trailers use empty response metadata')
   t.end()
 })


### PR DESCRIPTION
## Summary

- align the reconnect regression with the post-review null trailer sentinel now on main
- keep asserting that trailers from the previous attempt cannot leak

## Verification

- `npx tap --disable-coverage test/response-error-reset-trailers.js`
- ESLint and Prettier on the fixture