### PR TITLE
fix(proxy): preserve prototype-named headers

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -5,12 +5,16 @@ import { DecoratorHandler } from '../utils.js'
 function noop() {}
 
 function setOwnHeader(headers, key, value) {
-  Object.defineProperty(headers, key, {
-    value,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  })
+  if (key === '__proto__') {
+    Object.defineProperty(headers, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  } else {
+    headers[key] = value
+  }
 }
 
 // Accumulator used by reduceHeaders on the response path. Hoisted to module

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -4,6 +4,15 @@ import { DecoratorHandler } from '../utils.js'
 
 function noop() {}
 
+function setOwnHeader(headers, key, value) {
+  Object.defineProperty(headers, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
+}
+
 // Accumulator used by reduceHeaders on the response path. Hoisted to module
 // scope so it is allocated once rather than on every onHeaders/onUpgrade call.
 /**
@@ -13,7 +22,7 @@ function noop() {}
  * @returns {Record<string, string | string[]>}
  */
 const copyHeader = (acc, key, val) => {
-  acc[key] = val
+  setOwnHeader(acc, key, val)
   return acc
 }
 
@@ -455,7 +464,7 @@ export default () => (dispatch) => (opts, handler) => {
       } else if (key.length === 6 && eqiLower(key, 'expect')) {
         // undici doesn't support expect header.
       } else {
-        obj[key] = val
+        setOwnHeader(obj, key, val)
       }
       return obj
     },

--- a/test/proxy-prototype-safe-headers.js
+++ b/test/proxy-prototype-safe-headers.js
@@ -1,0 +1,75 @@
+import { test } from 'tap'
+import { compose, interceptors, parseHeaders } from '../lib/index.js'
+
+function requestHeaders(headers) {
+  let forwarded
+  const dispatch = compose((opts, handler) => {
+    forwarded = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers, proxy: {} },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return forwarded
+}
+
+function responseHeaders(headers) {
+  let forwarded
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, headers, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers: {}, proxy: {} },
+    {
+      onConnect() {},
+      onHeaders(statusCode, received) {
+        forwarded = received
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return forwarded
+}
+
+function assertSafeProtoHeader(t, headers, expected) {
+  t.equal(Object.getPrototypeOf(headers), Object.prototype, 'output prototype is unchanged')
+  t.ok(Object.hasOwn(headers, '__proto__'), '__proto__ remains an own header')
+  t.strictSame(headers.__proto__, expected, 'header value is preserved')
+  t.equal(headers['x-keep'], 'yes', 'ordinary headers are preserved')
+}
+
+test('proxy: request reduction safely preserves a repeated __proto__ header', (t) => {
+  const headers = parseHeaders(['__proto__', 'first', '__proto__', 'second', 'x-keep', 'yes'])
+
+  assertSafeProtoHeader(t, requestHeaders(headers), ['first', 'second'])
+  t.end()
+})
+
+test('proxy: response reduction safely preserves a single __proto__ header', (t) => {
+  const headers = parseHeaders(['__proto__', 'single', 'x-keep', 'yes'])
+
+  assertSafeProtoHeader(t, responseHeaders(headers), 'single')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- Define retained proxy headers as own data properties on both request and response output maps.
- Preserve the valid `__proto__` HTTP field name instead of invoking `Object.prototype.__proto__`'s legacy setter.
- Keep the output object's prototype unchanged even when a repeated `__proto__` field arrives as an array.

## Root cause

`parseHeaders()` deliberately creates prototype-named fields with `Object.defineProperty`, but the proxy rebuilt its header maps with `acc[key] = value` on ordinary objects. A scalar `__proto__` value was silently dropped; an array value replaced the output object's prototype.

## Tests

- Adds request-path coverage for repeated `__proto__` values.
- Adds response-path coverage for a scalar `__proto__` value.
- Verifies own-property preservation, unchanged prototypes, and ordinary-header passthrough.
- Full focused proxy run: 148 assertions pass across 11 suites.
- ESLint, Prettier, and `git diff --check` pass.