### PR TITLE
fix(body-factory): clean up rejected async dispatches

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -184,7 +184,14 @@ export default () => (dispatch) => (opts, handler) => {
 
   const body = new FactoryStream(opts.body).on('error', noop)
   try {
-    return dispatch({ ...opts, body }, new Handler(handler, body))
+    const result = dispatch({ ...opts, body }, new Handler(handler, body))
+    if (result != null && typeof result.catch === 'function') {
+      // DispatchFn permits Promise<void>. A rejecting async dispatcher may not
+      // also report the failure through handler.onError, so attach cleanup to
+      // the original promise while returning it unchanged to the caller.
+      result.catch((err) => body.destroy(err))
+    }
+    return result
   } catch (err) {
     body.destroy(err)
     throw err

--- a/test/review-body-factory-async-dispatch.js
+++ b/test/review-body-factory-async-dispatch.js
@@ -1,0 +1,33 @@
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('async dispatch rejection destroys its factory body', async (t) => {
+  const reason = new Error('async dispatch failed')
+  const dispatch = requestBodyFactory()(async () => {
+    throw reason
+  })
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  await t.rejects(result, reason, 'dispatch rejection is preserved')
+  // Factory construction and deferred _destroy each run on a later tick.
+  await tick()
+  await tick()
+
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'dispatch rejection is the cancellation reason')
+})


### PR DESCRIPTION
## Why

The body-factory stack from #147–#149 ultimately landed on `codex/body-factory-pending-abort` after its PR (#146) had already merged to `main`, so these commits never reached the default branch.

This PR re-delivers the async-dispatch cleanup from #147 as the final isolated commit in the replacement stack.

## Change

Attach cleanup to a promise returned by an inner dispatcher so a rejection destroys the factory body and aborts its cancellation signal, while preserving and returning the dispatcher's original promise.

## Stack

Base: #172 (which is based on #169, then #165)

## Checks

- `request-body-factory` plus all three regression suites: 4 suites, 15 assertions passed
- ESLint
- Prettier
- `git diff --check`

Original PR: #147
