### PR TITLE
fix(proxy): filter response trailers

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -19,6 +19,7 @@ const copyHeader = (acc, key, val) => {
 
 class Handler extends DecoratorHandler {
   #opts
+  #responseConnectionOptions = { value: null }
 
   constructor(proxyOpts, { handler }) {
     super(handler)
@@ -59,10 +60,15 @@ class Handler extends DecoratorHandler {
   }
 
   onHeaders(statusCode, headers, resume) {
+    // onHeaders may run for an informational response before the final one.
+    // Only the final field section's Connection options apply to its trailers.
+    this.#responseConnectionOptions.value = null
+
     return super.onHeaders(
       statusCode,
       reduceHeaders(
         {
+          connectionOptions: this.#responseConnectionOptions,
           headers,
           httpVersion: this.#opts.httpVersion ?? this.#opts.req?.httpVersion,
           isResponse: true,
@@ -72,6 +78,25 @@ class Handler extends DecoratorHandler {
         {},
       ),
       resume,
+    )
+  }
+
+  onComplete(trailers) {
+    if (trailers == null) {
+      return super.onComplete(trailers)
+    }
+
+    return super.onComplete(
+      reduceHeaders(
+        {
+          connectionOptions: this.#responseConnectionOptions,
+          headers: trailers,
+          isResponse: true,
+          isTrailer: true,
+        },
+        copyHeader,
+        {},
+      ),
     )
   }
 }
@@ -183,6 +208,12 @@ function joinNonEmptyHeaderValues(value) {
  * @param {boolean} [options.isResponse] Response path marker. When set,
  *   Forwarded is never synthesised regardless of `socket` (it would leak the
  *   proxy's own addresses downstream); an inbound Forwarded is still rejected.
+ * @param {boolean} [options.isTrailer] Trailer field-section marker. Trailer
+ *   fields are filtered without synthesising Via/Forwarded or treating their
+ *   presence as a late response error.
+ * @param {{ value: string[] | null }} [options.connectionOptions] Mutable
+ *   holder used by the response path to carry field names nominated by the
+ *   response's Connection header into its trailer field section.
  * @param {(acc: T, key: string, value: string | string[]) => T} fn Accumulator
  *   invoked once per retained header. The value is an array when the field
  *   appeared more than once (parseHeaders shape) — never pre-joined, because
@@ -190,7 +221,11 @@ function joinNonEmptyHeaderValues(value) {
  * @param {T} acc Initial accumulator value.
  * @returns {T}
  */
-function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, fn, acc) {
+function reduceHeaders(
+  { headers, proxyName, httpVersion, socket, isResponse, isTrailer, connectionOptions },
+  fn,
+  acc,
+) {
   let via = ''
   let viaSeen = false
   let forwarded = ''
@@ -225,6 +260,13 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const len = key.length
+    if (isTrailer && !(len === 10 && eqiLower(key, 'connection'))) {
+      // Trailer blocks cannot change request routing and are delivered only
+      // after the body. Do not validate singular routing fields or parse Via /
+      // Forwarded here: all of those fields are discarded by the retain pass.
+      continue
+    }
+
     if (len === 3 && eqiLower(key, 'via')) {
       // Via is list-valued (RFC 9110 §7.6.3): combine repeated field-lines.
       const v = headers[key]
@@ -286,12 +328,12 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   // otherwise `Connection: X-Custom` fails to strip `x-custom` and it leaks to
   // the next hop. trim() handles surrounding whitespace, so a plain comma split
   // suffices.
-  let remove = null
+  let remove = connectionOptions?.value ?? null
   if (Array.isArray(connection)) {
     // Repeated Connection field-lines (RFC 9110 §7.6.1): each part may itself
     // list several options. A repeat always carries multiple/custom tokens, so
     // the single-hop-token shortcut below never applies.
-    remove = []
+    remove ??= []
     for (const part of connection) {
       for (const token of part.split(',')) {
         remove.push(token.trim().toLowerCase())
@@ -301,10 +343,14 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     // Single value: one field-line, so one split over its comma list. The
     // isHopByHop guard skips the common single-token forms (`keep-alive`,
     // `close`, …) where there is nothing custom to strip.
-    remove = []
+    remove ??= []
     for (const token of connection.split(',')) {
       remove.push(token.trim().toLowerCase())
     }
+  }
+
+  if (connectionOptions) {
+    connectionOptions.value = remove
   }
 
   for (let i = 0; i < keys.length; i++) {
@@ -335,6 +381,14 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       const value = headers[key]
       acc = fn(acc, key, Array.isArray(value) ? value : value.toString())
     }
+  }
+
+  if (isTrailer) {
+    // Via and Forwarded were deliberately excluded by the retain loop. They
+    // are meaningful only in the initial field section: never append a Via
+    // segment to trailers, and never turn an echoed Forwarded trailer into a
+    // protocol error after the response body has already been delivered.
+    return acc
   }
 
   if (!isResponse && socket) {

--- a/test/proxy-response-trailers.js
+++ b/test/proxy-response-trailers.js
@@ -1,0 +1,100 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import { Agent, compose, interceptors } from '../lib/index.js'
+
+function dispatchAndCollectTrailers(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete: resolve,
+      onError: reject,
+    })
+  })
+}
+
+test('proxy: response trailers cross the same hop-by-hop boundary as headers', async (t) => {
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { connection: 'X-Header-Secret' }, () => {})
+    handler.onComplete({
+      ':status': '200',
+      Connection: ['X-Trailer-Secret', 'keep-alive'],
+      forwarded: 'for=spoofed',
+      host: ['first.example', 'second.example'],
+      'transfer-encoding': 'chunked',
+      via: 'HTTP/1.1 edge-proxy',
+      'x-header-secret': 'header-nominated secret',
+      'x-trailer-secret': 'trailer-nominated secret',
+      'x-checksum': 'abc123',
+      'x-list': ['one', 'two'],
+    })
+  }, interceptors.proxy())
+
+  const trailers = await dispatchAndCollectTrailers(dispatch, {
+    origin: 'http://upstream.example',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    proxy: { name: 'edge-proxy' },
+  })
+
+  t.same(trailers, {
+    'x-checksum': 'abc123',
+    'x-list': ['one', 'two'],
+  })
+})
+
+test('proxy: an absent response trailer block remains absent', async (t) => {
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(204, {}, () => {})
+    handler.onComplete(null)
+  }, interceptors.proxy())
+
+  const trailers = await dispatchAndCollectTrailers(dispatch, {
+    origin: 'http://upstream.example',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    proxy: {},
+  })
+
+  t.equal(trailers, null)
+})
+
+test('proxy: real response trailers honor Connection nominations from headers', async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(200, {
+      connection: 'keep-alive, X-Secret',
+      trailer: 'X-Secret, X-Checksum',
+    })
+    res.write('body')
+    res.addTrailers({
+      'x-secret': 'must not cross the proxy',
+      'x-checksum': 'abc123',
+    })
+    res.end()
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  t.teardown(() => server.close())
+
+  const agent = new Agent()
+  t.teardown(() => agent.close())
+  const dispatch = compose(agent, interceptors.proxy())
+
+  const trailers = await dispatchAndCollectTrailers(dispatch, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    proxy: {},
+  })
+
+  t.same(trailers, { 'x-checksum': 'abc123' })
+})


### PR DESCRIPTION
## Summary

- filter response trailer fields through the proxy's hop-by-hop boundary
- carry `Connection` field nominations from response headers into the corresponding trailer block
- discard trailer-local pseudo fields, hop-by-hop fields, `Via`, and `Forwarded` without synthesizing fields or raising a late response error
- preserve ordinary scalar/array trailer values and the existing absent-trailer value

## Root cause

The proxy reduced response headers in `onHeaders`, but inherited `onComplete` unchanged. As a result, upstream trailers bypassed all proxy filtering, including names nominated by the response's `Connection` header.

## Validation

- focused mock regression covering header- and trailer-local `Connection` nominations, static hop-by-hop fields, pseudo fields, `Via`, `Forwarded`, scalar values, and array values
- real Node HTTP server regression covering a header-nominated trailer field
- 143/143 assertions across the complete proxy-focused matrix
- ESLint (no errors; two pre-existing obsolete-disable warnings in unrelated review suites)
- Prettier check
- `git diff --check`
