### PR TITLE
fix(body-factory): observe generic dispatch thenables

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -185,11 +185,18 @@ export default () => (dispatch) => (opts, handler) => {
   const body = new FactoryStream(opts.body).on('error', noop)
   try {
     const result = dispatch({ ...opts, body }, new Handler(handler, body))
-    if (result != null && typeof result.catch === 'function') {
-      // DispatchFn permits Promise<void>. A rejecting async dispatcher may not
-      // also report the failure through handler.onError, so attach cleanup to
-      // the original promise while returning it unchanged to the caller.
-      result.catch((err) => body.destroy(err))
+    if (result != null) {
+      // Promise.resolve assimilates generic thenables and turns a throwing
+      // `.then` getter into an observed rejection. Keep returning the original
+      // dispatch result so the interceptor does not change its return contract.
+      Promise.resolve(result).catch((err) => {
+        try {
+          body.destroy(err)
+        } catch {
+          // Cleanup is best-effort. Throwing here would reject this otherwise
+          // detached observer and surface as an unhandled rejection.
+        }
+      })
     }
     return result
   } catch (err) {

--- a/test/review-body-factory-async-dispatch.js
+++ b/test/review-body-factory-async-dispatch.js
@@ -31,3 +31,115 @@ test('async dispatch rejection destroys its factory body', async (t) => {
   t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
   t.equal(factorySignal.reason, reason, 'dispatch rejection is the cancellation reason')
 })
+
+test('then-only dispatch rejection destroys its factory body', async (t) => {
+  const reason = new Error('thenable dispatch failed')
+  let thenCalls = 0
+  const thenable = {
+    then(...args) {
+      thenCalls++
+      args[1](reason)
+    },
+  }
+  const dispatch = requestBodyFactory()(() => thenable)
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  t.equal(result, thenable, 'the original thenable is returned')
+  await tick()
+  await tick()
+
+  t.equal(thenCalls, 1, 'the thenable rejection was observed once')
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'thenable rejection is the cancellation reason')
+})
+
+test('throwing dispatch then getter destroys its factory body', async (t) => {
+  const reason = new Error('then getter failed')
+  let thenReads = 0
+  const thenable = Object.defineProperty({}, 'then', {
+    get() {
+      thenReads++
+      throw reason
+    },
+  })
+  const dispatch = requestBodyFactory()(() => thenable)
+  const inner = new PassThrough()
+  let factorySignal
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: ({ signal }) => {
+        factorySignal = signal
+        return inner
+      },
+    },
+    { onError() {} },
+  )
+
+  t.equal(result, thenable, 'the original thenable is returned')
+  await tick()
+  await tick()
+
+  t.equal(thenReads, 1, 'the throwing then getter was observed once')
+  t.equal(inner.destroyed, true, 'factory-created stream was destroyed')
+  t.equal(factorySignal.aborted, true, 'factory cancellation signal was aborted')
+  t.equal(factorySignal.reason, reason, 'then getter error is the cancellation reason')
+})
+
+test('cleanup failure does not create an unhandled rejection', async (t) => {
+  const dispatchError = new Error('async dispatch failed')
+  const cleanupError = new Error('cleanup failed')
+  const inner = new PassThrough()
+  const unhandled = []
+  let factoryBody
+  let originalDestroy
+
+  const onUnhandledRejection = (err) => unhandled.push(err)
+  process.on('unhandledRejection', onUnhandledRejection)
+  t.teardown(() => {
+    process.removeListener('unhandledRejection', onUnhandledRejection)
+    if (factoryBody && originalDestroy) {
+      factoryBody.destroy = originalDestroy
+      factoryBody.destroy()
+    }
+  })
+
+  const dispatchResult = Promise.reject(dispatchError)
+  const dispatch = requestBodyFactory()((opts) => {
+    factoryBody = opts.body
+    originalDestroy = factoryBody.destroy
+    factoryBody.destroy = () => {
+      throw cleanupError
+    }
+    return dispatchResult
+  })
+
+  const result = dispatch(
+    {
+      method: 'PUT',
+      body: () => inner,
+    },
+    { onError() {} },
+  )
+
+  t.equal(result, dispatchResult, 'the original rejected promise is returned')
+  await t.rejects(result, dispatchError, 'the original dispatch rejection is preserved')
+  await tick()
+  await tick()
+
+  t.same(unhandled, [], 'the cleanup error was contained')
+})


### PR DESCRIPTION
## Summary

- observe every non-null dispatch result through `Promise.resolve` so then-only thenables and throwing `then` accessors trigger factory-body cleanup
- keep returning the original dispatch result unchanged
- contain cleanup exceptions so the detached rejection observer cannot create an unhandled rejection
- add focused regressions for all three edge cases

## Root cause

The async cleanup added in #173 inspected and invoked `.catch` directly. That skipped generic thenables without `.catch`, and a cleanup throw rejected the detached observer promise without a consumer.

This is a post-merge follow-up to the Copilot thread on #173.

## Validation

- `npx tap --disable-coverage --reporter=terse --jobs=1 test/review-body-factory-async-dispatch.js` (17 assertions)
- related body-factory regression suites (45 assertions)
- `npx tap --disable-coverage --reporter=terse --jobs=1 test/request-body-factory.js` (8 assertions)
- `npx eslint lib/interceptor/request-body-factory.js test/review-body-factory-async-dispatch.js`
- `npx prettier --check lib/interceptor/request-body-factory.js test/review-body-factory-async-dispatch.js`
- `git diff --check`