### PR TITLE
fix(proxy): reject conflicting request authorities

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -262,7 +262,6 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   let host = ''
   let hostSeen = false
   let authority = ''
-  let authoritySeen = false
   let scheme
   /** @type {string | string[]} */
   let connection = ''
@@ -337,15 +336,18 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       // :authority is singular (RFC 9113 §8.3.1): reject more than one. Pseudo
       // headers are always lowercase, so an exact compare is correct here.
       const v = headers[key]
-      if (authoritySeen || Array.isArray(v)) {
+      if (Array.isArray(v)) {
         throw new createError.BadGateway()
       }
       authority = v
-      authoritySeen = true
     }
   }
 
-  if (!isResponse && hostSeen && authoritySeen) {
+  const authorityValue = headers[':authority']
+  const hasAuthority =
+    Object.hasOwn(headers, ':authority') &&
+    (!Array.isArray(authorityValue) || authorityValue.length !== 0)
+  if (!isResponse && hostSeen && hasAuthority) {
     // RFC 9113 §8.3.1 forbids Host and :authority from identifying different
     // entities. Compare normalized authorities so harmless spelling differences
     // (host casing, a scheme's explicit default port) remain valid, while an

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -1,4 +1,5 @@
 import net from 'node:net'
+import { domainToASCII } from 'node:url'
 import createError from 'http-errors'
 import { DecoratorHandler } from '../utils.js'
 
@@ -164,6 +165,69 @@ function joinNonEmptyHeaderValues(value) {
   return joined
 }
 
+/**
+ * Normalize an HTTP authority for comparison. A neutral URL scheme keeps an
+ * explicit port intact so the request's actual scheme can decide whether that
+ * port is the default. Invalid authorities fail closed instead of falling back
+ * to a raw string comparison.
+ *
+ * @param {unknown} value
+ * @param {unknown} scheme
+ * @returns {string | null}
+ */
+function normalizeAuthority(value, scheme) {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('@')) {
+    return null
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code <= 0x20 || code === 0x7f) {
+      return null
+    }
+  }
+
+  let normalizedScheme = ''
+  if (scheme != null) {
+    if (typeof scheme !== 'string' || !/^[a-z][a-z\d+.-]*$/i.test(scheme)) {
+      return null
+    }
+    normalizedScheme = scheme.toLowerCase()
+  }
+
+  const url = URL.parse(`nxt-authority://${value}`)
+  if (
+    url == null ||
+    url.hostname === '' ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.pathname !== '' ||
+    url.search !== '' ||
+    url.hash !== ''
+  ) {
+    return null
+  }
+
+  // WHATWG URL keeps IPv6 literals bracketed. Preserve that unambiguous form
+  // directly; domainToASCII is for registered names (and IPv4 spellings), not
+  // IP-literal canonicalization.
+  const hostname =
+    url.hostname[0] === '[' ? url.hostname.toLowerCase() : domainToASCII(url.hostname)
+  if (hostname === '') {
+    return null
+  }
+
+  let port = url.port
+  if (
+    (normalizedScheme === 'http' && port === '80') ||
+    (normalizedScheme === 'https' && port === '443')
+  ) {
+    port = ''
+  }
+
+  return port ? `${hostname}:${port}` : hostname
+}
+
 // Removes hop-by-hop and pseudo headers.
 // Updates via and forwarded headers.
 // Only hop-by-hop headers may be set using the Connection general header.
@@ -198,6 +262,8 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   let host = ''
   let hostSeen = false
   let authority = ''
+  let authoritySeen = false
+  let scheme
   /** @type {string | string[]} */
   let connection = ''
   let connectionSeen = false
@@ -265,14 +331,30 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
         connection = v
         connectionSeen = true
       }
+    } else if (len === 7 && key === ':scheme') {
+      scheme = headers[key]
     } else if (len === 10 && key === ':authority') {
       // :authority is singular (RFC 9113 §8.3.1): reject more than one. Pseudo
       // headers are always lowercase, so an exact compare is correct here.
       const v = headers[key]
-      if (Array.isArray(v)) {
+      if (authoritySeen || Array.isArray(v)) {
         throw new createError.BadGateway()
       }
       authority = v
+      authoritySeen = true
+    }
+  }
+
+  if (!isResponse && hostSeen && authoritySeen) {
+    // RFC 9113 §8.3.1 forbids Host and :authority from identifying different
+    // entities. Compare normalized authorities so harmless spelling differences
+    // (host casing, a scheme's explicit default port) remain valid, while an
+    // invalid authority cannot bypass the check by appearing identically in both.
+    const requestScheme = scheme ?? (socket ? (socket.encrypted ? 'https' : 'http') : undefined)
+    const normalizedHost = normalizeAuthority(host, requestScheme)
+    const normalizedAuthority = normalizeAuthority(authority, requestScheme)
+    if (normalizedHost == null || normalizedHost !== normalizedAuthority) {
+      throw new createError.BadGateway()
     }
   }
 

--- a/test/proxy-authority-consistency.js
+++ b/test/proxy-authority-consistency.js
@@ -1,0 +1,109 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function requestHeaders(headers, proxy = {}) {
+  let captured
+  const base = (opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }
+  const dispatch = compose(base, interceptors.proxy())
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers, proxy },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return captured
+}
+
+test('proxy: rejects differing Host and :authority values', (t) => {
+  t.throws(
+    () =>
+      requestHeaders({
+        host: 'public.example',
+        ':authority': 'internal.example',
+        ':scheme': 'https',
+      }),
+    { statusCode: 502 },
+  )
+  t.end()
+})
+
+test('proxy: accepts case and default-port equivalent authorities', (t) => {
+  const https = requestHeaders(
+    {
+      host: 'EXAMPLE.COM:443',
+      ':authority': 'example.com',
+      ':scheme': 'HTTPS',
+    },
+    {
+      socket: {
+        localAddress: '192.0.2.1',
+        remoteAddress: '192.0.2.2',
+        encrypted: true,
+      },
+    },
+  )
+  t.match(https.forwarded, /host="example\.com"/)
+
+  const http = requestHeaders({
+    host: 'example.com:080',
+    ':authority': 'EXAMPLE.COM',
+    ':scheme': 'http',
+  })
+  t.notOk('host' in http)
+  t.notOk(':authority' in http)
+  t.end()
+})
+
+test('proxy: keeps non-default ports significant', (t) => {
+  t.throws(
+    () =>
+      requestHeaders({
+        host: 'example.com:8443',
+        ':authority': 'example.com',
+        ':scheme': 'https',
+      }),
+    { statusCode: 502 },
+  )
+  t.end()
+})
+
+test('proxy: accepts equivalent bracketed IPv6 authorities', (t) => {
+  const headers = requestHeaders({
+    host: '[2001:0DB8::1]:443',
+    ':authority': '[2001:db8::1]',
+    ':scheme': 'https',
+  })
+
+  t.notOk('host' in headers)
+  t.notOk(':authority' in headers)
+  t.end()
+})
+
+test('proxy: rejects invalid authorities even when their strings match', (t) => {
+  for (const authority of ['user@example.com', 'example.com:99999', 'example.com/path']) {
+    t.throws(
+      () =>
+        requestHeaders({
+          host: authority,
+          ':authority': authority,
+          ':scheme': 'https',
+        }),
+      { statusCode: 502 },
+      authority,
+    )
+  }
+  t.end()
+})


### PR DESCRIPTION
## Summary

- reject proxied requests whose `Host` and `:authority` identify different entities
- compare authorities after host canonicalization and HTTP/HTTPS default-port normalization
- fail closed for invalid paired authorities while preserving valid case/default-port-equivalent pairs
- preserve and regression-test canonical bracketed IPv6 authorities

## Why

RFC 9113 requires `Host` and `:authority` to agree. The proxy previously preferred `:authority` for `Forwarded` metadata but silently accepted a conflicting `Host`, allowing a malformed HTTP/2 request to cross the intermediary boundary.

## Validation

- all 8 proxy-focused suites: 101 assertions
- ESLint
- Prettier check
- `git diff --check`