### PR TITLE
fix(proxy): honor Connection for provenance fields

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -467,6 +467,17 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     }
   }
 
+  // Connection options apply to every field, including the two fields that
+  // are finalized below instead of passing through the ordinary retain loop.
+  // Drop the received value here; this proxy may still generate its own fresh
+  // Via/Forwarded value for the next hop.
+  if (remove?.includes('via')) {
+    via = ''
+  }
+  if (remove?.includes('forwarded')) {
+    forwarded = ''
+  }
+
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const len = key.length

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -467,17 +467,6 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     }
   }
 
-  // Connection options apply to every field, including the two fields that
-  // are finalized below instead of passing through the ordinary retain loop.
-  // Drop the received value here; this proxy may still generate its own fresh
-  // Via/Forwarded value for the next hop.
-  if (remove?.includes('via')) {
-    via = ''
-  }
-  if (remove?.includes('forwarded')) {
-    forwarded = ''
-  }
-
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const len = key.length
@@ -513,7 +502,7 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
     acc = fn(
       acc,
       'forwarded',
-      (forwarded ? forwarded + ', ' : '') +
+      (forwarded && !remove?.includes('forwarded') ? forwarded + ', ' : '') +
         [
           socket.localAddress && `by=${printIp(socket.localAddress, socket.localPort)}`,
           socket.remoteAddress && `for=${printIp(socket.remoteAddress, socket.remotePort)}`,
@@ -523,14 +512,14 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
           .filter(Boolean)
           .join(';'),
     )
-  } else if (forwarded) {
+  } else if (forwarded && !remove?.includes('forwarded')) {
     // Forwarded is a request-only header (RFC 7239): a proxy must neither emit
     // it on a response nor relay one an upstream echoed back.
     throw new createError.BadGateway()
   }
 
   if (proxyName) {
-    if (via) {
+    if (via && !remove?.includes('via')) {
       const viaLower = via.toLowerCase()
       const proxyNameLower = proxyName.toLowerCase()
       // A Via segment is "received-protocol received-by [comment]". Compare the
@@ -546,6 +535,8 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       via = ''
     }
     via += `${httpVersion ?? 'HTTP/1.1'} ${proxyName}`
+  } else if (remove?.includes('via')) {
+    via = ''
   }
 
   if (via) {

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -519,7 +519,7 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   }
 
   if (proxyName) {
-    if (via && !remove?.includes('via')) {
+    if (via) {
       const viaLower = via.toLowerCase()
       const proxyNameLower = proxyName.toLowerCase()
       // A Via segment is "received-protocol received-by [comment]". Compare the
@@ -530,7 +530,7 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       if (viaLower.includes(proxyNameLower) && viaHasReceivedBy(viaLower, proxyNameLower)) {
         throw new createError.LoopDetected()
       }
-      via += ', '
+      via = remove?.includes('via') ? '' : via + ', '
     } else {
       via = ''
     }

--- a/test/proxy-connection-special-fields.js
+++ b/test/proxy-connection-special-fields.js
@@ -1,0 +1,112 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function requestHeaders(headers, proxy) {
+  let received
+  const dispatch = compose((opts, handler) => {
+    received = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers, proxy },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return received
+}
+
+function responseHeaders(headers, proxy) {
+  let received
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, headers, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    { origin: 'http://upstream.test', path: '/', method: 'GET', headers: {}, proxy },
+    {
+      onConnect() {},
+      onHeaders(statusCode, value) {
+        received = value
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return received
+}
+
+test('proxy: Connection-nominated provenance is replaced on requests', (t) => {
+  const headers = requestHeaders(
+    {
+      connection: ['Forwarded', 'Via'],
+      forwarded: 'for=spoofed.example',
+      via: '1.1 upstream.example',
+      'x-keep': 'yes',
+    },
+    {
+      name: 'edge',
+      socket: {
+        localAddress: '192.0.2.1',
+        remoteAddress: '198.51.100.2',
+        encrypted: false,
+      },
+    },
+  )
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;for=198.51.100.2;proto=http')
+  t.equal(headers.via, 'HTTP/1.1 edge')
+  t.equal(headers['x-keep'], 'yes')
+  t.notOk('connection' in headers)
+  t.end()
+})
+
+test('proxy: Connection-nominated Forwarded is dropped without a socket', (t) => {
+  const headers = requestHeaders(
+    {
+      connection: 'Forwarded',
+      forwarded: 'for=spoofed.example',
+      'x-keep': 'yes',
+    },
+    true,
+  )
+
+  t.notOk('forwarded' in headers)
+  t.equal(headers['x-keep'], 'yes')
+  t.end()
+})
+
+test('proxy: Connection-nominated provenance is replaced on responses', (t) => {
+  const headers = responseHeaders(
+    {
+      connection: 'Forwarded, Via',
+      forwarded: 'for=spoofed.example',
+      via: '1.1 upstream.example',
+      'x-keep': 'yes',
+    },
+    { name: 'edge' },
+  )
+
+  t.notOk('forwarded' in headers)
+  t.equal(headers.via, 'HTTP/1.1 edge')
+  t.equal(headers['x-keep'], 'yes')
+  t.notOk('connection' in headers)
+  t.end()
+})

--- a/test/proxy-connection-special-fields.js
+++ b/test/proxy-connection-special-fields.js
@@ -93,6 +93,21 @@ test('proxy: Connection-nominated Forwarded is dropped without a socket', (t) =>
   t.end()
 })
 
+test('proxy: Connection-nominated Via still participates in loop detection', (t) => {
+  t.throws(
+    () =>
+      requestHeaders(
+        {
+          connection: 'Via',
+          via: '1.1 edge',
+        },
+        { name: 'edge' },
+      ),
+    { statusCode: 508 },
+  )
+  t.end()
+})
+
 test('proxy: Connection-nominated provenance is replaced on responses', (t) => {
   const headers = responseHeaders(
     {


### PR DESCRIPTION
## Summary

- Apply received `Connection` options to special `Via` and `Forwarded` fields as well as ordinary retained headers.
- Drop nominated inbound provenance before generating a fresh value for the next hop.
- Prevent a Connection-nominated `Forwarded` value from triggering a response/no-socket BadGateway after it has been declared hop-by-hop.

## Root cause

`Via` and `Forwarded` bypass the ordinary retain loop because proxy reduction finalizes them separately. Connection-nominated fields were filtered only in that retain loop, so these two fields were captured and re-emitted despite being scoped to the received connection.

## Validation

- 156/156 assertions across the complete proxy-focused matrix on current `main`
- request path with fresh Via and Forwarded synthesis
- request path without a socket
- response path with fresh Via generation
- ESLint
- Prettier
- `git diff --check`