### PR TITLE
refactor(cache): internalize cache key construction

### DIFF
--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -98,6 +98,16 @@ export default ({ origins } = {}) => {
       return dispatch(opts, handler)
     }
 
+    // Standalone interceptor compositions bypass lib/index.js, which normally
+    // supplies the request method. Apply the same default at this public
+    // boundary so the cache gate, key and downstream dispatcher agree.
+    if (opts.method == null) {
+      opts = {
+        ...opts,
+        method: opts.body != null ? 'POST' : 'GET',
+      }
+    }
+
     // RFC-agnostic policy gate (undici PR #4739): when an origins whitelist is
     // configured, a request to any other origin bypasses the cache entirely —
     // neither stored/served nor invalidated.

--- a/lib/interceptor/cache/store.js
+++ b/lib/interceptor/cache/store.js
@@ -1,7 +1,6 @@
 // Store access and cache-key construction: the default (in-memory sqlite)
 // store, the never-throw get wrapper, the shared get/set key builder and the
 // per-request cache option extraction.
-import undici from '@nxtedition/undici'
 import { stringify } from 'fast-querystring'
 import { parseHeaders } from '../../utils.js'
 import { SqliteCacheStore } from '../../sqlite-cache-store.js'
@@ -14,11 +13,11 @@ export function getStore(opts) {
 
 /**
  * RFC 9110 §4.2.3 origin normalization: equivalent target URIs must share one
- * cache key. `makeCacheKey` stringifies `opts.origin` verbatim, so the SAME
- * logical origin fragments into distinct entries — costing hits and duplicating
- * storage — when callers vary the scheme/host case, spell out the default port,
- * or pass a URL object (whose `toString()` appends a trailing `/`) vs a bare
- * string:
+ * cache key. Cache-key construction stringifies `opts.origin` verbatim, so the
+ * SAME logical origin fragments into distinct entries — costing hits and
+ * duplicating storage — when callers vary the scheme/host case, spell out the
+ * default port, or pass a URL object (whose `toString()` appends a trailing `/`)
+ * vs a bare string:
  *
  *   https://example.com  ==  https://example.com:443  ==  HTTPS://EXAMPLE.COM
  *   new URL('https://example.com')  ->  'https://example.com/'
@@ -61,6 +60,63 @@ export function tryGetEntry(store, key, logger) {
   }
 }
 
+// Ignore an iterator polluted onto Object.prototype while retaining real own
+// and inherited iterators (Headers, Map and custom iterable header containers).
+function hasSafeIterator(value) {
+  if (value == null || value === Object.prototype) {
+    return false
+  }
+
+  if (Object.hasOwn(value, Symbol.iterator)) {
+    return typeof value[Symbol.iterator] === 'function'
+  }
+
+  let owner = Object.getPrototypeOf(value)
+  while (owner != null && owner !== Object.prototype) {
+    if (Object.hasOwn(owner, Symbol.iterator)) {
+      return typeof value[Symbol.iterator] === 'function'
+    }
+    owner = Object.getPrototypeOf(owner)
+  }
+
+  return false
+}
+
+function normalizeKeyHeaders(headers) {
+  if (headers == null) {
+    return Object.create(null)
+  }
+
+  let parsed
+
+  // Arrays are the undici flat name/value form. `parseHeaders` handles Buffer
+  // names/values, duplicate fields, nullish values and casing consistently.
+  if (Array.isArray(headers)) {
+    parsed = parseHeaders(headers)
+  } else {
+    if (typeof headers !== 'object') {
+      throw new Error('opts.headers is not an object')
+    }
+
+    if (hasSafeIterator(headers)) {
+      const flat = []
+      for (const entry of headers) {
+        if (!Array.isArray(entry) || entry.length !== 2) {
+          throw new Error('opts.headers is not a valid header map')
+        }
+        flat.push(entry[0], entry[1])
+      }
+      parsed = parseHeaders(flat)
+    } else {
+      parsed = parseHeaders(headers)
+    }
+  }
+
+  // Header names are caller-controlled, so return a fresh null-prototype
+  // snapshot. This also makes `__proto__` an ordinary data property.
+  return Object.assign(Object.create(null), parsed)
+}
+
 /**
  * Builds the cache key shared by the get and set paths.
  *
@@ -78,50 +134,29 @@ export function tryGetEntry(store, key, logger) {
  * this — keep the cache outboard of DNS resolution.
  */
 export function makeKey(opts) {
-  // Build the key the same way for lookups and stores: makeCacheKey
-  // stringifies the origin (e.g. URL objects), so using raw opts on the get
-  // path while the set path normalizes would make the cache permanently miss.
-  // The flat name/value array form of opts.headers (legal at the undici
-  // client level) makes makeCacheKey throw — normalize it through
-  // parseHeaders first (which also lowercases the names). Header names are
-  // caller-controlled, so copy the normalized result into a null-prototype
-  // target before passing it to undici's cache-key builder.
-  const key = undici.util.cache.makeCacheKey(
-    Array.isArray(opts.headers)
-      ? {
-          ...opts,
-          headers: Object.assign(Object.create(null), parseHeaders(opts.headers)),
-        }
-      : opts,
-  )
+  if (!opts.origin) {
+    throw new Error('opts.origin is missing')
+  }
+
+  // Own the complete cache-key contract here instead of coupling this cache to
+  // an undici utility export. The same builder serves lookups and stores, so URL
+  // objects, a missing root path and every supported header representation are
+  // normalized identically on both paths.
+  const key = {
+    origin: String(opts.origin),
+    method: opts.method ?? (opts.body != null ? 'POST' : 'GET'),
+    path: opts.path || '/',
+    headers: normalizeKeyHeaders(opts.headers),
+  }
 
   // Canonicalize equivalent target URIs onto one key (RFC 9110 §4.2.3): scheme
   // /host case and default ports must not fragment the cache. `key.origin` is
-  // the stringified origin makeCacheKey produced, so this normalizes both the
-  // get and set paths identically.
-  if (typeof key.origin === 'string') {
-    key.origin = normalizeOrigin(key.origin)
-  }
+  // already stringified, so this normalizes both the get and set paths
+  // identically.
+  key.origin = normalizeOrigin(key.origin)
 
-  // makeCacheKey preserves request header names verbatim. Vary selector names
-  // are lowercased (in CacheHandler and matchesValue), so lowercase the key's
-  // header names once here — the same key feeds both the get and set paths, so
-  // this keeps Vary matching symmetric even when a caller supplies non-lowercase
-  // header names (the standalone interceptors.cache() composition; the wrapped
-  // pipeline already normalizes). A fresh object avoids mutating opts.headers.
-  // Header names are caller-controlled, so build a null-prototype map (a
-  // `__proto__` key on a plain object would silently overwrite the prototype
-  // instead of setting a property) and copy own keys only.
-  if (key.headers && typeof key.headers === 'object') {
-    const lower = Object.create(null)
-    for (const name of Object.keys(key.headers)) {
-      lower[name.toLowerCase()] = key.headers[name]
-    }
-    key.headers = lower
-  }
-
-  // The vendored makeCacheKey ignores opts.query. The wrapped pipeline is
-  // immune (the query interceptor rewrites path before the cache sees it),
+  // Core key construction deliberately handles opts.query here. The wrapped
+  // pipeline is immune (the query interceptor rewrites path before the cache sees it),
   // but a standalone interceptors.cache() composition would silently collide
   // distinct query strings onto one entry and serve the wrong response
   // (undici issue #4209 / PR #5081) — fold the query into the key path.

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -77,11 +77,11 @@ export function traceUrl(opts) {
         str = URL.parse(str)?.origin ?? '[redacted]'
       }
       // A URL#origin never ends in '/', so an origin-position string ending
-      // in one is either the URL.toString() artifact (makeCacheKey
-      // stringifies URL instances: 'http://x/' + '/p' = 'http://x//p') or a
-      // caller-supplied trailing slash; both must converge with the
-      // URL-instance branch above, or cache docs and undici:request docs get
-      // different url tags for the same dispatch.
+      // in one is either a URL.toString() artifact (cache-key construction
+      // stringifies URL instances, so 'http://x/' + '/p' becomes
+      // 'http://x//p') or a caller-supplied trailing slash. Both must converge
+      // with the URL-instance branch above, or cache docs and undici:request
+      // docs get different url tags for the same dispatch.
       if (str.endsWith('/')) {
         str = str.slice(0, -1)
       }

--- a/test/cache-coverage-interceptor.js
+++ b/test/cache-coverage-interceptor.js
@@ -708,15 +708,15 @@ test('cache: unparseable Location header is skipped during invalidation', async 
   t.equal(docs[0].err, null)
 })
 
-test('cache: invalidation trace doc tolerates a key without a method', async (t) => {
-  // A custom dispatch fn (the interceptor contract) doesn't require
-  // opts.method the way the real Agent does — the trace tagging must not
-  // assume it is present.
+test('cache: standalone interceptor defaults a missing method', async (t) => {
   const writer = makeWriter()
   const store = makeRecordingStore()
+  let dispatchedMethod
   const wrapped = interceptors.cache()((opts, handler) => {
+    dispatchedMethod = opts.method
     handler.onConnect(() => {})
-    handler.onHeaders(204, {}, () => {})
+    handler.onHeaders(200, { 'cache-control': 'max-age=60' }, () => {})
+    handler.onData(Buffer.from('ok'))
     handler.onComplete([])
     return true
   })
@@ -732,13 +732,37 @@ test('cache: invalidation trace doc tolerates a key without a method', async (t)
     makeInnerHandler(),
   )
 
-  t.equal(store.deletes.length, 1, 'target URI invalidated')
-  const docs = writer.docs.filter((doc) => doc.op === 'undici:cache-invalidate')
-  t.equal(docs.length, 1)
-  t.equal(docs[0].method, null, 'absent method tagged as null')
-  t.equal(docs[0].url, 'http://fake-origin/x')
-  t.equal(docs[0].paths, 1)
-  t.equal(docs[0].err, null)
+  t.equal(dispatchedMethod, 'GET', 'bodyless dispatch defaults to GET')
+  t.equal(store.deletes.length, 0, 'default GET does not invalidate')
+  t.equal(store.sets.length, 1, 'default GET response is stored')
+  t.equal(store.sets[0].key.method, 'GET', 'stored key uses the default')
+  const lookup = writer.docs.find((doc) => doc.op === 'undici:cache')
+  t.equal(lookup.method, 'GET', 'trace uses the default')
+
+  const postStore = makeRecordingStore()
+  let dispatchedPostMethod
+  const wrappedPost = interceptors.cache()((opts, handler) => {
+    dispatchedPostMethod = opts.method
+    handler.onConnect(() => {})
+    handler.onHeaders(204, {}, () => {})
+    handler.onComplete([])
+    return true
+  })
+
+  wrappedPost(
+    {
+      origin: 'http://fake-origin',
+      path: '/x',
+      body: 'payload',
+      headers: {},
+      cache: { store: postStore },
+    },
+    makeInnerHandler(),
+  )
+
+  t.equal(dispatchedPostMethod, 'POST', 'body-bearing dispatch defaults to POST')
+  t.equal(postStore.deletes.length, 1, 'default POST invalidates')
+  t.equal(postStore.deletes[0].method, 'POST', 'invalidation key uses the default')
 })
 
 // ---------------------------------------------------------------------------

--- a/test/cache-key.js
+++ b/test/cache-key.js
@@ -1,0 +1,116 @@
+import { test } from 'tap'
+import { makeKey } from '../lib/interceptor/cache/store.js'
+
+const base = {
+  origin: 'https://example.test',
+  method: 'GET',
+}
+
+test('cache key owns origin, method and root-path normalization', (t) => {
+  const opaqueOrigin = {
+    [Symbol.toPrimitive]() {
+      return 'opaque-cache-origin'
+    },
+    toString() {
+      throw new Error('String(origin) must honor the primitive conversion hook')
+    },
+  }
+
+  const key = makeKey({ ...base, origin: opaqueOrigin })
+
+  t.equal(key.origin, 'opaque-cache-origin', 'origin is stringified before normalization')
+  t.equal(key.method, 'GET')
+  t.equal(makeKey({ ...base, method: undefined }).method, 'GET', 'bodyless method defaults to GET')
+  t.equal(
+    makeKey({ ...base, method: undefined, body: 'payload' }).method,
+    'POST',
+    'body-bearing method defaults to POST',
+  )
+  t.equal(key.path, '/', 'missing path defaults to the root path')
+  t.equal(Object.getPrototypeOf(key.headers), null, 'even an empty header map is prototype-safe')
+  t.end()
+})
+
+test('cache key normalizes flat, object and iterable headers identically', (t) => {
+  const objectHeaders = Object.create(null)
+  objectHeaders['X-Test'] = 'one'
+  objectHeaders['x-test'] = 'two'
+  objectHeaders['__proto__'] = 'safe'
+  objectHeaders['x-null'] = null
+  objectHeaders['x-number'] = 1
+
+  const inputs = [
+    ['X-Test', 'one', 'x-test', 'two', '__proto__', 'safe', 'x-null', null, 'x-number', 1],
+    objectHeaders,
+    new Map([
+      ['X-Test', 'one'],
+      ['x-test', 'two'],
+      ['__proto__', 'safe'],
+      ['x-null', null],
+      ['x-number', 1],
+    ]),
+  ]
+
+  for (const headers of inputs) {
+    const key = makeKey({ ...base, headers })
+    t.equal(Object.getPrototypeOf(key.headers), null)
+    t.strictSame(key.headers['x-test'], ['one', 'two'])
+    t.equal(key.headers['__proto__'], 'safe')
+    t.equal(key.headers['x-number'], '1')
+    t.notOk(Object.hasOwn(key.headers, 'x-null'))
+    t.strictSame(Object.keys(key.headers), ['x-test', '__proto__', 'x-number'])
+  }
+
+  t.equal(objectHeaders['X-Test'], 'one', 'object input is not mutated')
+  t.equal(objectHeaders['x-test'], 'two', 'normalization does not rewrite the input')
+  t.equal(Object.getPrototypeOf(objectHeaders), null, 'normalization preserves the input prototype')
+  t.end()
+})
+
+test('cache key preserves duplicate flat header values', (t) => {
+  const key = makeKey({
+    ...base,
+    headers: ['X-Test', 'one', 'x-test', 'two'],
+  })
+
+  t.strictSame(key.headers['x-test'], ['one', 'two'])
+  t.end()
+})
+
+test('cache key ignores an iterator polluted onto Object.prototype', (t) => {
+  const original = Object.getOwnPropertyDescriptor(Object.prototype, Symbol.iterator)
+  t.teardown(() => {
+    if (original === undefined) {
+      delete Object.prototype[Symbol.iterator]
+    } else {
+      Object.defineProperty(Object.prototype, Symbol.iterator, original)
+    }
+  })
+
+  Object.defineProperty(Object.prototype, Symbol.iterator, {
+    configurable: true,
+    value: function pollutedIterator() {
+      throw new Error('polluted iterator must not run')
+    },
+  })
+
+  const key = makeKey({ ...base, headers: { 'X-Test': 'one' } })
+  t.equal(key.headers['x-test'], 'one')
+  t.equal(Object.getPrototypeOf(key.headers), null)
+  t.end()
+})
+
+test('cache key retains iterable entry-shape validation', (t) => {
+  const malformedIterable = {
+    *[Symbol.iterator]() {
+      yield ['x-test']
+    },
+  }
+
+  t.throws(
+    () => makeKey({ ...base, headers: malformedIterable }),
+    /opts\.headers is not a valid header map/,
+  )
+  t.throws(() => makeKey({ ...base, headers: 'x-test: one' }), /opts\.headers is not an object/)
+  t.end()
+})

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -12,6 +12,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
 import { parseHttpDate } from '../lib/utils.js'
+import { makeKey } from '../lib/interceptor/cache/store.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
@@ -108,7 +109,7 @@ test('storability: a missing Date is appended at receipt before forwarding and s
   )
 
   await flush()
-  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  const entry = store.get(makeKey(opts))
   t.equal(entry.headers.date, first.headers.date, 'the same generated Date is stored')
 
   const second = await rawRequest(dispatch, opts)

--- a/test/review-bugfixes-4-cache-immutable.js
+++ b/test/review-bugfixes-4-cache-immutable.js
@@ -7,6 +7,7 @@ import { test } from 'tap'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
+import { makeKey } from '../lib/interceptor/cache/store.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
@@ -71,7 +72,7 @@ test('cache: immutable does not override explicit max-age (expires on schedule)'
   // Expiry-on-schedule is asserted from the stored entry instead of sleeping
   // past the TTL: max-age bounds the freshness lifetime, immutable does not
   // extend it.
-  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  const entry = store.get(makeKey(opts))
   t.equal(entry.staleAt - entry.cachedAt, 5000, 'freshness is max-age, not immutable')
 })
 
@@ -103,7 +104,7 @@ test('cache: immutable alone is not cached (immutable is not a freshness source)
   // response has no freshness and is not stored — the origin is hit each time.
   t.equal(hits, 2, 'immutable without a lifetime is not cached')
 
-  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  const entry = store.get(makeKey(opts))
   t.equal(entry, undefined, 'nothing stored for immutable-only')
 })
 
@@ -132,7 +133,7 @@ test('cache: explicit s-maxage wins over immutable', async (t) => {
   await rawRequest(dispatch, opts)
   t.equal(hits, 1, 'served from cache within the s-maxage window')
 
-  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  const entry = store.get(makeKey(opts))
   t.equal(
     entry.staleAt - entry.cachedAt,
     60 * 1000,

--- a/test/review-bugfixes-5-directives.js
+++ b/test/review-bugfixes-5-directives.js
@@ -37,6 +37,7 @@ import {
   forbidsRequestDrivenStale,
 } from '../lib/interceptor/cache/freshness.js'
 import { CacheHandler } from '../lib/interceptor/cache/cache-handler.js'
+import { makeKey } from '../lib/interceptor/cache/store.js'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
 import undici from '@nxtedition/undici'
 
@@ -264,7 +265,7 @@ test('authorization permission requires syntactically valid response directives'
     await rawRequest(makeDispatch(), opts)
     await new Promise((resolve) => setImmediate(resolve))
     t.equal(
-      store.get(undici.util.cache.makeCacheKey(opts)),
+      store.get(makeKey(opts)),
       undefined,
       `${cacheControl}: authenticated response was not shared`,
     )

--- a/test/review-bugfixes-5-revalidation.js
+++ b/test/review-bugfixes-5-revalidation.js
@@ -21,6 +21,7 @@ import { createServer } from 'node:http'
 import { once } from 'node:events'
 import { interceptors, compose, cache as cacheModule } from '../lib/index.js'
 import { parseHttpDate } from '../lib/utils.js'
+import { makeKey } from '../lib/interceptor/cache/store.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
@@ -163,7 +164,7 @@ test('304 freshening appends a missing Date at validation receipt', async (t) =>
   )
 
   await settle()
-  const entry = store.get(undici.util.cache.makeCacheKey(opts))
+  const entry = store.get(makeKey(opts))
   t.equal(entry.headers.date, response.headers.date, 'the generated 304 Date updated storage')
   t.end()
 })

--- a/test/review-bugfixes-cache-2.js
+++ b/test/review-bugfixes-cache-2.js
@@ -419,7 +419,7 @@ test('cache: caller preconditions are ignored for a fresh cached redirect', asyn
 })
 
 // ---------------------------------------------------------------------------
-// get/set key asymmetry: the set path normalized the key via makeCacheKey
+// get/set key asymmetry: the set path normalized the key via makeKey
 // (origin.toString()) while the get path used raw opts, so a URL-object origin
 // could never produce a cache hit.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- move the cache-key contract into the package that owns the cache implementation
- remove the last use of `@nxtedition/undici`'s orphaned `util.cache` helper
- normalize origin/path/query plus flat, object, and iterable headers through one representation-independent path
- preserve duplicate values, ignore nullish values consistently, stringify scalar values, and retain prototype-pollution safety
- default missing standalone methods exactly like the main wrapper (`GET` without a body, `POST` with one)
- update storage assertions to exercise the actual shared `makeKey` boundary

This is the migration counterpart to the now-merged `nxtedition/undici#37` cache-helper removal.

## Validation
- final focused cache set before latest-main rebase: 429/429 assertions passed
- post-rebase key/interceptor set: 207/207 assertions passed
- broader cache integration: 215/215 passed
- ESLint and Prettier clean for changed files (one existing file-level warning remains)
- declaration/type tests and package dry-run pass
- full-suite-only load timeouts reproduce on the unchanged checkout; each affected file passes isolated