### PR TITLE
fix(proxy): honor :scheme in Forwarded

### DIFF
--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -301,6 +301,14 @@ function validateForwardedQuotedStrings(value) {
 }
 
 /**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+function normalizeScheme(value) {
+  return typeof value === 'string' && /^[a-z][a-z\d+.-]*$/i.test(value) ? value.toLowerCase() : null
+}
+
+/**
  * Normalize an HTTP authority for comparison. A neutral URL scheme keeps an
  * explicit port intact so the request's actual scheme can decide whether that
  * port is the default. Invalid authorities fail closed instead of falling back
@@ -324,10 +332,10 @@ function normalizeAuthority(value, scheme) {
 
   let normalizedScheme = ''
   if (scheme != null) {
-    if (typeof scheme !== 'string' || !/^[a-z][a-z\d+.-]*$/i.test(scheme)) {
+    normalizedScheme = normalizeScheme(scheme)
+    if (normalizedScheme == null) {
       return null
     }
-    normalizedScheme = scheme.toLowerCase()
   }
 
   const url = URL.parse(`nxt-authority://${value}`)
@@ -526,6 +534,13 @@ function reduceHeaders(
     }
   }
 
+  if (!isResponse && scheme != null) {
+    scheme = normalizeScheme(scheme)
+    if (scheme == null) {
+      throw new createError.BadGateway()
+    }
+  }
+
   const authorityValue = headers[':authority']
   const hasAuthority =
     Object.hasOwn(headers, ':authority') &&
@@ -629,7 +644,7 @@ function reduceHeaders(
         [
           socket.localAddress && `by=${printIp(socket.localAddress, socket.localPort)}`,
           socket.remoteAddress && `for=${printIp(socket.remoteAddress, socket.remotePort)}`,
-          `proto=${socket.encrypted ? 'https' : 'http'}`,
+          `proto=${scheme ?? (socket.encrypted ? 'https' : 'http')}`,
           forwardedHost && `host=${quoteForwardedString(forwardedHost)}`,
         ]
           .filter(Boolean)

--- a/test/proxy-forwarded-scheme.js
+++ b/test/proxy-forwarded-scheme.js
@@ -1,0 +1,61 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function forwardedHeader(scheme, encrypted) {
+  let forwarded
+  const dispatch = compose((opts, handler) => {
+    forwarded = opts.headers.forwarded
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  }, interceptors.proxy())
+
+  dispatch(
+    {
+      origin: 'http://upstream.test',
+      path: '/',
+      method: 'GET',
+      headers: scheme === undefined ? {} : { ':scheme': scheme },
+      proxy: {
+        socket: {
+          localAddress: '192.0.2.1',
+          encrypted,
+        },
+      },
+    },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  return forwarded
+}
+
+test('proxy: Forwarded proto prefers :scheme over a clear proxy socket', (t) => {
+  t.equal(forwardedHeader('HTTPS', false), 'by=192.0.2.1;proto=https')
+  t.end()
+})
+
+test('proxy: Forwarded proto prefers :scheme over an encrypted proxy socket', (t) => {
+  t.equal(forwardedHeader('http', true), 'by=192.0.2.1;proto=http')
+  t.end()
+})
+
+test('proxy: Forwarded proto falls back to the proxy socket', (t) => {
+  t.equal(forwardedHeader(undefined, false), 'by=192.0.2.1;proto=http')
+  t.equal(forwardedHeader(undefined, true), 'by=192.0.2.1;proto=https')
+  t.end()
+})
+
+test('proxy: an invalid :scheme cannot inject Forwarded parameters', (t) => {
+  t.throws(() => forwardedHeader('https;for=spoofed', false), { statusCode: 502 })
+  t.end()
+})


### PR DESCRIPTION
## Summary

- use the validated request `:scheme` for the synthesized `Forwarded` `proto` parameter
- fall back to the proxy socket's encryption state when `:scheme` is absent
- share one RFC scheme-token validator with authority normalization and normalize valid schemes to lowercase
- fail closed on invalid/injection-shaped scheme values

## Root cause

The proxy captured `:scheme` for Host/`:authority` comparison but ignored it when constructing `Forwarded`. It always derived `proto` from `socket.encrypted`, which describes the client-to-proxy transport and can differ from the original request scheme at an HTTP/2 or gateway boundary.

## Validation

- clear socket with `:scheme: HTTPS` emits `proto=https`
- encrypted socket with `:scheme: http` emits `proto=http`
- absent `:scheme` retains clear/encrypted socket fallback
- injection-shaped invalid scheme is rejected with 502
- 211/211 assertions across every proxy-related test suite on current `main`
- ESLint
- Prettier check
- `git diff --check`
