### PR TITLE
test(types): cover EventEmitter signal entry points (restore lost #159)

### DIFF
--- a/type-tests/event-emitter-signal.ts
+++ b/type-tests/event-emitter-signal.ts
@@ -1,6 +1,12 @@
 import { EventEmitter } from 'node:events'
-import type { RequestOptions } from '../lib/index.js'
+import type { DispatchOptions, LookupFn, RequestOptions } from '../lib/index.js'
 
-const options: RequestOptions = { signal: new EventEmitter() }
+const signal = new EventEmitter()
+const requestOptions: RequestOptions = { signal }
+const dispatchOptions: DispatchOptions = { signal }
+const lookup: LookupFn = (_origin, _options, callback) => {
+  callback(null, 'http://resolved.example.test')
+}
+lookup('http://service.example.test', { signal }, () => {})
 
-void options
+void [requestOptions, dispatchOptions]


### PR DESCRIPTION
## Restores lost PR #159

PR #159 was merged onto the intermediate branch
`codex/types-event-emitter-signal-coverage` and **never reached `main`** (its
merge commit is not an ancestor of HEAD), so its expanded type-test coverage
was lost. On `main`, `type-tests/event-emitter-signal.ts` only asserts that an
`EventEmitter`-style signal is accepted on `RequestOptions`.

This restores the broader coverage: an `EventEmitter` signal must also type-check
on `DispatchOptions` and in the `LookupFn` options bag — matching the runtime,
which accepts any `on`/`off` (or `addListener`/`removeListener`) object as a
signal. Test-only; compiles cleanly via the public declaration runner
(`test/public-types.js`).

Third of the PRs found to have been merged onto dead intermediate branches
(see also #162 for #66's live bugs and #163 for #98's Date-based variant
selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)