### PR TITLE
fix(response-error): honor primary option precedence

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -149,6 +149,6 @@ class Handler extends DecoratorHandler {
 }
 
 export default () => (dispatch) => (opts, handler) =>
-  opts.throwOnError !== false && opts.error !== false
+  (opts.error ?? opts.throwOnError ?? true)
     ? dispatch(opts, new Handler(opts, { handler }))
     : dispatch(opts, handler)

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -149,6 +149,6 @@ class Handler extends DecoratorHandler {
 }
 
 export default () => (dispatch) => (opts, handler) =>
-  (opts.error ?? opts.throwOnError ?? true)
+  (opts.error ?? opts.throwOnError ?? true) !== false
     ? dispatch(opts, new Handler(opts, { handler }))
     : dispatch(opts, handler)

--- a/test/response-error-option-precedence.js
+++ b/test/response-error-option-precedence.js
@@ -1,0 +1,59 @@
+import { test } from 'tap'
+import responseError from '../lib/interceptor/response-error.js'
+
+function dispatchErrorResponse(opts) {
+  let outcome
+  const dispatch = responseError()((_opts, handler) => {
+    handler.onConnect?.(() => {})
+    handler.onHeaders(500, {}, () => {})
+    handler.onComplete({})
+  })
+
+  dispatch(
+    {
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      headers: {},
+      ...opts,
+    },
+    {
+      onHeaders() {
+        return true
+      },
+      onComplete() {
+        outcome = 'complete'
+      },
+      onError() {
+        outcome = 'error'
+      },
+    },
+  )
+
+  return outcome
+}
+
+test('response-error gives error precedence over throwOnError', (t) => {
+  t.equal(
+    dispatchErrorResponse({ error: true, throwOnError: false }),
+    'error',
+    'the primary option enables response errors',
+  )
+  t.equal(
+    dispatchErrorResponse({ error: false, throwOnError: true }),
+    'complete',
+    'the primary option disables response errors',
+  )
+  t.end()
+})
+
+test('response-error uses throwOnError only when error is absent', (t) => {
+  t.equal(
+    dispatchErrorResponse({ throwOnError: false }),
+    'complete',
+    'the alias can disable errors',
+  )
+  t.equal(dispatchErrorResponse({ throwOnError: true }), 'error', 'the alias can enable errors')
+  t.equal(dispatchErrorResponse({}), 'error', 'response errors remain enabled by default')
+  t.end()
+})

--- a/test/response-error-option-precedence.js
+++ b/test/response-error-option-precedence.js
@@ -57,3 +57,10 @@ test('response-error uses throwOnError only when error is absent', (t) => {
   t.equal(dispatchErrorResponse({}), 'error', 'response errors remain enabled by default')
   t.end()
 })
+
+test('response-error is disabled only by an explicit false', (t) => {
+  for (const error of [0, '', NaN]) {
+    t.equal(dispatchErrorResponse({ error }), 'error', `${String(error)} does not disable errors`)
+  }
+  t.end()
+})


### PR DESCRIPTION
## Summary

- make the documented `error` option take precedence over its `throwOnError` alias
- preserve alias-only and default behavior
- cover conflicting, alias-only, and default option combinations

## Validation

- `npx tap --disable-coverage --reporter=terse test/response-error-option-precedence.js test/response-error-advanced.js test/response-error-falsy-body.js test/response-error-reset-trailers.js`
- `npx eslint lib/interceptor/response-error.js test/response-error-option-precedence.js`
- `npx prettier --check lib/interceptor/response-error.js test/response-error-option-precedence.js`
- `git diff --check`