### PR TITLE
fix(proxy): normalize :scheme cardinality

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -400,7 +400,19 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
         connectionSeen = true
       }
     } else if (len === 7 && key === ':scheme') {
-      scheme = headers[key]
+      // :scheme is singular (RFC 9113 §8.3.1). HeaderInput represents zero
+      // or one value as [] / [value], matching Host and :authority above.
+      let v = headers[key]
+      if (Array.isArray(v)) {
+        if (v.length > 1) {
+          throw new createError.BadGateway()
+        }
+        if (v.length === 0) {
+          continue
+        }
+        v = v[0]
+      }
+      scheme = v
     } else if (len === 10 && key === ':authority') {
       // :authority is singular (RFC 9113 §8.3.1): reject more than one. Pseudo
       // headers are always lowercase, so an exact compare is correct here.

--- a/test/proxy-scheme-cardinality.js
+++ b/test/proxy-scheme-cardinality.js
@@ -1,0 +1,73 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function proxyRequestHeaders(headers, proxy = {}) {
+  let captured
+  const dispatch = compose((opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers,
+      proxy,
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  return captured
+}
+
+test('proxy: singleton :scheme array normalizes default ports', (t) => {
+  const headers = proxyRequestHeaders({
+    host: 'EXAMPLE.COM:443',
+    ':authority': 'example.com',
+    ':scheme': ['https'],
+    'x-keep': 'yes',
+  })
+
+  t.same(headers, { 'x-keep': 'yes' })
+  t.end()
+})
+
+test('proxy: empty :scheme array falls back to the socket scheme', (t) => {
+  const headers = proxyRequestHeaders(
+    {
+      host: 'EXAMPLE.COM:443',
+      ':authority': 'example.com',
+      ':scheme': [],
+    },
+    {
+      socket: {
+        localAddress: '192.0.2.1',
+        encrypted: true,
+      },
+    },
+  )
+
+  t.equal(headers.forwarded, 'by=192.0.2.1;proto=https;host="example.com"')
+  t.end()
+})
+
+test('proxy: multiple :scheme values are rejected without authority fields', (t) => {
+  t.throws(() => proxyRequestHeaders({ ':scheme': ['http', 'https'], 'x-keep': 'yes' }), {
+    statusCode: 502,
+  })
+  t.end()
+})


### PR DESCRIPTION
## Summary

- apply singular-field cardinality rules to the HTTP/2 `:scheme` pseudo-header
- treat `[]` as absent, `[value]` as one value, and reject arrays with multiple values
- preserve scheme fallback to the proxy socket when `:scheme` is absent

## Root cause

The proxy already normalized zero/single/multiple values for singular `Host` and `:authority` fields, but assigned `:scheme` arrays directly. A valid singleton array therefore reached authority normalization as a non-string and caused a false 502, while duplicated schemes escaped validation when no authority comparison ran.

## Validation

- focused regressions for singleton/default-port equivalence, empty-array socket fallback, and unconditional duplicate rejection
- 179/179 assertions across every proxy-related test suite
- ESLint
- Prettier check
- `git diff --check`
