### PR TITLE
fix(proxy): ignore OWS-only list values

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -208,14 +208,24 @@ export function isHopByHop(key) {
   }
 }
 
+function isOwsOnly(value) {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code !== 0x20 && code !== 0x09) {
+      return false
+    }
+  }
+  return true
+}
+
 function joinNonEmptyHeaderValues(value) {
   if (!Array.isArray(value)) {
-    return value
+    return isOwsOnly(value) ? '' : value
   }
 
   let joined = ''
   for (const part of value) {
-    if (part !== '') {
+    if (!isOwsOnly(part)) {
       joined = joined ? `${joined}, ${part}` : part
     }
   }

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -209,6 +209,10 @@ export function isHopByHop(key) {
 }
 
 function isOwsOnly(value) {
+  if (typeof value !== 'string') {
+    return false
+  }
+
   for (let i = 0; i < value.length; i++) {
     const code = value.charCodeAt(i)
     if (code !== 0x20 && code !== 0x09) {

--- a/test/proxy-ows-only-values.js
+++ b/test/proxy-ows-only-values.js
@@ -33,6 +33,38 @@ function requestHeaders(headers, proxy) {
   return captured
 }
 
+function responseHeaders(headers) {
+  let captured
+  const dispatch = compose((opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, headers, () => {})
+    handler.onComplete({})
+  }, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers: {},
+      proxy: {},
+    },
+    {
+      onConnect() {},
+      onHeaders(_statusCode, receivedHeaders) {
+        captured = receivedHeaders
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return captured
+}
+
 test('proxy: OWS-only scalar Via does not create an empty list member', (t) => {
   const headers = requestHeaders({ via: ' \t ' }, { name: 'edge' })
 
@@ -66,5 +98,19 @@ test('proxy: OWS-only Forwarded array parts do not create empty list members', (
   )
 
   t.equal(headers.forwarded, 'for=192.0.2.1, by=192.0.2.10;for=192.0.2.20;proto=http')
+  t.end()
+})
+
+test('proxy: OWS detection preserves non-string response values', (t) => {
+  const via = {
+    length: 1,
+    toString() {
+      return 'HTTP/1.1 mock'
+    },
+  }
+
+  const headers = responseHeaders({ via })
+
+  t.equal(headers.via, via)
   t.end()
 })

--- a/test/proxy-ows-only-values.js
+++ b/test/proxy-ows-only-values.js
@@ -82,7 +82,7 @@ test('proxy: OWS-only Via array parts do not create empty list members', (t) => 
 test('proxy: OWS-only scalar Forwarded is treated as absent', (t) => {
   const headers = requestHeaders({ forwarded: '\t \t' }, {})
 
-  t.notOk(headers.forwarded)
+  t.notOk(Object.hasOwn(headers, 'forwarded'))
   t.end()
 })
 

--- a/test/proxy-ows-only-values.js
+++ b/test/proxy-ows-only-values.js
@@ -1,0 +1,70 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function requestHeaders(headers, proxy) {
+  let captured
+  const dispatch = compose((opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete({})
+  }, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers,
+      proxy,
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+  return captured
+}
+
+test('proxy: OWS-only scalar Via does not create an empty list member', (t) => {
+  const headers = requestHeaders({ via: ' \t ' }, { name: 'edge' })
+
+  t.equal(headers.via, 'HTTP/1.1 edge')
+  t.end()
+})
+
+test('proxy: OWS-only Via array parts do not create empty list members', (t) => {
+  const headers = requestHeaders({ via: ['\t ', 'HTTP/1.1 upstream', ' \t'] }, { name: 'edge' })
+
+  t.equal(headers.via, 'HTTP/1.1 upstream, HTTP/1.1 edge')
+  t.end()
+})
+
+test('proxy: OWS-only scalar Forwarded is treated as absent', (t) => {
+  const headers = requestHeaders({ forwarded: '\t \t' }, {})
+
+  t.notOk(headers.forwarded)
+  t.end()
+})
+
+test('proxy: OWS-only Forwarded array parts do not create empty list members', (t) => {
+  const headers = requestHeaders(
+    { forwarded: [' ', 'for=192.0.2.1', '\t'] },
+    {
+      socket: {
+        localAddress: '192.0.2.10',
+        remoteAddress: '192.0.2.20',
+      },
+    },
+  )
+
+  t.equal(headers.forwarded, 'for=192.0.2.1, by=192.0.2.10;for=192.0.2.20;proto=http')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- treat SP/HTAB-only `Via` and `Forwarded` values as empty
- skip OWS-only members when combining array-valued header inputs
- preserve non-empty header values byte-for-byte

## Root cause

The standalone proxy interceptor accepts normalized object and array `HeaderInput` directly. Its list combiner skipped only the exact empty string, so an OWS-only value such as `" \t"` survived even though Node's wire parser trims that value to empty. This could create a leading empty `Via` member when the proxy appended itself, or make an otherwise empty `Forwarded` field trigger a 502 when no socket metadata was available.

The emptiness check is deliberately limited to HTTP optional whitespace (SP and HTAB); other characters are not trimmed or broadened into empty values.

## Validation

- added standalone scalar and array coverage for both `Via` and `Forwarded`
- proxy matrix: 150 assertions passed
- ESLint, Prettier, and `git diff --check` passed
