### PR TITLE
fix(url): normalize plain object authorities

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,11 @@
-import net from 'node:net'
 import undici from '@nxtedition/undici'
 import { Scheduler } from '@nxtedition/scheduler'
-import { createNormalizedHeaders, invalidateNormalizedHeaders, parseHeaders } from './utils.js'
+import {
+  buildAuthority,
+  createNormalizedHeaders,
+  invalidateNormalizedHeaders,
+  parseHeaders,
+} from './utils.js'
 import { request as _request } from './request.js'
 import { SqliteCacheStore } from './sqlite-cache-store.js'
 import { validateTrace } from './trace.js'
@@ -47,10 +51,7 @@ function defaultLookup(origin, opts, callback) {
 
       let host = origin.host
       if (!host && origin.hostname) {
-        const port = origin.port || (protocol === 'https:' ? 443 : 80)
-        // Bracket IPv6 literals, otherwise `::1:80` is not a valid authority.
-        const hostname = net.isIPv6(origin.hostname) ? `[${origin.hostname}]` : origin.hostname
-        host = `${hostname}:${port}`
+        host = buildAuthority(protocol, origin.hostname, origin.port)
       }
 
       if (!host) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { addAbortListener } from 'node:events'
 import { errors, Readable } from '@nxtedition/undici'
-import { isStream } from './utils.js'
+import { buildAuthority, isStream } from './utils.js'
 
 const { InvalidArgumentError, RequestAbortedError } = errors
 
@@ -210,10 +210,7 @@ export function request(dispatch, urlOrOpts, optsOrNully) {
   if (!origin) {
     const protocol = url.protocol ?? 'http:'
     const host =
-      url.host ??
-      // `||` not `??`: an empty-string port must fall back to the default,
-      // matching defaultLookup; `??` would yield a trailing-colon origin.
-      (url.hostname ? `${url.hostname}:${url.port || (protocol === 'https:' ? 443 : 80)}` : null)
+      url.host || (url.hostname ? buildAuthority(protocol, url.hostname, url.port) : null)
 
     if (!host || !protocol) {
       throw new InvalidArgumentError('invalid url')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+import net from 'node:net'
 import { util } from '@nxtedition/undici'
 import createHttpError from 'http-errors'
 
@@ -574,14 +575,22 @@ export function parseURL(url) {
   }
 
   if (!(url instanceof URL)) {
-    const port = url.port != null ? url.port : url.protocol === 'https:' ? 443 : 80
-    const origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`
+    const origin =
+      url.origin != null
+        ? url.origin
+        : `${url.protocol}//${buildAuthority(url.protocol, url.hostname, url.port)}`
     const path = url.path != null ? url.path : `${url.pathname || ''}${url.search || ''}`
 
     url = buildURL(origin, path)
   }
 
   return url
+}
+
+export function buildAuthority(protocol, hostname, port) {
+  const normalizedHostname = net.isIPv6(hostname) ? `[${hostname}]` : hostname
+  const normalizedPort = port == null || port === '' ? (protocol === 'https:' ? 443 : 80) : port
+  return `${normalizedHostname}:${normalizedPort}`
 }
 
 // Build an absolute URL from an origin and a path by concatenation.

--- a/test/url-object-authority.js
+++ b/test/url-object-authority.js
@@ -1,0 +1,93 @@
+import { test } from 'tap'
+import { dispatch, request } from '../lib/index.js'
+import { parseURL } from '../lib/utils.js'
+
+function makeDispatcher(capture) {
+  return {
+    dispatch(opts, handler) {
+      capture(opts)
+      handler.onConnect?.(() => {})
+      handler.onHeaders?.(200, {}, () => {})
+      handler.onComplete?.({})
+      return true
+    },
+  }
+}
+
+async function captureRequest(url) {
+  let captured
+  const { body } = await request(url, {
+    dispatch: makeDispatcher((opts) => {
+      captured = opts
+    }),
+    dns: false,
+    lookup(origin, _opts, callback) {
+      callback(null, origin)
+    },
+  })
+  await body.dump()
+  return captured
+}
+
+test('plain URL objects bracket IPv6 hostnames consistently', async (t) => {
+  const parsed = parseURL({ protocol: 'http:', hostname: '::1', port: 8080, path: '/' })
+  t.equal(parsed.origin, 'http://[::1]:8080')
+
+  const requestOpts = await captureRequest({
+    protocol: 'http:',
+    hostname: '::1',
+    port: 8080,
+    path: '/',
+  })
+  t.equal(requestOpts.origin, 'http://[::1]:8080')
+
+  let dispatchOpts
+  await dispatch(
+    makeDispatcher((opts) => {
+      dispatchOpts = opts
+    }),
+    {
+      origin: { protocol: 'http:', hostname: '::1', port: 8080 },
+      path: '/',
+      method: 'GET',
+      dns: false,
+    },
+    {},
+  )
+  t.equal(dispatchOpts.origin, 'http://[::1]:8080')
+})
+
+test('plain URL objects preserve an explicit port zero', async (t) => {
+  const parsed = parseURL({
+    protocol: 'http:',
+    hostname: 'example.test',
+    port: 0,
+    path: '/',
+  })
+  t.equal(parsed.origin, 'http://example.test:0')
+
+  const opts = await captureRequest({
+    protocol: 'http:',
+    host: '',
+    hostname: 'example.test',
+    port: 0,
+    path: '/',
+  })
+
+  t.equal(opts.origin, 'http://example.test:0')
+
+  let dispatchOpts
+  await dispatch(
+    makeDispatcher((innerOpts) => {
+      dispatchOpts = innerOpts
+    }),
+    {
+      origin: { protocol: 'http:', hostname: 'example.test', port: 0 },
+      path: '/',
+      method: 'GET',
+      dns: false,
+    },
+    {},
+  )
+  t.equal(dispatchOpts.origin, 'http://example.test:0')
+})


### PR DESCRIPTION
## Summary

- centralize authority construction for plain URL-shaped objects
- bracket unbracketed IPv6 hostnames before appending a port
- preserve an explicitly supplied numeric or string port `0`
- treat an empty `host` field as absent and fall back to `hostname`
- apply the same rules in `request()`, default origin lookup, and `parseURL()`

## Root cause

The three plain-object URL paths built authorities independently. `request()` emitted ambiguous strings such as `http://::1:80`, both request and default lookup used truthiness for ports and changed `0` to the default port, and `parseURL()` did not bracket IPv6 literals.

## Impact

Every supported URL-object entry point now produces the same unambiguous authority without silently changing explicit ports.

## Validation

- focused IPv6/port-zero regressions: 6/6 assertions
- related request, URL utility, and public-type suites: 137/137 assertions
- ESLint
- Prettier check
- `git diff --check`