### PR TITLE
fix(log): snapshot redacted headers

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -9,64 +9,24 @@ const REDACTED = '[redacted]'
 // Header names (lowercase) whose values must never reach the logs.
 const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie', 'set-cookie'])
 
-// Allocation-free pre-scan: true when `headers` is a plain object that the
-// parse + redact path would reproduce verbatim — every key already lowercase,
-// every value a string (or array of strings), no secret header present. In
-// that case the original object can be logged as-is: log bindings only read
-// it (pino serializes child bindings eagerly), nothing in the pipeline
-// mutates a caller's headers object in place. Uses a `for..in` + `Object.hasOwn`
-// guard rather than `Object.keys` so the scan itself allocates nothing while
-// still ignoring inherited props exactly as `Object.keys` would.
-function isCleanHeaderObject(headers) {
-  for (const key in headers) {
-    if (!Object.hasOwn(headers, key)) {
-      continue
-    }
-    if (SECRET_HEADERS.has(key) || key.toLowerCase() !== key) {
-      return false
-    }
-    const val = headers[key]
-    if (Array.isArray(val)) {
-      for (const item of val) {
-        if (typeof item !== 'string') {
-          return false
-        }
-      }
-    } else if (typeof val !== 'string') {
-      return false
-    }
-  }
-  return true
-}
-
-// Return a loggable view of `headers` with credential values replaced by a
-// redaction marker. Copy-on-write: the common case (already-lowercased plain
-// object, string values, nothing to redact) returns the original object as-is,
-// allocating no new headers object (the pre-scan itself is allocation-free
-// too). Only when something actually needs work — flat-array
-// form ([name, value, name, value, ...] with Buffer or string entries from
-// onHeaders/onUpgrade), a secret header, a non-lowercase name, or a
-// non-string value — do we build a sanitized copy via parseHeaders, which
-// lowercases names, stringifies values (Buffers included, so no
-// `{type:'Buffer',data:[...]}` blobs in bindings), skips null/undefined, and
-// merges duplicate names into arrays instead of overwriting earlier values.
+// Return a stable log snapshot of `headers` with credential values replaced by
+// a redaction marker. The wire object must stay untouched, while the snapshot
+// must not observe later mutations by retry/follow callbacks or a dispatcher.
+// parseHeaders normalizes names and values; the object spread isolates trusted
+// internal snapshots for which parseHeaders is an identity fast path, and the
+// array copies isolate repeated field values too.
 function sanitizeHeaders(headers) {
   if (headers == null || typeof headers !== 'object') {
     return undefined
   }
 
-  if (!Array.isArray(headers) && isCleanHeaderObject(headers)) {
-    return headers
-  }
-
-  // A trusted request snapshot makes parseHeaders(headers) an identity fast
-  // path. Redaction must nevertheless happen on an isolated copy or it would
-  // replace credentials on the live wire headers.
   const sanitized = { ...parseHeaders(headers) }
 
-  for (const name of SECRET_HEADERS) {
-    if (name in sanitized) {
+  for (const [name, value] of Object.entries(sanitized)) {
+    if (SECRET_HEADERS.has(name)) {
       sanitized[name] = REDACTED
+    } else if (Array.isArray(value)) {
+      sanitized[name] = [...value]
     }
   }
 
@@ -246,9 +206,12 @@ class Handler extends DecoratorHandler {
   onHeaders(statusCode, headers, resume) {
     this.#timing.headers = performance.now() - this.#created
     this.#statusCode = statusCode
-    // Only used for log records; store the sanitized copy so set-cookie etc.
-    // never end up in retained (error-level) logs.
-    this.#headers = sanitizeHeaders(headers)
+    // Only used for log records. Avoid snapshot work for trace-only requests;
+    // when logging is active, retain an isolated copy so later dispatcher
+    // mutations cannot introduce set-cookie or other sensitive values.
+    if (this.#logger !== null) {
+      this.#headers = sanitizeHeaders(headers)
+    }
 
     return super.onHeaders(statusCode, headers, resume)
   }

--- a/test/log-redaction-snapshot.js
+++ b/test/log-redaction-snapshot.js
@@ -1,0 +1,88 @@
+import { Writable } from 'node:stream'
+import pino from 'pino'
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function captureLogger() {
+  let output = ''
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk
+      callback()
+    },
+  })
+
+  return {
+    logger: pino({ level: 'debug', base: null, timestamp: false }, stream),
+    records() {
+      return output
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+    },
+    output() {
+      return output
+    },
+  }
+}
+
+test('log snapshots request and response headers before later wire mutations', (t) => {
+  const capture = captureLogger()
+  const requestHeaders = {
+    'x-request-safe': 'visible',
+    'x-request-values': ['initial-request-value'],
+  }
+  const responseHeaders = {
+    'x-response-safe': 'visible',
+    'x-response-values': ['initial-response-value'],
+  }
+  let dispatchedHeaders
+
+  const dispatch = interceptors.log()((opts, handler) => {
+    dispatchedHeaders = opts.headers
+    handler.onConnect(() => {})
+
+    opts.headers.authorization = 'Bearer later-request-secret'
+    opts.headers['x-request-values'].push('later-request-array-value')
+
+    handler.onHeaders(500, responseHeaders, () => {})
+    responseHeaders['set-cookie'] = 'session=later-response-secret'
+    responseHeaders['x-response-values'].push('later-response-array-value')
+    handler.onComplete([])
+  })
+
+  dispatch(
+    {
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      headers: requestHeaders,
+      logger: capture.logger,
+    },
+    {},
+  )
+
+  const completed = capture.records().find((record) => record.msg === 'upstream request completed')
+
+  t.equal(dispatchedHeaders, requestHeaders, 'the wire request keeps its original header object')
+  t.equal(requestHeaders.authorization, 'Bearer later-request-secret', 'wire mutation still lands')
+  t.equal(
+    responseHeaders['set-cookie'],
+    'session=later-response-secret',
+    'response object mutation still lands',
+  )
+  t.strictSame(completed.ureq.headers, {
+    'x-request-safe': 'visible',
+    'x-request-values': ['initial-request-value'],
+  })
+  t.strictSame(completed.ures.headers, {
+    'x-response-safe': 'visible',
+    'x-response-values': ['initial-response-value'],
+  })
+  t.notMatch(capture.output(), /later-request-secret/)
+  t.notMatch(capture.output(), /later-response-secret/)
+  t.notMatch(capture.output(), /later-request-array-value/)
+  t.notMatch(capture.output(), /later-response-array-value/)
+  t.end()
+})

--- a/test/review-bugfixes-4-log-redact.js
+++ b/test/review-bugfixes-4-log-redact.js
@@ -335,14 +335,16 @@ test('log: real URL instance origin uses its credential-free origin', async (t) 
 })
 
 // ---------------------------------------------------------------------------
-// Copy-on-write fast path: nothing to redact → no new objects are allocated
+// Log metadata is snapshotted without replacing the wire object
 // ---------------------------------------------------------------------------
 
-test('log: clean headers and origin are passed through by reference (no copy)', async (t) => {
+test('log: clean headers are snapshotted without replacing the wire object', async (t) => {
   // Drive the interceptor over a stub dispatch so the exact opts objects reach
-  // the log handler and identity can be asserted on the captured binding.
+  // the log handler and both wire/log identity can be asserted.
   const logger = makeCapturingLogger()
+  let dispatchedHeaders
   const dispatch = interceptors.log()((opts, handler) => {
+    dispatchedHeaders = opts.headers
     handler.onConnect(() => {})
     handler.onHeaders(200, ['content-length', '0'], () => {})
     handler.onComplete([])
@@ -359,7 +361,10 @@ test('log: clean headers and origin are passed through by reference (no copy)', 
 
   const ureq = logger.bindings[0]?.ureq
   t.ok(ureq, 'child() was called with a ureq binding')
-  t.equal(ureq.headers, headers, 'zero-mutation header object bound by reference, not copied')
+  t.equal(dispatchedHeaders, headers, 'logging preserves the exact wire header object')
+  t.not(ureq.headers, headers, 'log headers are an isolated snapshot')
+  t.not(ureq.headers['x-multi'], headers['x-multi'], 'repeated values are isolated too')
+  t.strictSame(ureq.headers, headers, 'the snapshot preserves normalized values')
   t.equal(ureq.origin, origin, 'origin without userinfo logged as-is without URL parsing')
   t.equal(ureq.headers['x-plain'], 'visible-value', 'values still readable through the binding')
 })


### PR DESCRIPTION
## Summary

- make request and response headers in log metadata stable snapshots
- preserve the original wire header object and all subsequent wire mutations
- clone repeated header arrays so later mutations cannot alter completed log records
- skip response snapshot work for trace-only requests

## Root cause

The clean-header fast path returned the live header object. Retry/follow callbacks and dispatchers may mutate that object after logging starts, so later completion records could observe newly added credentials such as `Authorization` or `Set-Cookie` without redaction.

## Validation

- focused real-Pino request/response mutation regression
- 7 related log, normalization, and trace suites: 205 assertions
- ESLint
- Prettier
- `git diff --check`