### PR TITLE
fix(proxy): reject malformed Forwarded quotes

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -222,6 +222,29 @@ function joinNonEmptyHeaderValues(value) {
   return joined
 }
 
+function validateForwardedQuotedStrings(value) {
+  let quoted = false
+  let escaped = false
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value.charCodeAt(i)
+    if (escaped) {
+      escaped = false
+    } else if (quoted && char === 0x5c /* '\\' */) {
+      escaped = true
+    } else if (char === 0x22 /* '"' */) {
+      quoted = !quoted
+    }
+  }
+
+  // An open quoted-string hides the comma and trusted Forwarded element that
+  // this proxy is about to append. A quoted-pair left pending at EOF is one
+  // way the quoted-string can remain open.
+  if (quoted) {
+    throw new createError.BadGateway()
+  }
+}
+
 /**
  * Normalize an HTTP authority for comparison. A neutral URL scheme keeps an
  * explicit port intact so the request's actual scheme can decide whether that
@@ -498,6 +521,10 @@ function reduceHeaders({ headers, proxyName, httpVersion, socket, isResponse }, 
   }
 
   if (!isResponse && socket) {
+    if (forwarded) {
+      validateForwardedQuotedStrings(forwarded)
+    }
+
     const forwardedHost = authority || host
     acc = fn(
       acc,

--- a/test/proxy-forwarded-quoted-strings.js
+++ b/test/proxy-forwarded-quoted-strings.js
@@ -1,0 +1,126 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import net from 'node:net'
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+const socket = {
+  localAddress: '192.0.2.1',
+  remoteAddress: '198.51.100.2',
+  encrypted: false,
+}
+
+function proxyRequestHeaders(forwarded) {
+  let captured
+  const dispatch = compose((opts, handler) => {
+    captured = opts.headers
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers: { forwarded },
+      proxy: { socket },
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  return captured
+}
+
+test('proxy: rejects an unterminated Forwarded quoted-string', (t) => {
+  t.throws(() => proxyRequestHeaders('for="unterminated'), { statusCode: 502 })
+  t.end()
+})
+
+test('proxy: rejects a dangling quoted-pair in Forwarded', (t) => {
+  t.throws(() => proxyRequestHeaders('for="dangling\\'), { statusCode: 502 })
+  t.end()
+})
+
+test('proxy: preserves valid quoted commas and quoted-pairs in Forwarded', (t) => {
+  const forwarded = 'for="comma, quote\\" and slash\\\\";proto=https'
+  const headers = proxyRequestHeaders(forwarded)
+
+  t.equal(headers.forwarded, `${forwarded}, by=192.0.2.1;for=198.51.100.2;proto=http`)
+  t.end()
+})
+
+test('proxy: Node-accepted malformed Forwarded fails before upstream dispatch', async (t) => {
+  let receivedForwarded
+  let upstreamDispatches = 0
+  const dispatch = compose((opts, handler) => {
+    upstreamDispatches++
+    handler.onConnect(() => {})
+    handler.onHeaders(204, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  const server = createServer((req, res) => {
+    receivedForwarded = req.headers.forwarded
+    try {
+      dispatch(
+        {
+          origin: 'http://upstream.test',
+          path: req.url,
+          method: req.method,
+          headers: req.headers,
+          proxy: { req },
+        },
+        {
+          onConnect() {},
+          onHeaders() {
+            return true
+          },
+          onData() {},
+          onComplete() {
+            res.end()
+          },
+          onError(err) {
+            throw err
+          },
+        },
+      )
+    } catch (err) {
+      res.statusCode = err.statusCode ?? 500
+      res.end()
+    }
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  t.teardown(() => server.close())
+
+  const response = await new Promise((resolve, reject) => {
+    let data = ''
+    const client = net.connect(server.address().port, '127.0.0.1', () => {
+      client.end(
+        'GET / HTTP/1.1\r\nHost: public.test\r\nForwarded: for="unterminated\r\nConnection: close\r\n\r\n',
+      )
+    })
+    client.setEncoding('utf8')
+    client.on('data', (chunk) => {
+      data += chunk
+    })
+    client.on('end', () => resolve(data))
+    client.on('error', reject)
+  })
+
+  t.equal(receivedForwarded, 'for="unterminated')
+  t.match(response, /^HTTP\/1\.1 502 /)
+  t.equal(upstreamDispatches, 0)
+})


### PR DESCRIPTION
## Summary

- Validate inbound `Forwarded` quoted-string and quoted-pair balance before appending this proxy element.
- Reject an unterminated quote or pending quoted-pair with `502 Bad Gateway`.
- Preserve valid quoted commas, escaped quotes, and escaped backslashes.
- Exercise the boundary through a real Node 26 HTTP ingress path as well as focused standalone composition.

## Root cause

Node accepts HTTP field values without interpreting `Forwarded` grammar. An inbound value such as `for="unterminated` therefore reached the proxy unchanged. Appending the trusted `, by=...;for=...;proto=...` element placed it inside the attacker-opened quoted-string, so downstream parsers could no longer identify the nearest proxy provenance.

## Impact

Malformed inbound provenance now fails closed before any upstream dispatch. The validation scan is allocation-free and runs only when a non-empty inbound `Forwarded` value is about to be extended.

## Validation

- 16 proxy-focused suites: 182 assertions passed
- real Node 26 raw-wire ingress regression verifies 502 and zero upstream dispatches
- ESLint
- Prettier check
- syntax checks
- `git diff --check`