### PR TITLE
fix(body-factory): release inner stream listeners

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -7,6 +7,8 @@ class FactoryStream extends Readable {
   #factory
   #ac
   #body
+  #removeBodyListeners = noop
+  #cleanupFinished = noop
 
   constructor(factory) {
     super()
@@ -59,27 +61,36 @@ class FactoryStream extends Readable {
           }
 
           if (this.#body != null) {
-            this.#body
-              .on('data', (data) => {
-                // `?.`: a 'data' event can still be queued when _destroy() has
-                // already nulled #body, and `_read` guards the same way.
-                if (!this.push(data)) {
-                  this.#body?.pause()
-                }
-              })
-              .on('end', () => {
-                this.push(null)
-              })
+            const bodyStream = this.#body
+            const onData = (data) => {
+              // `?.`: a 'data' event can still be queued when _destroy() has
+              // already nulled #body, and `_read` guards the same way.
+              if (!this.push(data)) {
+                this.#body?.pause()
+              }
+            }
+            const onEnd = () => this.push(null)
+
+            // Register our end handler before finished(): it must push the
+            // outer EOF before finished's terminal callback removes listeners.
+            bodyStream.on('end', onEnd)
+
             // `finished` (not a bare 'error' listener) so a premature close —
             // the inner body destroyed without emitting 'end' or 'error', which
             // surfaces only as 'close' — becomes ERR_STREAM_PREMATURE_CLOSE and
             // fails the request, instead of hanging forever with no terminal
             // push(null). writable:false: these inner bodies are read-only.
-            finished(this.#body, { writable: false }, (err) => {
+            this.#cleanupFinished = finished(bodyStream, { writable: false }, (err) => {
               if (err) {
                 this.destroy(err)
               }
             })
+
+            bodyStream.on('data', onData)
+            this.#removeBodyListeners = () => {
+              bodyStream.removeListener('data', onData)
+              bodyStream.removeListener('end', onEnd)
+            }
           }
 
           callback(null)
@@ -120,10 +131,26 @@ class FactoryStream extends Readable {
       this.#ac = null
     }
 
+    this.#removeBodyListeners()
+    this.#removeBodyListeners = noop
+
     if (this.#body) {
-      this.#body.destroy(err)
+      const bodyStream = this.#body
+      const cleanupFinished = this.#cleanupFinished
+      // Keep finished's error listener installed until destroy() has emitted
+      // the inner stream's terminal events. Removing it first would turn a
+      // propagated body error into an uncaught second 'error' emission.
+      if (bodyStream.closed) {
+        cleanupFinished()
+      } else {
+        bodyStream.once('close', cleanupFinished)
+        bodyStream.destroy(err)
+      }
       this.#body = null
+    } else {
+      this.#cleanupFinished()
     }
+    this.#cleanupFinished = noop
 
     callback(err)
   }

--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -184,7 +184,14 @@ export default () => (dispatch) => (opts, handler) => {
 
   const body = new FactoryStream(opts.body).on('error', noop)
   try {
-    return dispatch({ ...opts, body }, new Handler(handler, body))
+    const result = dispatch({ ...opts, body }, new Handler(handler, body))
+    if (result != null && typeof result.catch === 'function') {
+      // DispatchFn permits Promise<void>. A rejecting async dispatcher may not
+      // also report the failure through handler.onError, so attach cleanup to
+      // the original promise while returning it unchanged to the caller.
+      result.catch((err) => body.destroy(err))
+    }
+    return result
   } catch (err) {
     body.destroy(err)
     throw err

--- a/test/review-body-factory-async-dispatch.js
+++ b/test/review-body-factory-async-dispatch.js
@@ -1,0 +1,33 @@
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('async dispatch rejection destroys its factory body', async (t) => {
+  const reason = new Error('async dispatch failed')
+  const dispatch = requestBodyFactory()(async () => {
+    throw reason
+  })
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  await t.rejects(result, reason, 'dispatch rejection is preserved')
+  // Factory construction and deferred _destroy each run on a later tick.
+  await tick()
+  await tick()
+
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'dispatch rejection is the cancellation reason')
+})

--- a/test/review-body-factory-listener-cleanup.js
+++ b/test/review-body-factory-listener-cleanup.js
@@ -1,0 +1,37 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { PassThrough } from 'node:stream'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+const observedEvents = ['data', 'end', 'error', 'close', 'finish']
+
+function listenerCounts(stream) {
+  return Object.fromEntries(observedEvents.map((event) => [event, stream.listenerCount(event)]))
+}
+
+test('completed factory body does not retain forwarding or finished listeners', async (t) => {
+  const server = createServer((req, res) => {
+    req.resume()
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const inner = new PassThrough()
+  const before = listenerCounts(inner)
+  const responsePromise = request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'POST',
+    body: () => inner,
+  })
+  inner.end('request body')
+
+  const response = await responsePromise
+  await response.body.text()
+  if (!inner.closed) {
+    await once(inner, 'close')
+  }
+
+  t.same(listenerCounts(inner), before, 'all factory-added listeners were removed')
+})


### PR DESCRIPTION
## Why

The body-factory stack from #147–#149 ultimately landed on `codex/body-factory-pending-abort` after its PR (#146) had already merged to `main`, so these commits never reached the default branch.

This PR re-delivers the listener-cleanup fix from #149 as the second isolated commit in the replacement stack.

## Change

Track and remove the factory's forwarding and `finished()` listeners after completion. When destroying an active inner stream, keep the error listener until close so a propagated body error cannot become an uncaught second error.

## Stack

Base: #169

## Checks

- `request-body-factory`, ended-stream, and listener-cleanup suites: 3 suites, 11 assertions passed
- Full three-PR stack: 4 suites, 15 assertions passed
- ESLint
- Prettier
- `git diff --check`

Original PR: #149
