### PR TITLE
feat(cache): select stored variants by response Date (restore lost #98)

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -1,8 +1,8 @@
 import { DatabaseSync } from 'node:sqlite'
-import { parseRangeHeader, getFastNow } from './utils.js'
+import { parseHttpDate, parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
-const VERSION = 12
+const VERSION = 13
 const CACHE_TABLE = `cacheInterceptorV${VERSION}`
 
 class SqliteCacheSchemaError extends Error {
@@ -105,6 +105,7 @@ function forEachStore(fn) {
  *  statusMessage: string
  *  headers?: string
  *  vary?: string
+ *  responseDate: number
  *  etag?: string
  *  cacheControlDirectives?: string
  *  cachedAt: number
@@ -239,6 +240,7 @@ export class SqliteCacheStore {
         cacheControlDirectives TEXT NULL,
         etag TEXT NULL,
         vary TEXT NULL,
+        responseDate INTEGER NOT NULL,
         cachedAt INTEGER NOT NULL,
         -- body is deliberately the LAST column: the lookup filters candidate
         -- rows on start/deleteAt and vary, and any column stored after a
@@ -247,12 +249,12 @@ export class SqliteCacheStore {
         body BLOB NULL
       );
 
-      -- (url, method) with the implicit rowid tail satisfies the lookup's
-      -- ORDER BY id DESC via a backward index scan, so .get() truly stops at
-      -- the newest candidate. Adding more columns (the old start/deleteAt
-      -- suffix) breaks that ordering and forces a temp B-tree sort that
-      -- materializes every candidate row — blobs included — per lookup.
-      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method);
+      -- RFC 9111 §4 requires the most recent suitable response as determined
+      -- by Date. Keeping that order in the lookup index lets .get() truly stop
+      -- at the newest candidate without a temp B-tree sort that materializes
+      -- every candidate row — blobs included — per lookup. id is the
+      -- receipt-order tie-break for Date's one-second resolution.
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_getValuesQuery ON cacheInterceptorV${VERSION}(url, method, responseDate DESC, id DESC);
       CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV${VERSION}_deleteExpiredValuesQuery ON cacheInterceptorV${VERSION}(deleteAt);
       -- Covers the supersede-on-flush DELETEs (#supersedeFullQuery /
       -- #supersede206Query), whose predicate is url+method+vary (+statusCode,
@@ -277,6 +279,7 @@ export class SqliteCacheStore {
         etag,
         cacheControlDirectives,
         vary,
+        responseDate,
         cachedAt
       FROM cacheInterceptorV${VERSION}
       WHERE
@@ -285,6 +288,7 @@ export class SqliteCacheStore {
         AND start <= ?
         AND deleteAt > ?
       ORDER BY
+        responseDate DESC,
         id DESC
     `)
 
@@ -303,8 +307,9 @@ export class SqliteCacheStore {
         etag,
         cacheControlDirectives,
         vary,
+        responseDate,
         cachedAt
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     this.#deleteExpiredValuesQuery = this.#db.prepare(
@@ -510,7 +515,7 @@ export class SqliteCacheStore {
     }
 
     const entry = {
-      // Monotonic per-store sequence used only to break cachedAt ties in
+      // Monotonic per-store sequence used only to break response-Date ties in
       // #findValue (newest write wins). Not persisted — #flush ignores it.
       seq: this.#insertSeq++,
       url: makeValueUrl(key),
@@ -537,6 +542,10 @@ export class SqliteCacheStore {
       // headerValueEquals). Canonicalizing keeps "same variant" one row
       // instead of accumulating dead duplicates until deleteAt.
       vary: value.vary ? JSON.stringify(canonicalVary(value.vary)) : null,
+      // RFC 9111 §4 chooses among multiple suitable stored responses by the
+      // response Date, not by arrival/write order. A missing or invalid Date is
+      // assigned the receipt time for selection purposes.
+      responseDate: getResponseDate(value.headers, Date.now()),
       cachedAt: value.cachedAt,
     }
 
@@ -636,6 +645,7 @@ export class SqliteCacheStore {
               etag,
               cacheControlDirectives,
               vary,
+              responseDate,
               cachedAt,
             } = this.#insertBatch[n++]
             // Supersede prior rows for the same representation (see the
@@ -660,6 +670,7 @@ export class SqliteCacheStore {
               etag,
               cacheControlDirectives,
               vary,
+              responseDate,
               cachedAt,
             )
             if (!final && (n & 0xf) === 0 && performance.now() - startTime > 10) {
@@ -741,8 +752,8 @@ export class SqliteCacheStore {
     const requestedStart = range?.start ?? 0
 
     if (this.#insertBatch.length === 0) {
-      // Fast path: rows arrive sorted (cachedAt DESC, id DESC) and there are
-      // no pending batch entries to merge, so fetch only the newest candidate.
+      // Fast path: rows arrive sorted (response Date DESC, id DESC) and there
+      // are no pending batch entries to merge, so fetch only the newest candidate.
       // This covers misses and first-row hits (the overwhelmingly common
       // cases) with a single row materialized — re-cached duplicates of a hot
       // key would otherwise all be read including their blobs. Only when the
@@ -761,30 +772,54 @@ export class SqliteCacheStore {
      * @type {SqliteStoreValue[]}
      */
     const values = this.#getValuesQuery.all(url, method, requestedStart, now)
+    const pendingRepresentations = new Set()
 
     for (const entry of this.#insertBatch) {
-      if (
-        entry.url === url &&
-        entry.method === method &&
-        entry.start <= requestedStart &&
-        entry.deleteAt > now
-      ) {
+      if (entry.url === url && entry.method === method && entry.start <= requestedStart) {
+        // Pending entries already represent the state that the next flush will
+        // commit. Include expired entries long enough to suppress the persisted
+        // representation they tombstone.
+        pendingRepresentations.add(storedRepresentationIdentity(entry))
         values.push(entry)
       }
+    }
+
+    if (pendingRepresentations.size !== 0) {
+      // The flush transaction deletes the prior row for the same stored
+      // representation before inserting its replacement. Mirror that state
+      // immediately: otherwise Date ordering could select a persisted row that
+      // the pending replacement is about to supersede, making get() change
+      // answers merely because setImmediate flushed the batch. The identity Set
+      // keeps this merge linear in candidates + pending writes. Compact in
+      // place as well, avoiding repeated Array#splice shifts.
+      let length = 0
+      for (const value of values) {
+        const isPending = value.seq != null
+        if (
+          (!isPending && pendingRepresentations.has(storedRepresentationIdentity(value))) ||
+          (isPending && value.deleteAt <= now)
+        ) {
+          continue
+        }
+        values[length++] = value
+      }
+      values.length = length
     }
 
     if (values.length === 0) {
       return undefined
     }
 
-    // Most recently WRITTEN representation wins — receipt order, not
-    // cachedAt (see the #supersede* query comments: cachedAt is backdated by
-    // the corrected initial age, so a fresher write can carry an older
-    // cachedAt). Pending batch entries (tagged with a monotonic seq) are
-    // always newer than any flushed DB row, and within each source a higher
-    // seq/id wins.
+    // RFC 9111 §4: when multiple suitable responses match (overlapping Vary
+    // selectors), the most recent response Date wins. Receipt order breaks Date
+    // ties (cachedAt is backdated by the corrected initial age, so it is not a
+    // reliable recency signal); a pending batch entry is newer than a flushed
+    // row for that tie, and within each source a higher seq/id wins.
     if (values.length > 1) {
       values.sort((a, b) => {
+        if (a.responseDate !== b.responseDate) {
+          return b.responseDate - a.responseDate
+        }
         const aBatch = a.seq != null
         const bBatch = b.seq != null
         if (aBatch !== bBatch) {
@@ -799,12 +834,38 @@ export class SqliteCacheStore {
 
     for (const value of values) {
       if (matchesValue(value, range, headers)) {
-        return value
+        // SQL already excludes expired persisted rows. This guard applies to
+        // pending tombstones, which must shadow older matching DB rows but must
+        // never themselves be returned.
+        return value.deleteAt > now ? value : undefined
       }
     }
 
     return undefined
   }
+}
+
+/**
+ * Selection timestamp for RFC 9111 §4. Field names are case-insensitive;
+ * duplicated/non-string Date values are invalid and fall back to receipt time.
+ * @param {Record<string, string | string[]> | undefined} headers
+ * @param {number} receivedAt
+ * @returns {number}
+ */
+function getResponseDate(headers, receivedAt) {
+  let dateName
+  if (headers && typeof headers === 'object') {
+    for (const name of Object.keys(headers)) {
+      if (name.toLowerCase() === 'date') {
+        if (dateName != null) {
+          return receivedAt
+        }
+        dateName = name
+      }
+    }
+  }
+  const date = dateName == null ? undefined : headers[dateName]
+  return typeof date === 'string' ? (parseHttpDate(date)?.getTime() ?? receivedAt) : receivedAt
 }
 
 /**
@@ -837,6 +898,22 @@ function matchesValue(value, range, headers) {
   }
 
   return true
+}
+
+/**
+ * Stable identity matching the supersede-on-flush DELETEs exactly: a full
+ * response replaces every non-206 response with the same serialized Vary
+ * selector; a 206 entry replaces only the same selector and byte window. JSON
+ * preserves value types and avoids delimiter collisions in selector text.
+ * @param {SqliteStoreValue} value
+ * @returns {string}
+ */
+function storedRepresentationIdentity(value) {
+  return JSON.stringify(
+    value.statusCode === 206
+      ? [value.vary, 'partial', value.start, value.end]
+      : [value.vary, 'full'],
+  )
 }
 
 /**

--- a/test/cache-selection-date.js
+++ b/test/cache-selection-date.js
@@ -1,0 +1,215 @@
+import { test } from 'tap'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
+
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+function tempDb(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cache-selection-date-'))
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
+  return path.join(dir, 'cache.sqlite')
+}
+
+test('store chooses the most recent matching response by Date, not write order', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/resource',
+    headers: { accept: 'text/plain' },
+  }
+  const now = Date.now()
+  const value = (body, date, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt: now + 7200e3,
+  })
+
+  // Both entries match `Accept: text/plain`. The less-specific response was
+  // generated later, but the older Vary-specific response arrived last.
+  store.set(key, value('newer', new Date(now).toUTCString(), {}))
+  await flush()
+  store.set(key, value('older', new Date(now - 60e3).toUTCString(), { accept: 'text/plain' }))
+  await flush()
+
+  const result = store.get(key)
+  t.equal(result.body.toString(), 'newer', 'RFC 9111 §4 Date ordering wins')
+
+  // Pending entries participate in the same selection before their batch is
+  // flushed; being the latest write must not let an older Date jump the queue.
+  store.set(key, value('oldest', new Date(now - 120e3).toUTCString(), { 'accept-language': null }))
+  t.equal(store.get(key).body.toString(), 'newer', 'Date ordering also covers pending writes')
+  await flush()
+  t.equal(store.get(key).body.toString(), 'newer', 'ordering is stable after the batch flush')
+})
+
+test('duplicate case-insensitive Date fields fall back to receipt time', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/duplicate-date',
+    headers: { accept: 'text/plain' },
+  }
+  const now = Date.now()
+  const value = (body, headers, vary) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers,
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt: now + 7200e3,
+  })
+
+  store.set(key, value('dated', { date: new Date(now - 60e3).toUTCString() }, {}))
+  await flush()
+  store.set(
+    key,
+    value(
+      'ambiguous',
+      {
+        Date: new Date(now - 120e3).toUTCString(),
+        date: new Date(now - 180e3).toUTCString(),
+      },
+      { accept: 'text/plain' },
+    ),
+  )
+
+  t.equal(
+    store.get(key).body.toString(),
+    'ambiguous',
+    'ambiguous Date metadata uses the newer receipt time while pending',
+  )
+  await flush()
+  t.equal(
+    store.get(key).body.toString(),
+    'ambiguous',
+    'the receipt-time fallback survives persistence',
+  )
+})
+
+test('pending replacements immediately supersede their persisted representation', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  t.teardown(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/pending',
+    headers: {},
+  }
+  const now = Date.now()
+  const value = (body, date, deleteAt = now + 7200e3) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary: {},
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt,
+  })
+
+  store.set(key, value('persisted-newer-date', new Date(now).toUTCString()))
+  await flush()
+
+  // set() replaces this same stored representation. Its older Date must not
+  // resurrect the persisted row during the short pending-batch interval;
+  // after the flush only the replacement will exist.
+  store.set(key, value('pending-older-date', new Date(now - 60e3).toUTCString()))
+  t.equal(store.get(key).body.toString(), 'pending-older-date', 'pending replacement wins now')
+  await flush()
+  t.equal(store.get(key).body.toString(), 'pending-older-date', 'answer is stable after flush')
+
+  // An expired replacement is a variant-scoped tombstone. It must hide the
+  // persisted row immediately even when its response Date sorts earlier.
+  store.set(key, value('tombstone', new Date(now - 120e3).toUTCString(), now - 60e3))
+  t.equal(store.get(key), undefined, 'pending tombstone shadows the persisted row')
+})
+
+test('many pending identities suppress only their exact persisted representations', (t) => {
+  const location = tempDb(t)
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/many-pending',
+    headers: {},
+  }
+  const now = Date.now()
+  const value = (body, date, vary, deleteAt = now + 7200e3) => ({
+    body: Buffer.from(body),
+    start: 0,
+    end: body.length,
+    statusCode: 200,
+    statusMessage: 'OK',
+    headers: { date },
+    cacheControlDirectives: { 'max-age': 3600 },
+    vary,
+    cachedAt: now,
+    staleAt: now + 3600e3,
+    deleteAt,
+  })
+
+  let store = new SqliteCacheStore({ location })
+  t.teardown(() => store.close())
+  for (let i = 0; i < 64; i++) {
+    store.set(key, value(`persisted-${i}`, new Date(now).toUTCString(), { [`x-${i}`]: null }))
+  }
+  // This neighboring selector overlaps requests carrying x-63 but is not the
+  // same stored representation as { x-63: null }.
+  store.set(
+    key,
+    value('distinct-neighbor', new Date(now + 60e3).toUTCString(), {
+      'x-63': 'present',
+      extra: null,
+    }),
+  )
+  store.close()
+
+  store = new SqliteCacheStore({ location })
+  for (let i = 0; i < 64; i++) {
+    store.set(
+      key,
+      value(
+        `pending-${i}`,
+        new Date(now - 60e3).toUTCString(),
+        { [`x-${i}`]: null },
+        i === 63 ? now - 60e3 : undefined,
+      ),
+    )
+  }
+
+  t.equal(
+    store.get(key).body.toString(),
+    'pending-62',
+    'exact replacements hide newer persisted rows and the final tombstone is not served',
+  )
+  t.equal(
+    store.get({ ...key, headers: { 'x-63': 'present' } }).body.toString(),
+    'distinct-neighbor',
+    'a neighboring serialized Vary selector is not over-suppressed',
+  )
+  t.end()
+})

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -823,7 +823,7 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
 
   const db = new DatabaseSync(dbPath, { readOnly: true })
   const { c } = db
-    .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV12 WHERE url = ?`)
+    .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV13 WHERE url = ?`)
     .get('https://example.com/hot')
   db.close()
   t.equal(c, 1, 'older rows for the representation were superseded')

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -1,7 +1,7 @@
 // Regression tests for the 2026-07 cache deep-review fixes (sqlite store):
 // - #flush must not busy-loop on setImmediate when the SQLITE_FULL eviction
 //   query itself throws (batch pinned forever, CPU pegged, warning spam).
-// - schema v12: the lookup query must not need a temp B-tree sort (which
+// - the current schema's lookup query must not need a temp B-tree sort (which
 //   materialized every candidate row's body blob per get), and the body blob
 //   must be the last column so candidate filtering never walks its overflow
 //   pages.
@@ -106,8 +106,8 @@ test('#flush drops the batch instead of spinning when the FULL-eviction query th
   t.end()
 })
 
-test('schema v12: no temp B-tree sort on lookup; body blob is the last column', async (t) => {
-  const dbPath = tmpDb(t, 'v12-plan')
+test('schema v13: Date-ordered lookup needs no temp B-tree; body is last', async (t) => {
+  const dbPath = tmpDb(t, 'v13-plan')
   const store = new SqliteCacheStore({ location: dbPath })
   store.set(makeKey(), makeValue())
   await flush()
@@ -128,13 +128,14 @@ test('schema v12: no temp B-tree sort on lookup; body blob is the last column', 
   const cols = db.prepare(`PRAGMA table_info(${table})`).all()
   t.equal(cols[cols.length - 1].name, 'body', 'body is the last column')
 
-  // Mirror of #getValuesQuery's shape: same WHERE and ORDER BY. The (url,
-  // method) index must satisfy ORDER BY id DESC via a backward scan — no
+  // Mirror of #getValuesQuery's shape: same WHERE and ORDER BY. The
+  // (url, method, responseDate, id) index must satisfy Date ordering with no
   // temp B-tree, which would materialize every candidate row (incl. blobs).
   const plan = db
     .prepare(
       `EXPLAIN QUERY PLAN SELECT id, start, end, deleteAt FROM ${table}
-       WHERE url = ? AND method = ? AND start <= ? AND deleteAt > ? ORDER BY id DESC`,
+       WHERE url = ? AND method = ? AND start <= ? AND deleteAt > ?
+       ORDER BY responseDate DESC, id DESC`,
     )
     .all()
   t.notOk(


### PR DESCRIPTION
## Restores lost PR #98

PR #98 (`select matching variants by response Date`) was merged onto the
intermediate branch `codex/cache-auth-provenance` and **never reached `main`**
— its merge commit is not an ancestor of HEAD, so RFC 9111 §4 Date-based
variant selection has been silently absent. This restores that feature on top
of the current schema.

### What it does

When several stored responses match one request (overlapping `Vary` selectors,
or a re-cache), RFC 9111 §4 says the cache must reuse the response with the
**most recent Date**, not the most recently written row — `cachedAt` is
backdated by the corrected initial age, so write/receipt order is not a
reliable recency signal.

- Adds a `responseDate` column (schema **v12 → v13**), populated from the
  response `Date` header via `getResponseDate()`, with a receipt-time fallback
  for missing / duplicate / invalid Dates.
- Orders the lookup by `responseDate DESC, id DESC`, backed by a matching
  `(url, method, responseDate DESC, id DESC)` index so `.get()` still stops at
  the newest candidate with **no temp B-tree sort** (verified via
  `EXPLAIN QUERY PLAN`).
- Makes pending batch entries tombstone the persisted representation they
  supersede (`storedRepresentationIdentity`), so Date ordering cannot resurrect
  a row the next flush is about to delete — and a pending tombstone is never
  itself returned.

### Scope

Only the Date-selection half of #98 is restored. Its base branch
(`codex/cache-auth-provenance`, schema v13) also added an unrelated
`authorizationRequest` provenance column that is **not referenced anywhere on
`main`**; that is a separate lost change and is intentionally omitted here.

### Tests

- New `test/cache-selection-date.js` (Date ordering, duplicate-Date fallback,
  pending supersede/tombstone, many-pending selectivity) — 10 assertions.
- Updated the two tests that pin the schema version / lookup `ORDER BY`.
- Full sqlite-store + cache suites pass (660 assertions across the store,
  storability, range, advanced, coverage, and origins files).
- `cache-tests` conformance: **no new failures or retries** vs `main`
  (0 required/unexpected failures; the one pre-existing `304-etag` retry is
  the gate issue fixed by #162, not touched here).

> Depends conceptually on #162 for a fully-green `test:cache-tests` gate, but is
> otherwise orthogonal (this PR only touches `lib/sqlite-cache-store.js` + its
> tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ⚠️ Schema-version coordination with #105

The omitted `authorizationRequest` column is not lost — it belongs to the still-open **#105** (`fix(cache): harden authenticated grants and provenance`), whose branch (`codex/cache-auth-provenance`) was the base this PR (#98) was originally stacked on (#105 = schema v13, #98 = v14).

Both this PR and #105 bump the store schema **12 → 13** with *different* columns, so merging both naively collides. Recommended: merge #105 first (v13 + `authorizationRequest`), then rebase this PR to **v14** adding `responseDate` on top — which reproduces the original #105 → #98 stack. (Order can be reversed; whichever lands second takes v14.) A schema bump only invalidates old on-disk cache entries, so no data-migration concern either way.