### PR TITLE
fix(body-factory): reject falsy failures

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -3,6 +3,13 @@ import { DecoratorHandler, isStream } from '../utils.js'
 
 function noop() {}
 
+function normalizeFactoryError(reason) {
+  // Node's stream construction callback treats every falsy value as success.
+  // A factory can throw or reject with any JavaScript value, so forwarding a
+  // falsy reason would leave this stream constructed without a body or EOF.
+  return reason || new Error('Request body factory failed', { cause: reason })
+}
+
 class FactoryStream extends Readable {
   #factory
   #ac
@@ -27,7 +34,9 @@ class FactoryStream extends Readable {
     // destroy with an error can still abort the factory's signal (see
     // _destroy) — e.g. the request failing before undici started writing
     // the body.
-    Promise.resolve(this.#factory({ signal: this.#ac.signal })).then(
+    // Promise.try is available on the Node 26 baseline and gives synchronous
+    // factory throws the same normalized rejection path as async failures.
+    Promise.try(() => this.#factory({ signal: this.#ac.signal })).then(
       (body) => {
         try {
           // Normalize binary bodies to Buffer (zero-copy: reinterpret the same
@@ -95,10 +104,10 @@ class FactoryStream extends Readable {
 
           callback(null)
         } catch (err) {
-          callback(err)
+          callback(normalizeFactoryError(err))
         }
       },
-      (err) => callback(err),
+      (err) => callback(normalizeFactoryError(err)),
     )
   }
 

--- a/test/review-body-factory-falsy-errors.js
+++ b/test/review-body-factory-falsy-errors.js
@@ -1,0 +1,103 @@
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { test } from 'tap'
+import { request } from '../lib/index.js'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+const falsyReasons = [
+  ['undefined', undefined],
+  ['null', null],
+  ['false', false],
+  ['zero', 0],
+  ['empty string', ''],
+]
+
+async function captureFactoryStreamError(factory) {
+  let body
+  const dispatch = requestBodyFactory()((opts) => {
+    body = opts.body
+  })
+
+  dispatch({ body: factory }, {})
+
+  const error = once(body, 'error', { signal: AbortSignal.timeout(1_000) })
+  body.resume()
+
+  try {
+    return (await error)[0]
+  } finally {
+    body.destroy()
+  }
+}
+
+function assertNormalizedError(t, err, reason) {
+  t.type(err, Error)
+  t.equal(err.message, 'Request body factory failed')
+  t.ok(Object.hasOwn(err, 'cause'), 'the original failure is retained as cause')
+  t.equal(err.cause, reason)
+}
+
+test('body factory normalizes falsy synchronous throws into stream errors', async (t) => {
+  for (const [name, reason] of falsyReasons) {
+    await t.test(name, async (t) => {
+      const err = await captureFactoryStreamError(() => {
+        throw reason
+      })
+      assertNormalizedError(t, err, reason)
+    })
+  }
+})
+
+test('body factory normalizes falsy asynchronous rejections into stream errors', async (t) => {
+  for (const [name, reason] of falsyReasons) {
+    await t.test(name, async (t) => {
+      const err = await captureFactoryStreamError(() => Promise.reject(reason))
+      assertNormalizedError(t, err, reason)
+    })
+  }
+})
+
+test('falsy body factory failures reject real requests promptly', async (t) => {
+  const server = createServer((req, res) => {
+    req.on('error', () => {})
+    res.on('error', () => {})
+    req.resume()
+    req.on('end', () => res.end())
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const cases = [
+    [
+      'synchronous throw',
+      undefined,
+      () => {
+        throw undefined
+      },
+    ],
+    ['asynchronous rejection', null, () => Promise.reject(null)],
+  ]
+
+  for (const [name, reason, factory] of cases) {
+    await t.test(name, async (t) => {
+      try {
+        await request(origin, {
+          method: 'POST',
+          body: factory,
+          signal: AbortSignal.timeout(1_000),
+          retry: false,
+          follow: false,
+          cache: false,
+          proxy: false,
+          verify: false,
+          error: false,
+        })
+        t.fail('request should reject')
+      } catch (err) {
+        assertNormalizedError(t, err, reason)
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- normalize falsy body-factory throws and promise rejections into a real `Error`
- preserve the original rejection value on `error.cause`
- use Node 26 `Promise.try()` so synchronous and asynchronous failures share one path
- add direct stream and real-request regressions for synchronous and asynchronous failures

## Root cause

Node stream construction callbacks interpret every falsy callback argument as success. Passing a factory failure such as `undefined`, `null`, `false`, `0`, or an empty string directly to `_construct` therefore left the stream open without a body or EOF, causing the request to hang indefinitely.

## Validation

- 17 request/body-factory suites: 177 assertions passed
- ESLint on the changed implementation and test
- Prettier check on the changed implementation and test
- `git diff --check`
