### PR TITLE
fix(stream): trust native disturbance state

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -413,6 +413,8 @@ export function parseHttpDate(date, now) {
 }
 
 export function isDisturbed(body) {
+  // Node 26 accepts arbitrary values here and returns false for absent and
+  // non-stream bodies, so callers do not need compatibility guards.
   return isStreamDisturbed(body)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,9 @@
-import { isDisturbed as isStreamDisturbed } from 'node:stream'
 import { util } from '@nxtedition/undici'
 import createHttpError from 'http-errors'
+
+// Node 26 accepts arbitrary values here and returns false for absent and
+// non-stream bodies, so callers do not need compatibility guards.
+export { isDisturbed } from 'node:stream'
 
 let fastNow = Date.now()
 
@@ -410,12 +413,6 @@ export function parseHttpDate(date, now) {
   // Date.UTC normalizes out-of-range components (Feb 30 → Mar 2); a
   // normalized day-of-month means the named date never existed — reject.
   return result.getUTCDate() === day ? result : undefined
-}
-
-export function isDisturbed(body) {
-  // Node 26 accepts arbitrary values here and returns false for absent and
-  // non-stream bodies, so callers do not need compatibility guards.
-  return isStreamDisturbed(body)
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import stream from 'node:stream'
+import { isDisturbed as isStreamDisturbed } from 'node:stream'
 import { util } from '@nxtedition/undici'
 import createHttpError from 'http-errors'
 
@@ -413,20 +413,7 @@ export function parseHttpDate(date, now) {
 }
 
 export function isDisturbed(body) {
-  if (
-    body == null ||
-    typeof body === 'string' ||
-    Buffer.isBuffer(body) ||
-    typeof body === 'function'
-  ) {
-    return false
-  }
-
-  if (body.readableDidRead === false) {
-    return false
-  }
-
-  return stream.isDisturbed(body)
+  return isStreamDisturbed(body)
 }
 
 /**

--- a/test/native-stream-disturbance.js
+++ b/test/native-stream-disturbance.js
@@ -1,0 +1,86 @@
+import { Readable } from 'node:stream'
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function destroyedUnreadBody() {
+  const body = new Readable({ read() {} })
+  body.destroy()
+  return body
+}
+
+test('redirect does not replay a destroyed unread Readable', (t) => {
+  const body = destroyedUnreadBody()
+  let dispatches = 0
+
+  const dispatch = compose((opts, handler) => {
+    dispatches++
+    handler.onConnect(() => {})
+    handler.onHeaders(307, { location: '/next' }, () => {})
+    handler.onComplete(null)
+    return true
+  }, interceptors.redirect())
+
+  t.equal(body.readableDidRead, false, 'body was cancelled before any data was read')
+  t.throws(
+    () =>
+      dispatch(
+        {
+          body,
+          follow: 1,
+          method: 'POST',
+          origin: 'http://example.test',
+          path: '/',
+        },
+        {
+          onConnect() {},
+          onError(err) {
+            throw err
+          },
+        },
+      ),
+    /Disturbed request cannot be redirected/,
+  )
+  t.equal(dispatches, 1, 'the cancelled body is not dispatched to the redirect target')
+  t.end()
+})
+
+test('retry does not replay a destroyed unread Readable', async (t) => {
+  const body = destroyedUnreadBody()
+  const networkError = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
+  let dispatches = 0
+  let retryCalls = 0
+
+  const dispatch = compose((opts, handler) => {
+    dispatches++
+    handler.onConnect(() => {})
+    handler.onError(networkError)
+    return true
+  }, interceptors.responseRetry())
+
+  const err = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        body,
+        method: 'POST',
+        origin: 'http://example.test',
+        path: '/',
+        retry() {
+          retryCalls++
+          return retryCalls === 1
+        },
+      },
+      {
+        onConnect() {},
+        onComplete() {
+          reject(new Error('unexpected completion'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(body.readableDidRead, false, 'body was cancelled before any data was read')
+  t.equal(err, networkError)
+  t.equal(dispatches, 1, 'the cancelled body is not dispatched a second time')
+  t.equal(retryCalls, 0, 'the retry strategy is skipped for a disturbed body')
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -230,6 +230,22 @@ test('isDisturbed - undisturbed stream returns false', (t) => {
   t.end()
 })
 
+test('isDisturbed - read stream returns true', (t) => {
+  const s = Readable.from(['body'])
+  t.equal(s.read(), 'body')
+  t.ok(isDisturbed(s))
+  t.end()
+})
+
+test('isDisturbed - destroyed unread stream returns true', (t) => {
+  const s = new Readable({ read() {} })
+  t.equal(s.readableDidRead, false)
+  s.destroy()
+  t.equal(s.readableDidRead, false)
+  t.ok(isDisturbed(s))
+  t.end()
+})
+
 // --- parseHeaders ---
 
 test('parseHeaders - array format', (t) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -216,10 +216,14 @@ test('bodyLength - blob returns size', (t) => {
 
 // --- isDisturbed ---
 
-test('isDisturbed - null/string/buffer/function returns false', (t) => {
+test('isDisturbed - non-stream bodies return false', (t) => {
   t.notOk(isDisturbed(null))
   t.notOk(isDisturbed('string'))
   t.notOk(isDisturbed(Buffer.from('hello')))
+  t.notOk(isDisturbed(new Uint8Array(1)))
+  t.notOk(isDisturbed(new Blob(['hello'])))
+  t.notOk(isDisturbed({}))
+  t.notOk(isDisturbed(42))
   t.notOk(isDisturbed(() => {}))
   t.end()
 })


### PR DESCRIPTION
## Summary

- delegate request-body disturbance detection to the Node 26 `node:stream` implementation
- stop treating a destroyed-before-read `Readable` as reusable
- cover unread, consumed, and destroyed stream states plus retry and redirect replay guards

## Root cause

The compatibility branch returned `false` whenever `readableDidRead` was false. Node reports a stream destroyed before its first read as disturbed, so that override could let retry and redirect attempt to reuse an already-cancelled body.

## Impact

Destroyed request streams are now rejected as non-replayable before retry or redirect can issue another dispatch. Ordinary unread streams and non-stream body primitives retain their existing `false` result.

## Validation

- `npx tap --disable-coverage --reporter=terse --jobs=1 --timeout=30 test/utils.js test/native-stream-disturbance.js`
- `npx tap --disable-coverage --reporter=terse --jobs=1 --timeout=60 test/redirect.js`
- `npx tap --disable-coverage --reporter=terse --jobs=1 --timeout=60 test/retry.js`
- `npx eslint lib/utils.js test/native-stream-disturbance.js test/utils.js`
- `npx prettier --check lib/utils.js test/native-stream-disturbance.js test/utils.js`
- `git diff --check`