### PR TITLE
fix(cache-control): preserve quotes across field lines

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,16 +111,19 @@ function skipQuotedArgument(directives, i, value) {
 export function parseCacheControl(header) {
   let directives
   if (Array.isArray(header)) {
-    directives = []
+    if (header.length === 0) {
+      return null
+    }
     for (const line of header) {
       if (typeof line !== 'string') {
         return null
       }
-      directives.push(...splitCacheControlLine(line))
     }
-    if (directives.length === 0) {
-      return null
-    }
+    // RFC 9110 §5.2 combines repeated field lines with commas before the
+    // field value is interpreted. Parse that combined value in one pass so an
+    // unterminated quoted-string in one line cannot expose directive-shaped
+    // text in a later line.
+    directives = splitCacheControlLine(header.join(','))
   } else if (header && typeof header === 'string') {
     directives = splitCacheControlLine(header)
   } else {

--- a/test/review-bugfixes-4-cache-control.js
+++ b/test/review-bugfixes-4-cache-control.js
@@ -58,6 +58,20 @@ test('parseCacheControl - array value is combined and parsed', (t) => {
   t.end()
 })
 
+test('parseCacheControl - quoted-string state spans duplicated field lines', (t) => {
+  t.strictSame(
+    parseCacheControl(['example="unterminated', 'public, s-maxage=3600']),
+    {},
+    'a later field line cannot escape an unterminated extension value',
+  )
+  t.strictSame(
+    parseCacheControl(['no-cache="set-cookie', 'x-secret"', 'max-age=60']),
+    { 'no-cache': ['set-cookie', 'x-secret'], 'max-age': 60 },
+    'a quoted field-name list can legitimately continue across field lines',
+  )
+  t.end()
+})
+
 test('parseCacheControl - commas inside extension quoted strings stay data', (t) => {
   t.strictSame(
     parseCacheControl('example="x, max-age=31536000, public"'),
@@ -84,6 +98,7 @@ test('parseCacheControl - single-element array', (t) => {
 
 test('parseCacheControl - non-string values return null', (t) => {
   t.equal(parseCacheControl([]), null)
+  t.equal(parseCacheControl(['public', 1]), null)
   t.equal(parseCacheControl(123), null)
   t.equal(parseCacheControl(null), null)
   t.equal(parseCacheControl(undefined), null)


### PR DESCRIPTION
## Summary

- Combine duplicated `Cache-Control` field lines before parsing, matching RFC 9110 field combination semantics.
- Preserve quoted-string state across line boundaries so an unterminated extension value cannot expose `public`, `s-maxage`, or other directive-shaped text from a later field line.
- Keep rejecting non-string array members and preserve the empty-array contract.

Follow-up to the post-merge Copilot review on #105: https://github.com/nxtedition/nxt-undici/pull/105#discussion_r3564561432

## Tests

- Adds cross-line unterminated-quote injection coverage.
- Adds a legitimate quoted field-name list spanning duplicated lines.
- Adds mixed-type array rejection coverage.
- 147 focused assertions pass.
- Full cache conformance runs pass in default (249 passes) and heuristic (260 passes) modes with zero required or harness failures; the single retry is the documented baseline.
- ESLint, Prettier, and `git diff --check` pass.
