### PR TITLE
fix(proxy): sanitize retry callback headers on every attempt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,9 +122,13 @@ function wrapDispatch(dispatcher) {
       interceptors.priority(),
       interceptors.dns(),
       interceptors.requestBodyFactory(),
+      // Keep proxy inside responseRetry: a retry strategy may legitimately
+      // mutate opts.headers, so every actual attempt must cross the proxy
+      // boundary and have hop-by-hop fields removed. proxy() builds a fresh
+      // header map, which also prevents Via/Forwarded from accumulating.
+      interceptors.proxy(),
       interceptors.responseRetry(),
       interceptors.responseVerify(),
-      interceptors.proxy(),
       interceptors.cache(),
       interceptors.redirect(),
       // log also emits the undici:request trace start/end docs. Later entries

--- a/test/proxy-retry-boundary.js
+++ b/test/proxy-retry-boundary.js
@@ -1,0 +1,49 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+
+test('proxy sanitizes headers added by a retry callback on every attempt', async (t) => {
+  const requests = []
+  const server = createServer((req, res) => {
+    requests.push(req.headers)
+
+    if (requests.length === 1) {
+      res.statusCode = 503
+      res.end('retry')
+      return
+    }
+
+    res.end('ok')
+  })
+
+  t.teardown(() => server.close())
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const { body } = await request(`http://127.0.0.1:${server.address().port}`, {
+    proxy: { name: 'edge' },
+    retry: (err, retryCount, opts) => {
+      t.equal(err.statusCode, 503)
+      t.equal(retryCount, 0)
+
+      opts.headers.connection = 'x-secret'
+      opts.headers['x-secret'] = 'must-not-leak'
+      opts.headers['proxy-authorization'] = 'must-not-leak'
+      opts.headers['x-retry-attempt'] = '2'
+      return true
+    },
+  })
+
+  t.equal(await body.text(), 'ok')
+  t.equal(requests.length, 2)
+  t.not(requests[1].connection, 'x-secret', 'the callback-provided Connection is stripped')
+  t.notOk(requests[1]['x-secret'], 'Connection-nominated fields are stripped from the retry')
+  t.notOk(requests[1]['proxy-authorization'], 'proxy credentials are stripped from the retry')
+  t.equal(requests[1]['x-retry-attempt'], '2', 'ordinary callback mutations are preserved')
+  t.same(
+    requests.map(({ via }) => via),
+    ['HTTP/1.1 edge', 'HTTP/1.1 edge'],
+    'Via is rebuilt once per attempt instead of accumulating',
+  )
+})


### PR DESCRIPTION
## Summary

- keep the proxy interceptor inside the response-retry boundary in the default pipeline
- sanitize callback-mutated headers before every upstream attempt
- preserve ordinary retry callback header mutations without accumulating `Via`

## Root cause

The default composition was `proxy(verify(retry(dispatch)))`. A custom retry strategy is intentionally allowed to mutate `opts.headers`, but response-retry dispatched later attempts through its captured inner dispatcher, below the proxy. A callback could therefore add `Connection`-nominated fields or `Proxy-Authorization` after attempt one and send them upstream on attempt two.

The pipeline is now `verify(retry(proxy(dispatch)))`, so each real attempt crosses the proxy boundary. The proxy already creates a fresh header map, so `Via` and `Forwarded` do not accumulate between attempts.

## Validation

- added a public-request two-attempt regression covering `Connection`, a nominated field, `Proxy-Authorization`, an ordinary callback mutation, and per-attempt `Via`
- proxy matrix: 119 assertions passed
- retry matrix: 275 assertions passed, one expected skip
- verify/log/body-factory interaction matrix: 97 assertions passed
- repository JavaScript suite: all 3,082 assertions passed (the existing Tap discovery issue still tries to execute `test/type-stubs/upstream-undici.d.ts` as a test file)
- ESLint, Prettier, and `git diff --check` passed
