### PR TITLE
docs(proxy): clarify Forwarded handling

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -178,11 +178,11 @@ function joinNonEmptyHeaderValues(value) {
  *   segment; defaults to `'HTTP/1.1'`.
  * @param {{ localAddress?: string, localPort?: number, remoteAddress?: string,
  *   remotePort?: number, encrypted?: boolean } | null} [options.socket] Request
- *   path only: when present, a Forwarded element is synthesised and appended
+ *   path only: when present, a Forwarded element is synthesized and appended
  *   after any non-empty inbound value. Without a socket, a non-empty inbound
  *   Forwarded value is treated as a BadGateway.
  * @param {boolean} [options.isResponse] Response path marker. When set,
- *   Forwarded is never synthesised regardless of `socket` (it would leak the
+ *   Forwarded is never synthesized regardless of `socket` (it would leak the
  *   proxy's own addresses downstream), and a non-empty inbound value is
  *   rejected. Empty Forwarded values are dropped on either path.
  * @param {(acc: T, key: string, value: string | string[]) => T} fn Accumulator

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -178,11 +178,13 @@ function joinNonEmptyHeaderValues(value) {
  *   segment; defaults to `'HTTP/1.1'`.
  * @param {{ localAddress?: string, localPort?: number, remoteAddress?: string,
  *   remotePort?: number, encrypted?: boolean } | null} [options.socket] Request
- *   path only: when present a Forwarded header is synthesised. An inbound
- *   Forwarded header is always treated as a BadGateway (it is request-only).
+ *   path only: when present, a Forwarded element is synthesised and appended
+ *   after any non-empty inbound value. Without a socket, a non-empty inbound
+ *   Forwarded value is treated as a BadGateway.
  * @param {boolean} [options.isResponse] Response path marker. When set,
  *   Forwarded is never synthesised regardless of `socket` (it would leak the
- *   proxy's own addresses downstream); an inbound Forwarded is still rejected.
+ *   proxy's own addresses downstream), and a non-empty inbound value is
+ *   rejected. Empty Forwarded values are dropped on either path.
  * @param {(acc: T, key: string, value: string | string[]) => T} fn Accumulator
  *   invoked once per retained header. The value is an array when the field
  *   appeared more than once (parseHeaders shape) — never pre-joined, because


### PR DESCRIPTION
## What changed

- Clarify how `reduceHeaders` handles inbound `Forwarded` values on request and response paths.
- Document that a request with a socket appends a synthesized element, non-empty values are rejected without a socket or on responses, and empty values are dropped.

## Why

The existing JSDoc said inbound `Forwarded` was always rejected, while the implementation deliberately distinguishes these cases. This resolves the outstanding documentation review comment from #19 without changing runtime behavior.

## Impact

Documentation-only. Proxy behavior is unchanged.

## Validation

- ESLint
- Prettier check
- `git diff --check`
- `node --check lib/interceptor/proxy.js`
- Seven proxy test suites: 91 assertions passed
