### PR TITLE
fix(proxy): parse Via comments for loop detection

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -101,7 +101,7 @@ function eqiLower(a, b) {
 
 // Via is a comma list, but each member may end in a nested HTTP comment whose
 // ctext can itself contain commas and quoted-pair escapes (RFC 9110 §7.6.3,
-// §5.6.5). Only top-level commas delimit received-by values for loop checks.
+// §5.6.5). Only top-level commas delimit members for loop checks.
 function viaSegmentHasReceivedBy(via, start, end, proxyName) {
   let i = start
   while (i < end && (via.charCodeAt(i) === 0x20 || via.charCodeAt(i) === 0x09)) {

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -99,6 +99,63 @@ function eqiLower(a, b) {
   return true
 }
 
+// Via is a comma list, but each member may end in a nested HTTP comment whose
+// ctext can itself contain commas and quoted-pair escapes (RFC 9110 §7.6.3,
+// §5.6.5). Only top-level commas delimit received-by values for loop checks.
+function viaSegmentHasReceivedBy(via, start, end, proxyName) {
+  let i = start
+  while (i < end && (via.charCodeAt(i) === 0x20 || via.charCodeAt(i) === 0x09)) {
+    i++
+  }
+  while (i < end && via.charCodeAt(i) !== 0x20 && via.charCodeAt(i) !== 0x09) {
+    i++
+  }
+  while (i < end && (via.charCodeAt(i) === 0x20 || via.charCodeAt(i) === 0x09)) {
+    i++
+  }
+
+  const receivedByStart = i
+  while (
+    i < end &&
+    via.charCodeAt(i) !== 0x20 &&
+    via.charCodeAt(i) !== 0x09 &&
+    via.charCodeAt(i) !== 0x28 /* '(' */
+  ) {
+    i++
+  }
+  return i > receivedByStart && via.slice(receivedByStart, i) === proxyName
+}
+
+function viaHasReceivedBy(via, proxyName) {
+  let start = 0
+  let commentDepth = 0
+  let escaped = false
+
+  for (let i = 0; i < via.length; i++) {
+    const char = via.charCodeAt(i)
+    if (commentDepth !== 0) {
+      if (escaped) {
+        escaped = false
+      } else if (char === 0x5c /* '\\' */) {
+        escaped = true
+      } else if (char === 0x28 /* '(' */) {
+        commentDepth++
+      } else if (char === 0x29 /* ')' */) {
+        commentDepth--
+      }
+    } else if (char === 0x28 /* '(' */) {
+      commentDepth = 1
+    } else if (char === 0x2c /* ',' */) {
+      if (viaSegmentHasReceivedBy(via, start, i, proxyName)) {
+        return true
+      }
+      start = i + 1
+    }
+  }
+
+  return viaSegmentHasReceivedBy(via, start, via.length, proxyName)
+}
+
 // Matches hop-by-hop headers — meaningful only for a single transport-level
 // connection, so a proxy must not retransmit or cache them. This is the single
 // source of truth for that set: it is used both for the per-key strip below
@@ -367,13 +424,7 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       // whether the whole segment ends with proxyName — endsWith() trips a
       // false-positive loop for any unrelated proxy whose name merely has
       // proxyName as a suffix (e.g. name 'proxy' vs upstream 'otherproxy').
-      if (
-        viaLower.includes(proxyNameLower) &&
-        viaLower.split(',').some((seg) => {
-          const by = seg.trim().split(/\s+/)[1]
-          return by != null && by === proxyNameLower
-        })
-      ) {
+      if (viaLower.includes(proxyNameLower) && viaHasReceivedBy(viaLower, proxyNameLower)) {
         throw new createError.LoopDetected()
       }
       via += ', '

--- a/test/proxy-via-comments.js
+++ b/test/proxy-via-comments.js
@@ -44,6 +44,12 @@ test('proxy: a Via received-by lookalike inside a comment is not a loop', async 
   t.equal(headers.via, '1.1 upstream (outer (note, 1.1 edge , tail)), HTTP/1.1 edge')
 })
 
+test('proxy: quoted-pair parentheses keep a Via comma inside its comment', async (t) => {
+  const headers = await responseWithVia('1.1 upstream (note\\) still comment, 1.1 edge)', 'edge')
+
+  t.equal(headers.via, '1.1 upstream (note\\) still comment, 1.1 edge), HTTP/1.1 edge')
+})
+
 test('proxy: a genuine Via loop is found before a comma-bearing comment', async (t) => {
   await t.rejects(responseWithVia('1.1 edge (note, other proxy)', 'edge'), { statusCode: 508 })
 })

--- a/test/proxy-via-comments.js
+++ b/test/proxy-via-comments.js
@@ -1,0 +1,49 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function responseWithVia(via, name) {
+  return new Promise((resolve, reject) => {
+    const dispatch = compose((opts, handler) => {
+      handler.onConnect(() => {})
+      try {
+        handler.onHeaders(200, { via }, () => {})
+        handler.onComplete([])
+      } catch (err) {
+        handler.onError(err)
+      }
+    }, interceptors.proxy())
+
+    let received
+    dispatch(
+      {
+        origin: 'http://upstream.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        proxy: { name },
+      },
+      {
+        onConnect() {},
+        onHeaders(statusCode, headers) {
+          received = headers
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(received)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('proxy: a Via received-by lookalike inside a comment is not a loop', async (t) => {
+  const headers = await responseWithVia('1.1 upstream (outer (note, 1.1 edge , tail))', 'edge')
+
+  t.equal(headers.via, '1.1 upstream (outer (note, 1.1 edge , tail)), HTTP/1.1 edge')
+})
+
+test('proxy: a genuine Via loop is found before a comma-bearing comment', async (t) => {
+  await t.rejects(responseWithVia('1.1 edge (note, other proxy)', 'edge'), { statusCode: 508 })
+})


### PR DESCRIPTION
## Summary

- Parse Via list delimiters without treating commas inside HTTP comments as new proxy segments.
- Track nested comments and quoted-pair escapes while locating each top-level `received-by` token.
- Keep the existing case-insensitive fast rejection and genuine-loop behavior.

## Root cause

Loop detection used `via.split(",")`. RFC 9110 allows Via members to end in comments, and HTTP comment text can contain commas. A valid value such as `1.1 upstream (note, 1.1 edge , tail)` therefore made comment text look like a real `received-by` segment and incorrectly raised 508 Loop Detected.

## Tests

- Adds a nested comma-bearing comment containing a received-by lookalike.
- Verifies a genuine loop before a comma-bearing comment still raises 508.
- 82 focused assertions pass across the affected Via and header-preservation suites.
- ESLint, Prettier, and `git diff --check` pass.