### PR TITLE
fix(request): make abort listeners propagation-safe

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import { addAbortListener } from 'node:events'
 import { errors, Readable } from '@nxtedition/undici'
 import { isStream } from './utils.js'
 
@@ -67,7 +68,10 @@ export class RequestHandler {
       // The validation above accepts either an EventTarget (addEventListener)
       // or an EventEmitter (.on), matching undici's contract — so honour both
       // here instead of assuming addEventListener and crashing on an emitter.
-      if (typeof signal.addEventListener === 'function') {
+      if (signal instanceof AbortSignal) {
+        const disposable = addAbortListener(signal, onAbort)
+        this.removeAbortListener = () => disposable[Symbol.dispose]()
+      } else if (typeof signal.addEventListener === 'function') {
         signal.addEventListener('abort', onAbort)
         this.removeAbortListener = () => signal.removeEventListener('abort', onAbort)
       } else {

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,6 +7,17 @@ const { InvalidArgumentError, RequestAbortedError } = errors
 
 function noop() {}
 
+function tryAddAbortListener(signal, listener) {
+  try {
+    return addAbortListener(signal, listener)
+  } catch (err) {
+    if (err?.code !== 'ERR_INVALID_ARG_TYPE') {
+      throw err
+    }
+    return null
+  }
+}
+
 export class RequestHandler {
   constructor({ signal, method, body, highWaterMark }, resolve) {
     if (isStream(body) && body.closed) {
@@ -65,15 +76,17 @@ export class RequestHandler {
           this.abort(this.reason)
         }
       }
-      // The validation above accepts either an EventTarget (addEventListener)
-      // or an EventEmitter (.on), matching undici's contract — so honour both
-      // here instead of assuming addEventListener and crashing on an emitter.
-      if (signal instanceof AbortSignal) {
-        const disposable = addAbortListener(signal, onAbort)
-        this.removeAbortListener = () => disposable[Symbol.dispose]()
-      } else if (typeof signal.addEventListener === 'function') {
-        signal.addEventListener('abort', onAbort)
-        this.removeAbortListener = () => signal.removeEventListener('abort', onAbort)
+      // Let Node recognize native AbortSignals so cross-realm instances get a
+      // propagation-resistant listener. Generic EventTargets and EventEmitters
+      // retain their compatibility paths.
+      if (typeof signal.addEventListener === 'function') {
+        const disposable = tryAddAbortListener(signal, onAbort)
+        if (disposable) {
+          this.removeAbortListener = () => disposable[Symbol.dispose]()
+        } else {
+          signal.addEventListener('abort', onAbort)
+          this.removeAbortListener = () => signal.removeEventListener('abort', onAbort)
+        }
       } else {
         signal.on('abort', onAbort)
         this.removeAbortListener = () => signal.removeListener('abort', onAbort)

--- a/test/request-safe-abort-listener.js
+++ b/test/request-safe-abort-listener.js
@@ -1,0 +1,43 @@
+import { getEventListeners } from 'node:events'
+import { test } from 'tap'
+import { RequestHandler, request } from '../lib/request.js'
+
+test('AbortSignal reaches transport past stopImmediatePropagation', async (t) => {
+  const controller = new AbortController()
+  const reason = new Error('user abort')
+  let transportReason
+
+  controller.signal.addEventListener('abort', (event) => event.stopImmediatePropagation())
+
+  const result = request(
+    (_opts, handler) => {
+      handler.onConnect((abortReason) => {
+        transportReason = abortReason
+        handler.onError(abortReason)
+      })
+    },
+    'http://example.test',
+    { method: 'GET', signal: controller.signal },
+  )
+
+  controller.abort(reason)
+
+  await t.rejects(result, reason)
+  t.equal(transportReason, reason, 'transport receives the original abort reason')
+})
+
+test('AbortSignal listener disposable is cleaned up on request error', (t) => {
+  const controller = new AbortController()
+  const reason = new Error('dispatch failed')
+  const handler = new RequestHandler(
+    { method: 'GET', body: null, signal: controller.signal },
+    (result) => void result.catch(() => {}),
+  )
+
+  t.equal(getEventListeners(controller.signal, 'abort').length, 1, 'listener is installed')
+
+  handler.onError(reason)
+
+  t.equal(getEventListeners(controller.signal, 'abort').length, 0, 'listener is disposed')
+  t.end()
+})

--- a/test/request-safe-abort-listener.js
+++ b/test/request-safe-abort-listener.js
@@ -2,11 +2,16 @@ import { getEventListeners } from 'node:events'
 import { test } from 'tap'
 import { RequestHandler, request } from '../lib/request.js'
 
-test('AbortSignal reaches transport past stopImmediatePropagation', async (t) => {
+test('cross-realm AbortSignal reaches transport past stopImmediatePropagation', async (t) => {
   const controller = new AbortController()
+  const foreignPrototype = Object.create(EventTarget.prototype)
+  Object.defineProperties(foreignPrototype, Object.getOwnPropertyDescriptors(AbortSignal.prototype))
+  Object.setPrototypeOf(controller.signal, foreignPrototype)
+
   const reason = new Error('user abort')
   let transportReason
 
+  t.notOk(controller.signal instanceof AbortSignal, 'signal has a foreign-realm prototype')
   controller.signal.addEventListener('abort', (event) => event.stopImmediatePropagation())
 
   const result = request(

--- a/test/request-safe-abort-listener.js
+++ b/test/request-safe-abort-listener.js
@@ -46,3 +46,24 @@ test('AbortSignal listener disposable is cleaned up on request error', (t) => {
   t.equal(getEventListeners(controller.signal, 'abort').length, 0, 'listener is disposed')
   t.end()
 })
+
+test('generic EventTarget abort compatibility is retained', (t) => {
+  const signal = new EventTarget()
+  const handler = new RequestHandler(
+    { method: 'GET', body: null, signal },
+    (result) => void result.catch(() => {}),
+  )
+  let transportReason
+
+  handler.onConnect((reason) => {
+    transportReason = reason
+  })
+  signal.dispatchEvent(new Event('abort'))
+
+  t.equal(transportReason?.code, 'UND_ERR_ABORTED', 'generic abort reaches transport')
+
+  handler.onError(transportReason)
+
+  t.equal(getEventListeners(signal, 'abort').length, 0, 'generic listener is removed')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- use Node's `addAbortListener()` for native `AbortSignal` instances
- dispose the returned listener when the request settles
- retain generic `EventTarget` and `EventEmitter` signal compatibility

## Why

An ordinary `abort` listener can be skipped when an earlier listener calls `stopImmediatePropagation()`. That can prevent request cancellation from reaching the transport. Node's supported helper installs a propagation-resistant listener and provides explicit cleanup through its disposable.

## Validation

- `npx tap --disable-coverage --reporter=terse test/request-safe-abort-listener.js test/request-handler.js test/request-async-dispatch-rejection.js test/review-bugfixes-misc.js test/request-falsy-abort-reason.js test/signal.js test/signal-advanced.js`
- `npx eslint lib/request.js test/request-safe-abort-listener.js`
- `npx prettier --check lib/request.js test/request-safe-abort-listener.js`
- `git diff --check`
