### PR TITLE
refactor: reuse undici error classes

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,33 +1,5 @@
-export class UndiciError extends Error {
-  constructor(message, options) {
-    super(message, options)
-    this.name = 'UndiciError'
-    this.code = 'UND_ERR'
-  }
-}
+import { errors } from '@nxtedition/undici'
 
-export class InvalidArgumentError extends UndiciError {
-  constructor(message) {
-    super(message)
-    this.name = 'InvalidArgumentError'
-    this.message = message || 'Invalid Argument Error'
-    this.code = 'UND_ERR_INVALID_ARG'
-  }
-}
+const { UndiciError, InvalidArgumentError, AbortError, RequestAbortedError } = errors
 
-export class AbortError extends UndiciError {
-  constructor(message) {
-    super(message)
-    this.name = 'AbortError'
-    this.message = message || 'The operation was aborted'
-  }
-}
-
-export class RequestAbortedError extends AbortError {
-  constructor(message) {
-    super(message)
-    this.name = 'AbortError'
-    this.message = message || 'Request aborted'
-    this.code = 'UND_ERR_ABORTED'
-  }
-}
+export { UndiciError, InvalidArgumentError, AbortError, RequestAbortedError }

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import tp from 'node:timers/promises'
+import { errors } from '@nxtedition/undici'
 import {
   DecoratorHandler,
   isDisturbed,
@@ -9,8 +10,9 @@ import {
   parseHeaders,
   parseHttpDate,
 } from '../utils.js'
-import { RequestAbortedError } from '../errors.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
+
+const { RequestAbortedError } = errors
 
 // Maximum number of >= 400 response body bytes buffered for replay in case
 // the response is not retried. Larger bodies are passed straight through and

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,8 @@
 import assert from 'node:assert'
-import { InvalidArgumentError, RequestAbortedError } from './errors.js'
+import { errors, Readable } from '@nxtedition/undici'
 import { isStream } from './utils.js'
-import { Readable } from '@nxtedition/undici'
+
+const { InvalidArgumentError, RequestAbortedError } = errors
 
 function noop() {}
 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -16,8 +16,10 @@
 // happens inside dispatch/handler control flow, and reentrancy there is
 // unsupported.
 
+import { errors } from '@nxtedition/undici'
 import { validateTrace as validateTraceWriter } from '@nxtedition/trace'
-import { InvalidArgumentError } from './errors.js'
+
+const { InvalidArgumentError } = errors
 
 // installTrace is part of the surface: the per-thread default writer lives in
 // the Symbol.for('@nxtedition/app/trace') slot and is mirrored

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,69 +1,56 @@
-/* eslint-disable */
+import { errors } from '@nxtedition/undici'
 import { test } from 'tap'
 import {
-  UndiciError,
-  InvalidArgumentError,
   AbortError,
+  InvalidArgumentError,
   RequestAbortedError,
+  UndiciError,
 } from '../lib/errors.js'
+import { RequestHandler } from '../lib/request.js'
+import { validateTrace } from '../lib/trace.js'
 
-test('UndiciError', (t) => {
-  const err = new UndiciError('test message')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof UndiciError)
-  t.equal(err.name, 'UndiciError')
-  t.equal(err.code, 'UND_ERR')
-  t.equal(err.message, 'test message')
+test('deep-import error facade preserves dependency constructor identity', (t) => {
+  t.equal(UndiciError, errors.UndiciError)
+  t.equal(InvalidArgumentError, errors.InvalidArgumentError)
+  t.equal(AbortError, errors.AbortError)
+  t.equal(RequestAbortedError, errors.RequestAbortedError)
   t.end()
 })
 
-test('InvalidArgumentError', (t) => {
-  const err = new InvalidArgumentError('bad arg')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof UndiciError)
-  t.ok(err instanceof InvalidArgumentError)
-  t.equal(err.name, 'InvalidArgumentError')
-  t.equal(err.code, 'UND_ERR_INVALID_ARG')
-  t.equal(err.message, 'bad arg')
+test('request validation uses the dependency InvalidArgumentError', (t) => {
+  const err = t.throws(
+    () => new RequestHandler({ method: 'GET', body: null }, 'not-a-function'),
+    /invalid resolve/,
+  )
+
+  t.ok(err instanceof errors.InvalidArgumentError)
+  t.equal(err.constructor, errors.InvalidArgumentError)
   t.end()
 })
 
-test('InvalidArgumentError default message', (t) => {
-  const err = new InvalidArgumentError()
-  t.equal(err.message, 'Invalid Argument Error')
+test('trace validation uses the dependency InvalidArgumentError', (t) => {
+  const err = t.throws(() => validateTrace({}), /invalid trace/)
+
+  t.ok(err instanceof errors.InvalidArgumentError)
+  t.equal(err.constructor, errors.InvalidArgumentError)
   t.end()
 })
 
-test('AbortError', (t) => {
-  const err = new AbortError('aborted')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof UndiciError)
-  t.ok(err instanceof AbortError)
-  t.equal(err.name, 'AbortError')
-  t.equal(err.message, 'aborted')
-  t.end()
-})
+test('request abort fallback uses the dependency RequestAbortedError', (t) => {
+  const signal = {
+    aborted: true,
+    reason: undefined,
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  const handler = new RequestHandler({ method: 'GET', body: null, signal }, () => {})
+  let reason
 
-test('AbortError default message', (t) => {
-  const err = new AbortError()
-  t.equal(err.message, 'The operation was aborted')
-  t.end()
-})
+  handler.onConnect((err) => {
+    reason = err
+  })
 
-test('RequestAbortedError', (t) => {
-  const err = new RequestAbortedError('req aborted')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof UndiciError)
-  t.ok(err instanceof AbortError)
-  t.ok(err instanceof RequestAbortedError)
-  t.equal(err.name, 'AbortError')
-  t.equal(err.code, 'UND_ERR_ABORTED')
-  t.equal(err.message, 'req aborted')
-  t.end()
-})
-
-test('RequestAbortedError default message', (t) => {
-  const err = new RequestAbortedError()
-  t.equal(err.message, 'Request aborted')
+  t.ok(reason instanceof errors.RequestAbortedError)
+  t.equal(reason.constructor, errors.RequestAbortedError)
   t.end()
 })

--- a/test/review-bugfixes-4-retry-abort-backoff.js
+++ b/test/review-bugfixes-4-retry-abort-backoff.js
@@ -2,6 +2,7 @@ import { test } from 'tap'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
 import tp from 'node:timers/promises'
+import { errors } from '@nxtedition/undici'
 import { compose, interceptors, request, getGlobalDispatcher } from '../lib/index.js'
 
 // Regression tests: a downstream abort that lands DURING the retry backoff
@@ -96,7 +97,7 @@ test('retry: abort during backoff delivers onError with the reason (raw dispatch
 // ---------------------------------------------------------------------------
 
 test('retry: reasonless abort during backoff falls back to RequestAbortedError', async (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const server = await start503Server()
   t.teardown(server.close.bind(server))
@@ -143,6 +144,7 @@ test('retry: reasonless abort during backoff falls back to RequestAbortedError',
   const err = await Promise.race([onError, tp.setTimeout(2000, null)])
 
   t.ok(err, 'terminal onError delivered')
+  t.ok(err instanceof errors.RequestAbortedError, 'uses the dependency error class')
   t.equal(err?.code, 'UND_ERR_ABORTED', 'fallback is a RequestAbortedError')
   t.ok(Date.now() - abortedAt < 1500, 'terminal error is prompt')
 })


### PR DESCRIPTION
## Summary

- use `@nxtedition/undici.errors` constructors directly in request validation, trace validation, and response-retry abort fallbacks
- replace the duplicated error implementations in `lib/errors.js` with a thin facade over those exact constructors
- replace implementation self-tests with regressions covering strict facade identity and errors emitted by the real request, trace, and retry paths

## Why

The local classes duplicated the dependency's names, messages, and error codes, but they had different constructor identities. An error created by nxt-undici therefore failed `instanceof @nxtedition/undici.errors.InvalidArgumentError` and the equivalent abort check.

## Compatibility

`lib/errors.js` is included by the package's `lib/*` publish rule and there is no exports map, so its deep-import path remains resolvable. This PR preserves that path and its four named exports (`UndiciError`, `InvalidArgumentError`, `AbortError`, and `RequestAbortedError`); each export is now strictly identical to the corresponding dependency constructor. No documented top-level export changes.

## Validation

- 150 assertions across focused request, trace, retry, validation, and identity suites
- public declaration compilation
- ESLint on all changed files
- Prettier on all changed files
- `npm pack --dry-run --json` confirms `lib/errors.js` remains published
- `git diff --check`
