### PR TITLE
docs(headers): align parseHeaders input contract

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -680,12 +680,12 @@ function setOwnHeader(obj, key, value) {
 const normalizedHeaders = new WeakSet()
 
 /**
- * @param {Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]} headers
+ * @param {Record<string, unknown> | unknown[] | null | undefined} headers
  * @returns {Record<string, string | string[]>}
  */
 export function parseHeaders(headers) {
-  if (normalizedHeaders.has(headers)) {
-    return headers
+  if (headers != null && typeof headers === 'object' && normalizedHeaders.has(headers)) {
+    return /** @type {Record<string, string | string[]>} */ (headers)
   }
 
   const obj = {}


### PR DESCRIPTION
Follow-up to the post-merge review on #165.

## What changed

- Document `parseHeaders()` as accepting nullish inputs and arbitrary object/array values that it normalizes through string coercion.
- Narrow the private trusted-header fast path to non-null objects and cast the branded result to its normalized output shape for checkJs/IDE accuracy.

There is no behavior change: existing tests already cover numeric value coercion, null handling, the trusted fast path, and the public optional/null declaration.

## Validation

- `npx tap --disable-coverage --reporter=terse test/utils.js test/normalized-headers.js test/public-types.js` (119 assertions)
- `npx eslint lib/utils.js`
- `npx prettier --check lib/utils.js`
- `git diff origin/main...HEAD --check`