### PR TITLE
fix(proxy): reject malformed Via comments

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -127,6 +127,36 @@ function viaSegmentHasReceivedBy(via, start, end, proxyName) {
   return i > receivedByStart && via.slice(receivedByStart, i) === proxyName
 }
 
+function validateViaComments(via) {
+  let commentDepth = 0
+  let escaped = false
+
+  for (let i = 0; i < via.length; i++) {
+    const char = via.charCodeAt(i)
+    if (commentDepth !== 0) {
+      if (escaped) {
+        escaped = false
+      } else if (char === 0x5c /* '\\' */) {
+        escaped = true
+      } else if (char === 0x28 /* '(' */) {
+        commentDepth++
+      } else if (char === 0x29 /* ')' */) {
+        commentDepth--
+      }
+    } else if (char === 0x28 /* '(' */) {
+      commentDepth = 1
+    }
+  }
+
+  // Appending our member to an unterminated comment would place it inside that
+  // comment. A later traversal would then miss our received-by forever and the
+  // loop guard could be bypassed. A quoted-pair can leave the comment open by
+  // ending with a pending escape or by escaping its would-be closing parenthesis.
+  if (commentDepth !== 0) {
+    throw new createError.BadGateway()
+  }
+}
+
 function viaHasReceivedBy(via, proxyName) {
   let start = 0
   let commentDepth = 0
@@ -152,14 +182,6 @@ function viaHasReceivedBy(via, proxyName) {
       }
       start = i + 1
     }
-  }
-
-  // Appending our member to an unterminated comment would place it inside that
-  // comment. A later traversal would then miss our received-by forever and the
-  // loop guard could be bypassed. A dangling quoted-pair leaves the comment
-  // unterminated too, because it escapes the byte that would otherwise close it.
-  if (commentDepth !== 0) {
-    throw new createError.BadGateway()
   }
 
   return viaSegmentHasReceivedBy(via, start, via.length, proxyName)
@@ -535,10 +557,11 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       // whether the whole segment ends with proxyName — endsWith() trips a
       // false-positive loop for any unrelated proxy whose name merely has
       // proxyName as a suffix (e.g. name 'proxy' vs upstream 'otherproxy').
-      // Always parse a non-empty Via before appending our member. The previous
-      // includes() fast guard skipped malformed comments that did not contain
-      // our name yet, allowing the appended member to be hidden inside them.
-      if (viaHasReceivedBy(viaLower, proxyNameLower)) {
+      // Always validate comment structure before appending our member. Keep the
+      // includes() guard for received-by matching so the common non-looping path
+      // avoids the segment parser and its slices.
+      validateViaComments(viaLower)
+      if (viaLower.includes(proxyNameLower) && viaHasReceivedBy(viaLower, proxyNameLower)) {
         throw new createError.LoopDetected()
       }
       via += ', '

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -154,6 +154,14 @@ function viaHasReceivedBy(via, proxyName) {
     }
   }
 
+  // Appending our member to an unterminated comment would place it inside that
+  // comment. A later traversal would then miss our received-by forever and the
+  // loop guard could be bypassed. A dangling quoted-pair leaves the comment
+  // unterminated too, because it escapes the byte that would otherwise close it.
+  if (commentDepth !== 0) {
+    throw new createError.BadGateway()
+  }
+
   return viaSegmentHasReceivedBy(via, start, via.length, proxyName)
 }
 
@@ -527,7 +535,10 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
       // whether the whole segment ends with proxyName — endsWith() trips a
       // false-positive loop for any unrelated proxy whose name merely has
       // proxyName as a suffix (e.g. name 'proxy' vs upstream 'otherproxy').
-      if (viaLower.includes(proxyNameLower) && viaHasReceivedBy(viaLower, proxyNameLower)) {
+      // Always parse a non-empty Via before appending our member. The previous
+      // includes() fast guard skipped malformed comments that did not contain
+      // our name yet, allowing the appended member to be hidden inside them.
+      if (viaHasReceivedBy(viaLower, proxyNameLower)) {
         throw new createError.LoopDetected()
       }
       via += ', '

--- a/test/proxy-via-comments.js
+++ b/test/proxy-via-comments.js
@@ -53,3 +53,11 @@ test('proxy: quoted-pair parentheses keep a Via comma inside its comment', async
 test('proxy: a genuine Via loop is found before a comma-bearing comment', async (t) => {
   await t.rejects(responseWithVia('1.1 edge (note, other proxy)', 'edge'), { statusCode: 508 })
 })
+
+test('proxy: an unterminated Via comment is rejected before appending', async (t) => {
+  await t.rejects(responseWithVia('1.1 upstream (unterminated', 'edge'), { statusCode: 502 })
+})
+
+test('proxy: a dangling quoted-pair in a Via comment is rejected', async (t) => {
+  await t.rejects(responseWithVia('1.1 upstream (dangling\\', 'edge'), { statusCode: 502 })
+})


### PR DESCRIPTION
## Summary

- Reject structurally incomplete HTTP comments in inbound `Via` values before appending this proxy member.
- Run the comment-aware scan for every non-empty `Via`, rather than only when the value already contains this proxy name.
- Cover both an unterminated comment and a dangling quoted-pair.

## Root cause

The parser added by #187 correctly ignored commas inside valid comments, but its `includes(proxyName)` fast guard skipped malformed comments that did not contain this proxy name yet. Appending `, HTTP/1.1 edge` to an unterminated comment placed the new member inside that comment. A later traversal then missed `edge` forever, bypassing loop detection while the malformed chain kept growing. Node 26 accepts these values as HTTP header field values, so the boundary is reachable from real traffic.

## Impact

Malformed `Via` comment structure now fails closed with `502 Bad Gateway`. Valid nested comments, quoted-pairs, and genuine loop detection retain their existing behavior.

## Validation

- 15 proxy-focused suites: 178 assertions passed
- real Undici transport repro returns `BadGatewayError` with status 502
- ESLint
- Prettier check
- syntax checks
- `git diff --check`