### PR TITLE
fix(dns): preserve configured origin authority

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import * as dns from 'node:dns'
-import { DecoratorHandler, getFastNow, parseHeaders } from '../utils.js'
+import { buildURL, DecoratorHandler, getFastNow, parseHeaders } from '../utils.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 import xxhash from 'xxhash-wasm'
 
@@ -286,10 +286,17 @@ export default () => (dispatch) => {
       if (typeof lookup !== 'function') {
         throw new TypeError('opts.dns.lookup must be a function')
       }
-      const url = new URL(opts.path ?? '', opts.origin)
+      // Parse the authority exclusively from the configured origin. Treating
+      // opts.path as a URL reference would let an origin-form path beginning
+      // with `//` (or an absolute/backslash equivalent) replace the hostname,
+      // scheme and port before DNS resolution. buildURL keeps the origin
+      // authoritative while still giving hash balancing a normalized pathname.
+      // The original opts.path is forwarded unchanged below.
+      const url = new URL(opts.origin)
+      const { pathname } = buildURL(url.origin, opts.path)
       const balance = opts.dns.balance
 
-      const { host, hostname, pathname } = url
+      const { host, hostname } = url
 
       if (net.isIP(hostname)) {
         return await dispatch(opts, wrapped)

--- a/test/dns-origin-authority.js
+++ b/test/dns-origin-authority.js
@@ -1,0 +1,87 @@
+import { test } from 'tap'
+import xxhash from 'xxhash-wasm'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'https://victim.test:8443'
+const RECORDS = [
+  { address: '192.0.2.10', family: 4 },
+  { address: '192.0.2.11', family: 4 },
+  { address: '192.0.2.12', family: 4 },
+]
+const HASHER = await xxhash()
+
+const cases = [
+  {
+    name: 'network-path reference',
+    path: '//attacker.test:9443/network?query=1',
+    pathname: '//attacker.test:9443/network',
+  },
+  {
+    name: 'absolute-form URL',
+    path: 'http://attacker.test:9443/absolute?query=1',
+    pathname: '/http://attacker.test:9443/absolute',
+  },
+  {
+    name: 'slash-backslash authority',
+    path: '/\\attacker.test:9443/backslash?query=1',
+    pathname: '//attacker.test:9443/backslash',
+  },
+  {
+    name: 'leading backslash authority',
+    path: '\\\\attacker.test:9443/backslash-root?query=1',
+    pathname: '///attacker.test:9443/backslash-root',
+  },
+  {
+    name: 'ordinary origin-form path',
+    path: '/safe//attacker.test:9443/path?query=1',
+    pathname: '/safe//attacker.test:9443/path',
+  },
+]
+
+for (const { name, path, pathname } of cases) {
+  test(`dns: ${name} cannot replace the configured origin authority`, async (t) => {
+    const lookups = []
+    let seen
+
+    const lookup = (hostname, options, callback) => {
+      lookups.push({ hostname, options })
+      callback(null, RECORDS)
+    }
+    const dispatch = interceptors.dns()((opts, handler) => {
+      seen = opts
+      handler.onConnect(() => {})
+      handler.onComplete([])
+    })
+
+    await new Promise((resolve, reject) => {
+      dispatch(
+        {
+          origin: ORIGIN,
+          path,
+          method: 'GET',
+          headers: {},
+          dns: { balance: 'hash', lookup, ttl: 30_000 },
+        },
+        {
+          onConnect() {},
+          onHeaders() {
+            return true
+          },
+          onData() {},
+          onComplete: resolve,
+          onError: reject,
+        },
+      )
+    })
+
+    t.same(lookups, [{ hostname: 'victim.test', options: { all: true } }])
+    t.equal(seen.path, path, 'the original request path is forwarded unchanged')
+    t.equal(seen.headers.host, 'victim.test:8443', 'Host remains the configured authority')
+
+    const selected = RECORDS[HASHER.h32(pathname) % RECORDS.length].address
+    const rewritten = new URL(seen.origin)
+    t.equal(rewritten.protocol, 'https:', 'the configured scheme is preserved')
+    t.equal(rewritten.hostname, selected, 'hash balancing uses the path under the fixed origin')
+    t.equal(rewritten.port, '8443', 'the configured port is preserved')
+  })
+}


### PR DESCRIPTION
## Summary

- derive DNS authority exclusively from the configured request origin
- interpret the request path only as path data for hash balancing
- preserve the original path unchanged when dispatching to the resolved address
- cover network-path, absolute-form, backslash authority, and ordinary origin-form paths

## Root cause

The DNS interceptor constructed a URL with `new URL(opts.path, opts.origin)`. WHATWG URL resolution treats `//host`, absolute-form URLs, and equivalent backslash forms as authority-bearing references. A caller-controlled path could therefore replace the configured hostname, scheme, and port before DNS resolution, causing the request to be sent to a different origin.

The interceptor now parses authority only from `opts.origin` and uses the existing origin-preserving URL builder solely to derive the pathname used for hash balancing.

## Validation

- focused DNS, DNS trace, redirect-base, and related review suites: 208 assertions passed
- ESLint
- Prettier check
- `git diff --check`
