### PR TITLE
fix(proxy): accept singleton authority arrays

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -235,9 +235,19 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       }
     } else if (len === 4 && eqiLower(key, 'host')) {
       // Host is singular (RFC 9110 §7.2, RFC 7230 §5.4): more than one is a
-      // protocol error, so reject rather than combine.
-      const v = headers[key]
-      if (hostSeen || Array.isArray(v)) {
+      // protocol error, so reject rather than combine. HeaderInput also allows
+      // callers to express zero or one field value as [] / [value].
+      let v = headers[key]
+      if (Array.isArray(v)) {
+        if (v.length > 1) {
+          throw new createError.BadGateway()
+        }
+        if (v.length === 0) {
+          continue
+        }
+        v = v[0]
+      }
+      if (hostSeen) {
         throw new createError.BadGateway()
       }
       host = v
@@ -268,9 +278,16 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     } else if (len === 10 && key === ':authority') {
       // :authority is singular (RFC 9113 §8.3.1): reject more than one. Pseudo
       // headers are always lowercase, so an exact compare is correct here.
-      const v = headers[key]
+      // As with Host, [] means absent and [value] is one field value.
+      let v = headers[key]
       if (Array.isArray(v)) {
-        throw new createError.BadGateway()
+        if (v.length > 1) {
+          throw new createError.BadGateway()
+        }
+        if (v.length === 0) {
+          continue
+        }
+        v = v[0]
       }
       authority = v
     }

--- a/test/proxy-singleton-authority-values.js
+++ b/test/proxy-singleton-authority-values.js
@@ -1,0 +1,95 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function proxyRequestHeaders(headers) {
+  let captured
+  const base = (opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }
+  const dispatch = compose(base, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers,
+      proxy: {
+        socket: {
+          localAddress: '192.0.2.1',
+          encrypted: false,
+        },
+      },
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  return captured
+}
+
+test('proxy: singleton Host array is one field value', (t) => {
+  const headers = proxyRequestHeaders({ host: ['example.test'] })
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=http;host="example.test"')
+  t.end()
+})
+
+test('proxy: empty Host array is absent', (t) => {
+  const headers = proxyRequestHeaders({ host: [] })
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=http')
+  t.end()
+})
+
+test('proxy: singleton :authority array is one field value', (t) => {
+  const headers = proxyRequestHeaders({ ':authority': ['example.test'] })
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=http;host="example.test"')
+  t.end()
+})
+
+test('proxy: empty :authority array is absent', (t) => {
+  const headers = proxyRequestHeaders({ ':authority': [] })
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=http')
+  t.end()
+})
+
+test('proxy: multiple Host array values are rejected', (t) => {
+  t.throws(() => proxyRequestHeaders({ host: ['one.test', 'two.test'] }), { statusCode: 502 })
+  t.end()
+})
+
+test('proxy: multiple :authority array values are rejected', (t) => {
+  t.throws(() => proxyRequestHeaders({ ':authority': ['one.test', 'two.test'] }), {
+    statusCode: 502,
+  })
+  t.end()
+})
+
+test('proxy: case-variant Host fields remain duplicates', (t) => {
+  t.throws(() => proxyRequestHeaders({ Host: ['one.test'], host: ['two.test'] }), {
+    statusCode: 502,
+  })
+  t.end()
+})
+
+test('proxy: an empty Host array does not create a duplicate', (t) => {
+  const headers = proxyRequestHeaders({ Host: [], host: ['example.test'] })
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=http;host="example.test"')
+  t.end()
+})


### PR DESCRIPTION
## What changed

- Treat `Host: []` and `:authority: []` as absent fields.
- Treat one-element arrays as one singular field value and preserve them in synthesized `Forwarded` provenance.
- Continue rejecting arrays with more than one value and case-variant duplicate `Host` fields.
- Add focused standalone-composition regressions for every cardinality and duplicate case.

## Root cause

`HeaderInput` permits array-valued object headers, including zero- and one-element arrays. Proxy reduction treated every array-valued `Host` or `:authority` as proof of repeated field lines, so valid singleton values failed with `502 Bad Gateway`. The duplicate guard was testing representation rather than cardinality.

## Impact

Callers can use the documented array header shape for singular authority fields without weakening request-smuggling protections: only zero or one value is accepted, while actual duplicates still fail closed.

This is intentionally independent of the standalone header-normalization and prototype-safety fixes.

## Validation

- focused proxy and related regression matrix: 149/149 assertions
- new authority-cardinality regressions: 8/8 assertions
- public declaration compilation included in the focused matrix
- ESLint
- Prettier
- `git diff --check`