### PR TITLE
fix(proxy): normalize standalone header inputs

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import createError from 'http-errors'
-import { DecoratorHandler } from '../utils.js'
+import { DecoratorHandler, parseHeaders } from '../utils.js'
 
 function noop() {}
 
@@ -435,7 +435,11 @@ export default () => (dispatch) => (opts, handler) => {
 
   const headers = reduceHeaders(
     {
-      headers: opts.headers ?? {},
+      // The interceptor is public and can be composed without request(), so
+      // opts.headers may still be any HeaderInput shape (including a raw flat
+      // array or nullish object values). parseHeaders owns normalization and
+      // is an O(1) identity operation for the package's trusted snapshots.
+      headers: parseHeaders(opts.headers),
       httpVersion: opts.proxy.httpVersion ?? opts.proxy.req?.httpVersion,
       socket: opts.proxy.socket ?? opts.proxy.req?.socket,
       proxyName: opts.proxy.name,

--- a/test/proxy-normalize-header-input.js
+++ b/test/proxy-normalize-header-input.js
@@ -1,0 +1,65 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function proxyRequestHeaders(headers) {
+  let captured
+  const base = (opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }
+  const dispatch = compose(base, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers,
+      proxy: {},
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  return captured
+}
+
+test('proxy: standalone composition normalizes flat-array headers', (t) => {
+  const headers = proxyRequestHeaders([
+    'Connection',
+    'X-Per-Hop',
+    'X-Per-Hop',
+    'must not leak',
+    'X-Keep',
+    'preserved',
+  ])
+
+  t.notOk('connection' in headers, 'Connection is stripped')
+  t.notOk('x-per-hop' in headers, 'Connection-nominated header is stripped')
+  t.equal(headers['x-keep'], 'preserved', 'ordinary header is normalized and preserved')
+  t.end()
+})
+
+test('proxy: standalone composition drops nullish object header values', (t) => {
+  const headers = proxyRequestHeaders({
+    'X-Null': null,
+    'X-Undefined': undefined,
+    'X-Keep': 'preserved',
+  })
+
+  t.notOk('x-null' in headers, 'null header is dropped')
+  t.notOk('x-undefined' in headers, 'undefined header is dropped')
+  t.equal(headers['x-keep'], 'preserved', 'ordinary header is normalized and preserved')
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Route proxy request headers through `parseHeaders()` before reducing hop-by-hop fields.
- Preserve the private normalized-header identity fast path for the default request pipeline.
- Add standalone-composition regressions for flat header arrays, `Connection`-nominated stripping, case normalization, and nullish object values.

## Root cause

The public proxy interceptor can be composed directly, where `DispatchOptions.headers` is still the full `HeaderInput` union. `reduceHeaders()` assumed a normalized object map: flat arrays were treated as numeric object properties, while null or undefined object values reached `.toString()` and threw. The default `request()` pipeline hid this because it normalizes at its public boundary.

## Impact

Standalone proxy composition now accepts the same documented header shapes as the rest of the public dispatch API. Already-normalized package-owned snapshots remain O(1) through `parseHeaders()` and are not walked again.

## Validation

- proxy-focused and related regression matrix: 147/147 assertions
- normalized-header fast-path plus new focused tests: 23/23 assertions
- public declaration compilation included in the focused matrix
- ESLint
- Prettier
- `git diff --check`