### PR TITLE
refactor(url): use Node 26 non-throwing parser

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -94,11 +94,7 @@ function sanitizeOrigin(origin) {
   if (!str.includes('@')) {
     return str
   }
-  try {
-    return new URL(str).origin
-  } catch {
-    return REDACTED
-  }
+  return URL.parse(str)?.origin ?? REDACTED
 }
 
 // Summarize the request body (type + size) instead of embedding its content.

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -268,18 +268,14 @@ class Handler extends DecoratorHandler {
 // for object-form origins). A raw string compare misclassifies such
 // same-origin redirects as cross-origin and strips authorization/cookie,
 // breaking authenticated redirect flows with a confusing 401. Normalize
-// through `new URL` before comparing; if optsOrigin is not parseable, keep
-// the raw-compare result (already false here), which fails toward stripping —
-// the safe direction.
+// through `URL.parse` before comparing; if optsOrigin is not parseable, the
+// optional chain produces false, which fails toward stripping — the safe
+// direction.
 function isSameOrigin(optsOrigin, target) {
   if (optsOrigin === target) {
     return true
   }
-  try {
-    return new URL(optsOrigin).origin === target
-  } catch {
-    return false
-  }
+  return URL.parse(optsOrigin)?.origin === target
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4.4

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -72,11 +72,7 @@ export function traceUrl(opts) {
       // than lose the doc.
       str = typeof origin === 'string' ? origin : String(origin)
       if (str.includes('@')) {
-        try {
-          str = new URL(str).origin
-        } catch {
-          str = '[redacted]'
-        }
+        str = URL.parse(str)?.origin ?? '[redacted]'
       }
       // A URL#origin never ends in '/', so an origin-position string ending
       // in one is either the URL.toString() artifact (makeCacheKey

--- a/test/review-bugfixes-5-trace.js
+++ b/test/review-bugfixes-5-trace.js
@@ -32,6 +32,14 @@ test('traceUrl: trailing-slash string origins converge with URL-instance origins
   t.end()
 })
 
+test('traceUrl: unparseable credential-bearing origins are redacted', (t) => {
+  t.equal(
+    traceUrl({ origin: 'http://secret:password@not a valid host', path: '/private' }),
+    '[redacted]/private',
+  )
+  t.end()
+})
+
 async function startServer(handler) {
   const server = createServer(handler)
   server.listen(0)


### PR DESCRIPTION
## Summary

- replace three non-throwing `try { new URL() } catch` normalization paths with Node 26 `URL.parse()`
- keep throwing URL construction in request, redirect resolution, DNS, and shared URL validation unchanged
- retain fail-closed credential redaction and cross-origin header stripping behavior
- add a regression for unparseable credential-bearing trace origins

## Dependency

Stacked on #174, which declares Node.js 26 as the minimum runtime.

## Verification

- focused trace/log/redirect suites: 103 assertions pass
- public declarations compile
- ESLint, Prettier, and `git diff --check` pass