### PR TITLE
fix(priority): align effective socket QoS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import undici from '@nxtedition/undici'
-import { Scheduler } from '@nxtedition/scheduler'
+import { parsePriority, Scheduler } from '@nxtedition/scheduler'
 import { createNormalizedHeaders, invalidateNormalizedHeaders, parseHeaders } from './utils.js'
 import { request as _request } from './request.js'
 import { SqliteCacheStore } from './sqlite-cache-store.js'
@@ -91,21 +91,7 @@ export function compose(...interceptors) {
   return dispatch
 }
 
-const PRIORITY_TOS_MAP = {}
-PRIORITY_TOS_MAP[Scheduler.HIGHEST] = 0xb8 // EF
-PRIORITY_TOS_MAP['highest'] = 0xb8 // EF
-PRIORITY_TOS_MAP[Scheduler.HIGHER] = 0x88 // AF41
-PRIORITY_TOS_MAP['higher'] = 0x88 // AF41
-PRIORITY_TOS_MAP[Scheduler.HIGH] = 0x68 // AF31
-PRIORITY_TOS_MAP['high'] = 0x68 // AF31
-PRIORITY_TOS_MAP[Scheduler.NORMAL] = 0x00 // BE
-PRIORITY_TOS_MAP['normal'] = 0x00 // BE
-PRIORITY_TOS_MAP[Scheduler.LOW] = 0x04 // LE
-PRIORITY_TOS_MAP['low'] = 0x04 // LE
-PRIORITY_TOS_MAP[Scheduler.LOWER] = 0x04 // LE
-PRIORITY_TOS_MAP['lower'] = 0x04 // LE
-PRIORITY_TOS_MAP[Scheduler.LOWEST] = 0x04 // LE
-PRIORITY_TOS_MAP['lowest'] = 0x04 // LE
+const PRIORITY_TOS = [0x04, 0x04, 0x04, 0x00, 0x68, 0x88, 0xb8]
 
 function wrapDispatch(dispatcher) {
   let wrappedDispatcher = dispatcherCache.get(dispatcher)
@@ -179,6 +165,16 @@ function wrapDispatch(dispatcher) {
           Object.assign(headers, parseHeaders(globalThis.__nxt_undici_global_headers))
         }
 
+        // Use the same effective priority for both scheduler admission and
+        // socket QoS. Header-derived priority is a supported path, including
+        // duplicate last-wins values, and parsePriority provides the
+        // scheduler's exact normalization for names, numbers and unknowns.
+        const headerPriority = Array.isArray(headers['nxt-priority'])
+          ? headers['nxt-priority'][headers['nxt-priority'].length - 1]
+          : headers['nxt-priority']
+        const priority = opts.priority ?? headerPriority
+        const parsedPriority = priority == null ? Scheduler.NORMAL : parsePriority(priority)
+
         return dispatch(
           {
             id: opts.id ?? headers['request-id'],
@@ -206,8 +202,7 @@ function wrapDispatch(dispatcher) {
               opts.bodyTimeout ??
               (typeof opts.timeout === 'number' ? opts.timeout : undefined),
             idempotent: opts.idempotent,
-            typeOfService:
-              opts.typeOfService ?? (opts.priority ? (PRIORITY_TOS_MAP[opts.priority] ?? 0) : 0),
+            typeOfService: opts.typeOfService ?? PRIORITY_TOS[parsedPriority - Scheduler.LOWEST],
             retry: opts.retry ?? 8,
             proxy: opts.proxy ?? false,
             cache: opts.cache ?? false,
@@ -225,14 +220,7 @@ function wrapDispatch(dispatcher) {
             trace: validateTrace(opts.trace),
             dns: opts.dns ?? true,
             connect: opts.connect,
-            // A duplicated nxt-priority request header parses to an array; the
-            // scheduler and PRIORITY_TOS_MAP expect a scalar, so take the last
-            // (last-wins). opts.priority, when set, is already scalar.
-            priority:
-              opts.priority ??
-              (Array.isArray(headers['nxt-priority'])
-                ? headers['nxt-priority'][headers['nxt-priority'].length - 1]
-                : headers['nxt-priority']),
+            priority,
             lookup: opts.lookup ?? defaultLookup,
           },
           handler,

--- a/test/priority-type-of-service.js
+++ b/test/priority-type-of-service.js
@@ -1,0 +1,53 @@
+import { test } from 'tap'
+import { dispatch } from '../lib/index.js'
+
+async function capture(extra) {
+  let captured
+  const dispatcher = {
+    dispatch(opts, handler) {
+      captured = opts
+      handler.onConnect?.(() => {})
+      handler.onHeaders?.(200, {}, () => {})
+      handler.onComplete?.({})
+      return true
+    },
+  }
+
+  await dispatch(
+    dispatcher,
+    {
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      dns: false,
+      lookup: false,
+      ...extra,
+    },
+    {},
+  )
+  return captured
+}
+
+test('header-derived priority also controls socket type of service', async (t) => {
+  const scalar = await capture({ headers: { 'nxt-priority': 'high' } })
+  t.equal(scalar.priority, 'high')
+  t.equal(scalar.typeOfService, 0x68)
+
+  const repeated = await capture({ headers: { 'nxt-priority': ['low', 'higher'] } })
+  t.equal(repeated.priority, 'higher')
+  t.equal(repeated.typeOfService, 0x88)
+
+  const overridden = await capture({
+    headers: { 'nxt-priority': 'high' },
+    typeOfService: 7,
+  })
+  t.equal(overridden.typeOfService, 7)
+})
+
+test('unknown priority names cannot read inherited type-of-service values', async (t) => {
+  for (const priority of ['constructor', 'toString', '__proto__']) {
+    const opts = await capture({ priority })
+    t.equal(opts.priority, priority)
+    t.equal(opts.typeOfService, 0, `${priority} falls back to best effort`)
+  }
+})


### PR DESCRIPTION
## Summary

- compute the effective priority once after header normalization
- use the supported last-wins `nxt-priority` header value for both scheduling and socket QoS
- normalize QoS lookup with the scheduler's `parsePriority()`
- replace the prototype-bearing object lookup with a bounded numeric table

## Root cause

The scheduler received priority from either `opts.priority` or the `nxt-priority` header, but `typeOfService` was derived only from `opts.priority`. Header-driven requests therefore used normal best-effort socket QoS despite higher/lower scheduler admission. The plain-object lookup also returned inherited values for names such as `constructor`, `toString`, and `__proto__`, forwarding functions or objects as `typeOfService`.

## Impact

Every supported priority input now produces consistent scheduler and network QoS behavior, while unknown names safely normalize to best effort.

## Validation

- focused scalar, duplicate-header, explicit-override, and hostile-name regressions
- related priority/core/public-type suites: 48/48 assertions
- ESLint
- Prettier check
- `git diff --check`