### PR TITLE
fix(proxy): preserve retry trailer handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ import { SqliteCacheStore } from './sqlite-cache-store.js'
 import { validateTrace } from './trace.js'
 
 const dispatcherCache = new WeakMap()
+const proxyInterceptors = await import('./interceptor/proxy.js')
 
 export const interceptors = {
   query: (await import('./interceptor/query.js')).default,
@@ -16,7 +17,7 @@ export const interceptors = {
   responseVerify: (await import('./interceptor/response-verify.js')).default,
   log: (await import('./interceptor/log.js')).default,
   redirect: (await import('./interceptor/redirect.js')).default,
-  proxy: (await import('./interceptor/proxy.js')).default,
+  proxy: proxyInterceptors.default,
   cache: (await import('./interceptor/cache/index.js')).default,
   requestId: (await import('./interceptor/request-id.js')).default,
   dns: (await import('./interceptor/dns.js')).default,
@@ -122,13 +123,17 @@ function wrapDispatch(dispatcher) {
       interceptors.priority(),
       interceptors.dns(),
       interceptors.requestBodyFactory(),
-      // Keep proxy inside responseRetry: a retry strategy may legitimately
-      // mutate opts.headers, so every actual attempt must cross the proxy
-      // boundary and have hop-by-hop fields removed. proxy() builds a fresh
-      // header map, which also prevents Via/Forwarded from accumulating.
-      interceptors.proxy(),
+      // A retry strategy may legitimately mutate opts.headers, so every
+      // actual attempt must cross the proxy's request boundary and have
+      // hop-by-hop fields removed. The proxy builds a fresh header map, which
+      // also prevents Via/Forwarded from accumulating between attempts.
+      proxyInterceptors.proxyRequest(),
       interceptors.responseRetry(),
       interceptors.responseVerify(),
+      // Keep response filtering outside responseRetry. Retry must observe the
+      // upstream Trailer field before the proxy strips it so it can disable
+      // unsafe buffering/resumption for responses that announce trailers.
+      proxyInterceptors.proxyResponse(),
       interceptors.cache(),
       interceptors.redirect(),
       // log also emits the undici:request trace start/end docs. Later entries

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -576,7 +576,7 @@ function printIp(address, port) {
   return str
 }
 
-export default () => (dispatch) => (opts, handler) => {
+export const proxyRequest = () => (dispatch) => (opts, handler) => {
   if (!opts.proxy) {
     return dispatch(opts, handler)
   }
@@ -620,5 +620,15 @@ export default () => (dispatch) => (opts, handler) => {
     {},
   )
 
-  return dispatch({ ...opts, headers }, new Handler(opts.proxy, { handler }))
+  return dispatch({ ...opts, headers }, handler)
 }
+
+export const proxyResponse = () => (dispatch) => (opts, handler) => {
+  if (!opts.proxy) {
+    return dispatch(opts, handler)
+  }
+
+  return dispatch(opts, new Handler(opts.proxy, { handler }))
+}
+
+export default () => (dispatch) => proxyRequest()(proxyResponse()(dispatch))

--- a/test/proxy-retry-boundary.js
+++ b/test/proxy-retry-boundary.js
@@ -4,7 +4,7 @@ import { request } from '../lib/index.js'
 test('proxy sanitizes headers added by a retry callback on every attempt', async (t) => {
   const requests = []
   const dispatcher = (opts, handler) => {
-    requests.push(opts.headers)
+    requests.push({ ...opts.headers })
     handler.onConnect(() => {})
     if (requests.length === 1) {
       handler.onHeaders(503, { 'content-length': '5' }, () => {})

--- a/test/proxy-retry-boundary.js
+++ b/test/proxy-retry-boundary.js
@@ -1,27 +1,25 @@
-import { once } from 'node:events'
-import { createServer } from 'node:http'
 import { test } from 'tap'
 import { request } from '../lib/index.js'
 
 test('proxy sanitizes headers added by a retry callback on every attempt', async (t) => {
   const requests = []
-  const server = createServer((req, res) => {
-    requests.push(req.headers)
-
+  const dispatcher = (opts, handler) => {
+    requests.push(opts.headers)
+    handler.onConnect(() => {})
     if (requests.length === 1) {
-      res.statusCode = 503
-      res.end('retry')
-      return
+      handler.onHeaders(503, { 'content-length': '5' }, () => {})
+      handler.onData(Buffer.from('retry'))
+    } else {
+      handler.onHeaders(200, { 'content-length': '2' }, () => {})
+      handler.onData(Buffer.from('ok'))
     }
+    handler.onComplete({})
+    return true
+  }
 
-    res.end('ok')
-  })
-
-  t.teardown(() => server.close())
-  server.listen(0, '127.0.0.1')
-  await once(server, 'listening')
-
-  const { body } = await request(`http://127.0.0.1:${server.address().port}`, {
+  const { body } = await request('http://127.0.0.1', {
+    dispatch: dispatcher,
+    dns: false,
     proxy: { name: 'edge' },
     retry: (err, retryCount, opts) => {
       t.equal(err.statusCode, 503)
@@ -37,7 +35,7 @@ test('proxy sanitizes headers added by a retry callback on every attempt', async
 
   t.equal(await body.text(), 'ok')
   t.equal(requests.length, 2)
-  t.not(requests[1].connection, 'x-secret', 'the callback-provided Connection is stripped')
+  t.notOk(requests[1].connection, 'Connection is stripped before the transport boundary')
   t.notOk(requests[1]['x-secret'], 'Connection-nominated fields are stripped from the retry')
   t.notOk(requests[1]['proxy-authorization'], 'proxy credentials are stripped from the retry')
   t.equal(requests[1]['x-retry-attempt'], '2', 'ordinary callback mutations are preserved')
@@ -46,4 +44,42 @@ test('proxy sanitizes headers added by a retry callback on every attempt', async
     ['HTTP/1.1 edge', 'HTTP/1.1 edge'],
     'Via is rebuilt once per attempt instead of accumulating',
   )
+})
+
+test('proxy leaves Trailer visible to retry before filtering the response', async (t) => {
+  let attempts = 0
+  let retryCalls = 0
+  const dispatcher = (_opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+
+    if (attempts === 1) {
+      handler.onHeaders(503, { trailer: 'x-checksum' }, () => {})
+      handler.onData(Buffer.from('unavailable'))
+      handler.onComplete({ 'x-checksum': 'ok' })
+    } else {
+      handler.onHeaders(200, {}, () => {})
+      handler.onData(Buffer.from('unexpected retry'))
+      handler.onComplete({})
+    }
+    return true
+  }
+
+  const { statusCode, headers, body } = await request('http://127.0.0.1', {
+    dispatch: dispatcher,
+    dns: false,
+    proxy: {},
+    error: false,
+    verify: false,
+    retry: () => {
+      retryCalls++
+      return true
+    },
+  })
+
+  t.equal(statusCode, 503)
+  t.equal(await body.text(), 'unavailable')
+  t.equal(attempts, 1, 'a response that announces trailers is not retried')
+  t.equal(retryCalls, 0, 'the retry strategy is bypassed for a trailer response')
+  t.notOk(headers.trailer, 'the proxy still strips Trailer before exposing the response')
 })


### PR DESCRIPTION
## Summary

- split the proxy interceptor into request and response stages for the default pipeline
- keep request sanitization inside response-retry so every upstream attempt is filtered
- keep response filtering outside response-retry so announced trailers still disable unsafe buffering/resumption
- make the retry-boundary test inspect headers before the transport can generate its own `Connection` field

## Root cause

PR #189 moved the combined proxy interceptor inside response-retry to close a request-header leak on later attempts. That also moved response filtering inward, so the proxy removed the hop-by-hop `Trailer` field before response-retry could observe it. A proxied response announcing trailers could then enter retry buffering even though the retry layer deliberately passes such responses through immediately.

The public `interceptors.proxy()` behavior remains combined and unchanged. The default pipeline uses its request and response stages separately: `proxyRequest` is inside retry and `proxyResponse` remains outside it.

This also addresses both exact-head Copilot comments on #189.

## Validation

- added a regression proving a proxied 503 with `Trailer` is passed through once and filtered before exposure
- changed the retry header regression to a deterministic pre-transport dispatcher boundary, where `Connection` can be asserted absent
- proxy matrix: 151 assertions passed
- retry/verify/log/body-factory matrix: 347 assertions passed, one expected skip
- repository JavaScript run: 3,112 assertions passed; two unrelated `cache-advanced` assertions flaked under the concurrent run and the file passed 100/100 immediately in isolation
- ESLint, Prettier, and `git diff --check` passed
