### PR TITLE
fix(retry): retain terminal response metadata

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -99,7 +99,15 @@ class Handler extends DecoratorHandler {
     // metadata for a response that this outer handler never saw (for example,
     // the failed range-resume attempt hidden by response-retry). Keep that
     // response as a unit instead of replacing it with stale captured metadata.
-    if (err?.res != null && typeof err.res === 'object') {
+    const hasResponseMetadata =
+      err?.res != null &&
+      typeof err.res === 'object' &&
+      !Array.isArray(err.res) &&
+      Object.hasOwn(err.res, 'statusCode') &&
+      Object.hasOwn(err.res, 'headers') &&
+      Object.hasOwn(err.res, 'trailers')
+
+    if (hasResponseMetadata) {
       err.statusCode ??= err.res.statusCode
       err.req ??= {
         path: this.#opts.path,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -95,9 +95,16 @@ class Handler extends DecoratorHandler {
       return
     }
 
+    // An inner response decorator can know more than this outer handler. In
+    // particular, response-retry hides a failed body-resume response's headers
+    // after the original response headers have already been exposed, and puts
+    // the resume attempt's status on the terminal error. Do not overwrite that
+    // current status with the earlier response status observed here.
+    const statusCode = err?.statusCode ?? (this.#statusCode || undefined)
+
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode: this.#statusCode || undefined,
+        statusCode,
         headers: this.#headers,
         trailers: this.#trailers,
         body: null,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -95,18 +95,28 @@ class Handler extends DecoratorHandler {
       return
     }
 
+    // An inner response interceptor may already have decorated the error with
+    // metadata for a response that this outer handler never saw (for example,
+    // the failed range-resume attempt hidden by response-retry). Keep that
+    // response as a unit instead of replacing it with stale captured metadata.
+    if (err?.res != null) {
+      super.onError(err)
+      return
+    }
+
     // An inner response decorator can know more than this outer handler. In
     // particular, response-retry hides a failed body-resume response's headers
     // after the original response headers have already been exposed, and puts
     // the resume attempt's status on the terminal error. Do not overwrite that
-    // current status with the earlier response status observed here.
-    const statusCode = err?.statusCode ?? (this.#statusCode || undefined)
+    // current status with the earlier response status observed here, or pair
+    // that status with headers/trailers from the earlier response.
+    const hasInnerStatus = err?.statusCode != null
 
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode,
-        headers: this.#headers,
-        trailers: this.#trailers,
+        statusCode: hasInnerStatus ? err.statusCode : this.#statusCode || undefined,
+        headers: hasInnerStatus ? null : this.#headers,
+        trailers: hasInnerStatus ? null : this.#trailers,
         body: null,
       }),
     )

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -99,7 +99,7 @@ class Handler extends DecoratorHandler {
     // metadata for a response that this outer handler never saw (for example,
     // the failed range-resume attempt hidden by response-retry). Keep that
     // response as a unit instead of replacing it with stale captured metadata.
-    if (err?.res != null) {
+    if (err?.res != null && typeof err.res === 'object') {
       err.statusCode ??= err.res.statusCode
       err.req ??= {
         path: this.#opts.path,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -108,7 +108,9 @@ class Handler extends DecoratorHandler {
       Object.hasOwn(err.res, 'trailers')
 
     if (hasResponseMetadata) {
-      err.statusCode ??= err.res.statusCode
+      if (!Number.isFinite(err.statusCode) && Number.isFinite(err.res.statusCode)) {
+        err.statusCode = err.res.statusCode
+      }
       err.req ??= {
         path: this.#opts.path,
         origin: this.#opts.origin,
@@ -125,11 +127,12 @@ class Handler extends DecoratorHandler {
     // the resume attempt's status on the terminal error. Do not overwrite that
     // current status with the earlier response status observed here, or pair
     // that status with headers/trailers from the earlier response.
-    const hasDifferentStatus = err?.statusCode != null && err.statusCode !== this.#statusCode
+    const innerStatusCode = Number.isFinite(err?.statusCode) ? err.statusCode : undefined
+    const hasDifferentStatus = innerStatusCode != null && innerStatusCode !== this.#statusCode
 
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode: err?.statusCode ?? (this.#statusCode || undefined),
+        statusCode: innerStatusCode ?? (this.#statusCode || undefined),
         headers: hasDifferentStatus ? null : this.#headers,
         trailers: hasDifferentStatus ? null : this.#trailers,
         body: null,

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -100,6 +100,13 @@ class Handler extends DecoratorHandler {
     // the failed range-resume attempt hidden by response-retry). Keep that
     // response as a unit instead of replacing it with stale captured metadata.
     if (err?.res != null) {
+      err.statusCode ??= err.res.statusCode
+      err.req ??= {
+        path: this.#opts.path,
+        origin: this.#opts.origin,
+        method: this.#opts.method,
+        headers: this.#opts.headers,
+      }
       super.onError(err)
       return
     }
@@ -110,13 +117,13 @@ class Handler extends DecoratorHandler {
     // the resume attempt's status on the terminal error. Do not overwrite that
     // current status with the earlier response status observed here, or pair
     // that status with headers/trailers from the earlier response.
-    const hasInnerStatus = err?.statusCode != null
+    const hasDifferentStatus = err?.statusCode != null && err.statusCode !== this.#statusCode
 
     super.onError(
       decorateError(err, this.#opts, {
-        statusCode: hasInnerStatus ? err.statusCode : this.#statusCode || undefined,
-        headers: hasInnerStatus ? null : this.#headers,
-        trailers: hasInnerStatus ? null : this.#trailers,
+        statusCode: err?.statusCode ?? (this.#statusCode || undefined),
+        headers: hasDifferentStatus ? null : this.#headers,
+        trailers: hasDifferentStatus ? null : this.#trailers,
         body: null,
       }),
     )

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -108,14 +108,19 @@ class Handler extends DecoratorHandler {
       Object.hasOwn(err.res, 'trailers')
 
     if (hasResponseMetadata) {
-      if (!Number.isFinite(err.statusCode) && Number.isFinite(err.res.statusCode)) {
-        err.statusCode = err.res.statusCode
-      }
-      err.req ??= {
-        path: this.#opts.path,
-        origin: this.#opts.origin,
-        method: this.#opts.method,
-        headers: this.#opts.headers,
+      try {
+        if (!Number.isFinite(err.statusCode) && Number.isFinite(err.res.statusCode)) {
+          err.statusCode = err.res.statusCode
+        }
+        err.req ??= {
+          path: this.#opts.path,
+          origin: this.#opts.origin,
+          method: this.#opts.method,
+          headers: this.#opts.headers,
+        }
+      } catch (er) {
+        super.onError(new AggregateError([er, err]))
+        return
       }
       super.onError(err)
       return

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -420,14 +420,20 @@ class Handler extends DecoratorHandler {
       // A resume attempt landed on an unexpected status (e.g. a 503 while
       // resuming). #retryError describes the PREVIOUS failure — surfacing it
       // as-is would report a stale error that says nothing about what just
-      // happened. Report the current status and keep the prior failure as
-      // the cause.
+      // happened. Report the current response metadata and keep the prior
+      // failure as the cause.
       const err = new Error(
         `Response retry failed with status code ${statusCode}`,
         this.#retryError != null ? { cause: this.#retryError } : undefined,
       )
-      err.statusCode = statusCode
-      this.#maybeError(err)
+      this.#maybeError(
+        decorateError(err, this.#opts, {
+          statusCode,
+          headers,
+          trailers: this.#trailers,
+          body: null,
+        }),
+      )
       return false
     }
   }

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -426,6 +426,7 @@ class Handler extends DecoratorHandler {
         `Response retry failed with status code ${statusCode}`,
         this.#retryError != null ? { cause: this.#retryError } : undefined,
       )
+      invalidateNormalizedHeaders(this.#opts.headers)
       this.#maybeError(
         decorateError(err, this.#opts, {
           statusCode,

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -1,0 +1,61 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+test('response error preserves the terminal body-resume status', async (t) => {
+  let attempts = 0
+  const firstError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })
+
+  const dispatch = compose(
+    (opts, handler) => {
+      attempts++
+      handler.onConnect(() => {})
+
+      if (attempts === 1) {
+        handler.onHeaders(
+          200,
+          { 'content-length': '10', etag: '"same"', 'x-attempt': 'first' },
+          () => {},
+        )
+        handler.onData(Buffer.from('hello'))
+        handler.onError(firstError)
+      } else {
+        // response-retry does not expose these resume headers after the first
+        // response's headers have reached the caller. It instead reports this
+        // attempt's status on the terminal error.
+        handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
+        handler.onComplete([])
+      }
+    },
+    interceptors.responseRetry(),
+    interceptors.responseError(),
+  )
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry: () => true,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('request unexpectedly completed'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
+  t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
+  t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
+  t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
+  t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -56,7 +56,11 @@ test('response error preserves the terminal body-resume status', async (t) => {
   t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
   t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
   t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
-  t.equal(err.res.headers, null, 'does not pair terminal status with earlier response headers')
+  t.same(
+    err.res.headers,
+    { 'x-attempt': 'second' },
+    'pairs the terminal status with the terminal attempt headers',
+  )
   t.equal(err.res.trailers, null, 'does not pair terminal status with earlier response trailers')
   t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
   t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -146,3 +146,33 @@ test('response error keeps captured metadata when the inner status matches', asy
   t.equal(err.statusCode, 503, 'keeps the matching terminal status')
   t.equal(err.res.headers, headers, 'keeps headers captured for that status')
 })
+
+test('response error tolerates primitive inner response metadata', async (t) => {
+  const innerError = Object.assign(new Error('network failed'), { res: 'unexpected' })
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, innerError, 'forwards the original error')
+  t.same(err.res, { statusCode: undefined, headers: undefined, trailers: undefined })
+  t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -177,6 +177,6 @@ test('response error tolerates primitive inner response metadata', async (t) => 
   })
 
   t.equal(err, innerError, 'forwards the original error')
-  t.same(err.res, { statusCode: undefined, headers: undefined, trailers: undefined })
+  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: undefined })
   t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -56,6 +56,51 @@ test('response error preserves the terminal body-resume status', async (t) => {
   t.equal(attempts, 2, 'made the initial request and one body-resume attempt')
   t.equal(err.statusCode, 503, 'keeps the status from the terminal resume failure')
   t.equal(err.res.statusCode, 503, 'decorated response metadata uses the terminal status')
+  t.equal(err.res.headers, null, 'does not pair terminal status with earlier response headers')
+  t.equal(err.res.trailers, null, 'does not pair terminal status with earlier response trailers')
   t.match(err.message, /503/, 'keeps the retry layer error describing the failed attempt')
   t.equal(err.cause, firstError, 'keeps the original connection failure as the cause')
+})
+
+test('response error preserves inner response metadata as a unit', async (t) => {
+  const response = {
+    statusCode: 503,
+    headers: { 'x-attempt': 'second' },
+    trailers: { 'x-terminal': 'yes' },
+  }
+  const innerError = Object.assign(new Error('terminal response failed'), {
+    statusCode: 503,
+    res: response,
+  })
+
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'x-attempt': 'first' }, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, innerError, 'forwards the inner error')
+  t.equal(err.res, response, 'keeps the inner response metadata object intact')
+  t.same(err.res.headers, { 'x-attempt': 'second' }, 'keeps the terminal response headers')
+  t.same(err.res.trailers, { 'x-terminal': 'yes' }, 'keeps the terminal response trailers')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -182,3 +182,35 @@ test('response error tolerates primitive inner response metadata', async (t) => 
   t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: null })
   t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
 })
+
+test('response error replaces incomplete inner response metadata', async (t) => {
+  const headers = { 'x-attempt': 'captured' }
+  const innerError = Object.assign(new Error('response interrupted'), { res: {} })
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(503, headers, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, innerError, 'forwards the original error')
+  t.strictSame(err.res, { statusCode: 503, headers, trailers: null })
+  t.equal(err.req.origin, 'http://example.test', 'decorates request metadata')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -179,6 +179,6 @@ test('response error tolerates primitive inner response metadata', async (t) => 
   })
 
   t.equal(err, innerError, 'forwards the original error')
-  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: undefined })
+  t.strictSame(err.res, { statusCode: undefined, headers: null, trailers: null })
   t.equal(err.req.origin, 'http://example.test', 'still decorates request metadata')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -69,7 +69,6 @@ test('response error preserves inner response metadata as a unit', async (t) => 
     trailers: { 'x-terminal': 'yes' },
   }
   const innerError = Object.assign(new Error('terminal response failed'), {
-    statusCode: 503,
     res: response,
   })
 
@@ -101,6 +100,49 @@ test('response error preserves inner response metadata as a unit', async (t) => 
 
   t.equal(err, innerError, 'forwards the inner error')
   t.equal(err.res, response, 'keeps the inner response metadata object intact')
+  t.equal(err.statusCode, 503, 'backfills the top-level status from inner response metadata')
+  t.same(
+    err.req,
+    {
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      headers: {},
+    },
+    'adds request metadata without replacing the inner response',
+  )
   t.same(err.res.headers, { 'x-attempt': 'second' }, 'keeps the terminal response headers')
   t.same(err.res.trailers, { 'x-terminal': 'yes' }, 'keeps the terminal response trailers')
+})
+
+test('response error keeps captured metadata when the inner status matches', async (t) => {
+  const headers = { 'content-type': 'text/plain', 'x-attempt': 'terminal' }
+  const innerError = Object.assign(new Error('response interrupted'), { statusCode: 503 })
+
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(503, headers, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err.statusCode, 503, 'keeps the matching terminal status')
+  t.equal(err.res.headers, headers, 'keeps headers captured for that status')
 })

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -22,8 +22,10 @@ test('response error preserves the terminal body-resume status', async (t) => {
         // response-retry does not expose these resume headers after the first
         // response's headers have reached the caller. It instead reports this
         // attempt's status on the terminal error.
-        handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
-        handler.onComplete([])
+        const shouldContinue = handler.onHeaders(503, { 'x-attempt': 'second' }, () => {})
+        if (shouldContinue !== false) {
+          handler.onComplete([])
+        }
       }
     },
     interceptors.responseRetry(),

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -214,3 +214,67 @@ test('response error replaces incomplete inner response metadata', async (t) => 
   t.strictSame(err.res, { statusCode: 503, headers, trailers: null })
   t.equal(err.req.origin, 'http://example.test', 'decorates request metadata')
 })
+
+test('response error replaces an invalid status with inner response metadata', async (t) => {
+  const response = { statusCode: 503, headers: {}, trailers: null }
+  const innerError = Object.assign(new Error('terminal response failed'), {
+    statusCode: Number.NaN,
+    res: response,
+  })
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err.statusCode, 503, 'uses the finite response metadata status')
+  t.equal(err.res, response, 'keeps the inner response metadata object intact')
+})
+
+test('response error ignores an invalid top-level status', async (t) => {
+  const headers = { 'x-attempt': 'captured' }
+  const innerError = Object.assign(new Error('response interrupted'), { statusCode: '503' })
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(503, headers, () => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err.statusCode, 503, 'falls back to the captured numeric status')
+  t.equal(err.res.headers, headers, 'keeps metadata captured for that status')
+})

--- a/test/response-error-retry-status.js
+++ b/test/response-error-retry-status.js
@@ -278,3 +278,37 @@ test('response error ignores an invalid top-level status', async (t) => {
   t.equal(err.statusCode, 503, 'falls back to the captured numeric status')
   t.equal(err.res.headers, headers, 'keeps metadata captured for that status')
 })
+
+test('response error contains decoration failures for frozen inner errors', async (t) => {
+  const innerError = Object.freeze(
+    Object.assign(new Error('terminal response failed'), {
+      res: { statusCode: 503, headers: {}, trailers: null },
+    }),
+  )
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onError(innerError)
+  }, interceptors.responseError())
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+      },
+      {
+        onConnect() {},
+        onHeaders() {},
+        onData() {},
+        onComplete() {},
+        onError: resolve,
+      },
+    )
+  })
+
+  t.type(err, AggregateError, 'forwards a contained decoration failure')
+  t.type(err.errors[0], TypeError, 'retains the mutation failure')
+  t.equal(err.errors[1], innerError, 'retains the original frozen error')
+})

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -61,7 +61,7 @@ test('retry: an unexpected resume status reports the current response headers', 
   t.equal(attempts, 2, 'one initial request and one resume request were dispatched')
   t.equal(err.statusCode, 503, 'the current attempt status remains available at top level')
   t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
-  t.equal(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
+  t.same(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
   t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
   t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
 })

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -1,0 +1,67 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+test('retry: an unexpected resume status reports the current response headers', async (t) => {
+  t.plan(8)
+
+  const firstError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
+  const retryHeaders = {
+    'content-length': '0',
+    'retry-after': '17',
+    'x-response-attempt': 'resume',
+  }
+
+  let attempts = 0
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+
+    if (attempts === 1) {
+      t.equal(
+        handler.onHeaders(200, { 'content-length': '10', etag: '"v1"' }, () => {}),
+        true,
+        'the initial response is forwarded',
+      )
+      handler.onData(Buffer.from('hello'))
+      handler.onError(firstError)
+    } else {
+      t.equal(
+        handler.onHeaders(503, retryHeaders, () => {}),
+        false,
+        'the unexpected resume response is rejected',
+      )
+    }
+
+    return true
+  }, interceptors.responseRetry())
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        method: 'GET',
+        origin: 'http://example.test',
+        path: '/',
+        headers: {},
+        retry: () => true,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onData() {},
+        onComplete() {
+          reject(new Error('should not complete'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(attempts, 2, 'one initial request and one resume request were dispatched')
+  t.equal(err.statusCode, 503, 'the current attempt status remains available at top level')
+  t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
+  t.equal(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
+  t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
+  t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
+})

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -1,10 +1,12 @@
 import { test } from 'tap'
 import { compose, interceptors } from '../lib/index.js'
+import { createNormalizedHeaders, parseHeaders } from '../lib/utils.js'
 
 test('retry: an unexpected resume status reports the current response headers', async (t) => {
-  t.plan(9)
+  t.plan(11)
 
   const firstError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
+  const requestHeaders = createNormalizedHeaders({ authorization: 'Bearer test' })
   const retryHeaders = {
     'content-length': '0',
     'retry-after': '17',
@@ -12,6 +14,7 @@ test('retry: an unexpected resume status reports the current response headers', 
   }
 
   let attempts = 0
+  let terminalRequestHeaders
   const dispatch = compose((opts, handler) => {
     attempts++
     handler.onConnect(() => {})
@@ -25,6 +28,8 @@ test('retry: an unexpected resume status reports the current response headers', 
       handler.onData(Buffer.from('hello'))
       handler.onError(firstError)
     } else {
+      terminalRequestHeaders = createNormalizedHeaders(opts.headers)
+      opts.headers = terminalRequestHeaders
       t.equal(
         handler.onHeaders(503, retryHeaders, () => {}),
         false,
@@ -41,7 +46,7 @@ test('retry: an unexpected resume status reports the current response headers', 
         method: 'GET',
         origin: 'http://example.test',
         path: '/',
-        headers: {},
+        headers: requestHeaders,
         retry: () => true,
       },
       {
@@ -65,4 +70,14 @@ test('retry: an unexpected resume status reports the current response headers', 
   t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
   t.equal(err.body, undefined, 'no stale buffered body is attached to the terminal error')
   t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
+  t.equal(
+    err.req.headers,
+    terminalRequestHeaders,
+    'request metadata retains the terminal header snapshot',
+  )
+  t.not(
+    parseHeaders(err.req.headers),
+    terminalRequestHeaders,
+    'the exposed request headers are no longer trusted as normalized',
+  )
 })

--- a/test/response-retry-terminal-headers.js
+++ b/test/response-retry-terminal-headers.js
@@ -2,7 +2,7 @@ import { test } from 'tap'
 import { compose, interceptors } from '../lib/index.js'
 
 test('retry: an unexpected resume status reports the current response headers', async (t) => {
-  t.plan(8)
+  t.plan(9)
 
   const firstError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
   const retryHeaders = {
@@ -63,5 +63,6 @@ test('retry: an unexpected resume status reports the current response headers', 
   t.equal(err.res.statusCode, 503, 'response metadata identifies the current attempt')
   t.same(err.res.headers, retryHeaders, 'response metadata contains the current attempt headers')
   t.equal(err.res.trailers, null, 'trailers are null because the attempt ended at headers')
+  t.equal(err.body, undefined, 'no stale buffered body is attached to the terminal error')
   t.equal(err.cause, firstError, 'the failure that triggered the resume remains the cause')
 })


### PR DESCRIPTION
Restores the response-retry fix from original PR #156, whose branch became stranded after its dependency stack merged.

This delivery is rebased directly onto main after the normalized-headers foundation merged and remains a separate fix. Unexpected resume statuses expose the current headers and terminal metadata, while request-header trust is invalidated before terminal error metadata crosses the user boundary.

Verification:
- retry focused tests: 103 assertions passed
- ESLint passed
- Prettier passed
- git diff --check passed