### PR TITLE
fix(body-factory): complete already-ended streams

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -44,7 +44,16 @@ class FactoryStream extends Readable {
             this.push(body)
             this.push(null)
           } else if (isStream(body)) {
-            this.#body = body
+            // A factory may resolve after its stream has already emitted
+            // 'end'. Attaching an end listener at that point can never
+            // complete this wrapper. Treat a cleanly exhausted result as an
+            // empty body; a stream closed before end still goes through
+            // finished() below and reports ERR_STREAM_PREMATURE_CLOSE.
+            if (body.readableEnded) {
+              this.push(null)
+            } else {
+              this.#body = body
+            }
           } else {
             this.#body = Readable.from(body)
           }

--- a/test/review-body-factory-ended-stream.js
+++ b/test/review-body-factory-ended-stream.js
@@ -1,0 +1,43 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { Readable } from 'node:stream'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('factory result that already ended completes as an empty body', async (t) => {
+  let requestBody = ''
+  const server = createServer((req, res) => {
+    req.on('data', (chunk) => {
+      requestBody += chunk
+    })
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(new Error('ended factory stream left the request hanging')),
+    5_000,
+  )
+  t.teardown(() => clearTimeout(timeout))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'POST',
+    retry: false,
+    signal: controller.signal,
+    body: async () => {
+      const ended = Readable.from(['already consumed'])
+      for await (const chunk of ended) {
+        // Exhaust the stream before the factory resolves.
+        void chunk
+      }
+      return ended
+    },
+  })
+  clearTimeout(timeout)
+
+  t.equal(await response.body.text(), 'ok')
+  t.equal(requestBody, '', 'the exhausted stream contributes no body bytes')
+})


### PR DESCRIPTION
## Why

The fix from #148 was merged into the `codex/body-factory-pending-abort` branch after that branch's PR (#146) had already merged to `main`, so the commit never reached the default branch.

This PR re-delivers that fix on the normalized-headers foundation (#165) without combining it with the later body-factory fixes.

## Change

Treat a factory-produced stream that has already ended cleanly as an empty completed body. Prematurely closed streams continue through `finished()` and surface `ERR_STREAM_PREMATURE_CLOSE`.

## Checks

- `request-body-factory` and ended-stream regression suites: 2 suites, 10 assertions passed
- Full three-PR stack: 4 suites, 15 assertions passed
- ESLint
- Prettier
- `git diff --check`

Original PR: #148
