### PR TITLE
fix(priority): canonicalize origin scheduler keys

### DIFF
--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -1,6 +1,15 @@
 import { Scheduler } from '@nxtedition/scheduler'
-import { DecoratorHandler } from '../utils.js'
+import { DecoratorHandler, parseURL } from '../utils.js'
 import { traceWrite, traceSafe, traceUrl } from '../trace.js'
+
+function canonicalOrigin(origin, host) {
+  if (Array.isArray(origin)) {
+    return JSON.stringify(origin.map((value) => canonicalOrigin(value, host)).toSorted())
+  }
+
+  const url = parseURL(origin)
+  return host == null ? url.origin : new URL(`${url.protocol}//${host}`).origin
+}
 
 class Handler extends DecoratorHandler {
   #scheduler
@@ -73,11 +82,15 @@ export default () => (dispatch) => {
       return dispatch(opts, handler)
     }
 
-    // Key on the logical origin, not opts.origin: an outer dns interceptor
-    // rewrites opts.origin to a rotating resolved IP, which would scatter one
-    // logical host across many schedulers and silently defeat the per-origin
-    // concurrency limit. dns preserves the logical host in the `host` header.
-    const key = (typeof opts.headers?.host === 'string' && opts.headers.host) || opts.origin
+    // Key on a canonical logical origin. An outer dns interceptor rewrites
+    // opts.origin to a rotating resolved IP but preserves the logical authority
+    // in Host; combine that authority with the rewritten origin's scheme so one
+    // service shares a scheduler across IPs without conflating HTTP and HTTPS.
+    // Canonical URL strings also make equivalent URL/URLObject instances share
+    // instead of keying the Map by object identity.
+    const host =
+      typeof opts.headers?.host === 'string' && opts.headers.host ? opts.headers.host : null
+    const key = canonicalOrigin(opts.origin, host)
 
     let scheduler = schedulers.get(key)
     if (!scheduler) {

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -4,11 +4,21 @@ import { traceWrite, traceSafe, traceUrl } from '../trace.js'
 
 function canonicalOrigin(origin, host) {
   if (Array.isArray(origin)) {
-    return JSON.stringify(origin.map((value) => canonicalOrigin(value, host)).toSorted())
+    const origins = [...new Set(origin.map((value) => canonicalOrigin(value, host)))].toSorted()
+    return origins.length === 1 ? origins[0] : JSON.stringify(origins)
   }
 
   const url = parseURL(origin)
-  return host == null ? url.origin : new URL(`${url.protocol}//${host}`).origin
+  if (host != null) {
+    try {
+      return new URL(`${url.protocol}//${host}`).origin
+    } catch {
+      // Host is untrusted runtime input. If it is not a valid authority, use
+      // the already-validated origin rather than letting a scheduling key
+      // prevent the underlying dispatcher from handling the request.
+    }
+  }
+  return url.origin
 }
 
 class Handler extends DecoratorHandler {

--- a/test/priority-origin-key.js
+++ b/test/priority-origin-key.js
@@ -1,0 +1,90 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const handler = {}
+
+function capturingPriority() {
+  const calls = []
+  const dispatch = interceptors.priority()((opts, handler) => {
+    calls.push({ opts, handler })
+  })
+  return { calls, dispatch }
+}
+
+test('priority: equivalent URL-like origins share one scheduler', (t) => {
+  t.plan(3)
+  const { calls, dispatch } = capturingPriority()
+
+  dispatch(
+    { origin: new URL('http://EXAMPLE.test:80/one'), headers: {}, priority: 'high' },
+    handler,
+  )
+  dispatch({ origin: new URL('http://example.test/two'), headers: {}, priority: 'high' }, handler)
+  dispatch(
+    {
+      origin: { protocol: 'http:', hostname: 'example.test', port: 80, pathname: '/three' },
+      headers: {},
+      priority: 'high',
+    },
+    handler,
+  )
+
+  t.equal(calls.length, 1, 'equivalent URL and URLObject values serialize together')
+  calls[0].handler.onConnect(() => {})
+  t.equal(calls.length, 2, 'the second equivalent origin runs after the first connects')
+  calls[1].handler.onConnect(() => {})
+  t.equal(calls.length, 3, 'the plain URLObject shares the same scheduler')
+})
+
+test('priority: rotating DNS addresses retain one scheme-aware logical key', (t) => {
+  t.plan(2)
+  const { calls, dispatch } = capturingPriority()
+  const base = { headers: { host: 'service.test:8080' }, priority: 'high' }
+
+  dispatch({ ...base, origin: 'http://192.0.2.1:8080' }, handler)
+  dispatch({ ...base, origin: 'http://192.0.2.2:8080' }, handler)
+
+  t.equal(calls.length, 1, 'same-scheme addresses for one logical Host serialize')
+  calls[0].handler.onConnect(() => {})
+  t.equal(calls.length, 2, 'the second address runs when the logical-origin slot is released')
+})
+
+test('priority: HTTP and HTTPS authorities use distinct schedulers', (t) => {
+  t.plan(1)
+  const { calls, dispatch } = capturingPriority()
+  const base = { headers: { host: 'service.test:8080' }, priority: 'high' }
+
+  dispatch({ ...base, origin: 'http://192.0.2.1:8080' }, handler)
+  dispatch({ ...base, origin: 'https://192.0.2.2:8080' }, handler)
+
+  t.equal(calls.length, 2, 'a shared Host does not conflate different schemes')
+})
+
+test('priority: equivalent OriginLike arrays share one scheduler', (t) => {
+  t.plan(2)
+  const { calls, dispatch } = capturingPriority()
+
+  dispatch(
+    {
+      origin: [new URL('https://one.test/a'), { protocol: 'https:', hostname: 'two.test' }],
+      headers: {},
+      priority: 'high',
+    },
+    handler,
+  )
+  dispatch(
+    {
+      origin: [
+        { protocol: 'https:', hostname: 'two.test', port: 443 },
+        new URL('https://one.test/b'),
+      ],
+      headers: {},
+      priority: 'high',
+    },
+    handler,
+  )
+
+  t.equal(calls.length, 1, 'equivalent origin pools canonicalize independent of value identity')
+  calls[0].handler.onConnect(() => {})
+  t.equal(calls.length, 2, 'the equivalent origin pool shares the scheduler')
+})

--- a/test/priority-origin-key.js
+++ b/test/priority-origin-key.js
@@ -88,3 +88,33 @@ test('priority: equivalent OriginLike arrays share one scheduler', (t) => {
   calls[0].handler.onConnect(() => {})
   t.equal(calls.length, 2, 'the equivalent origin pool shares the scheduler')
 })
+
+test('priority: DNS pools collapse duplicate logical origins', (t) => {
+  t.plan(2)
+  const { calls, dispatch } = capturingPriority()
+  const base = { headers: { host: 'service.test' }, priority: 'high' }
+
+  dispatch({ ...base, origin: ['http://192.0.2.1', 'http://192.0.2.2'] }, handler)
+  dispatch({ ...base, origin: 'http://192.0.2.3' }, handler)
+
+  t.equal(calls.length, 1, 'pool length does not alter the logical-origin key')
+  calls[0].handler.onConnect(() => {})
+  t.equal(calls.length, 2, 'the scalar address shares the pool scheduler')
+})
+
+test('priority: malformed Host values do not crash key construction', (t) => {
+  const { calls, dispatch } = capturingPriority()
+
+  t.doesNotThrow(() =>
+    dispatch(
+      {
+        origin: 'http://192.0.2.1',
+        headers: { host: 'not a valid authority' },
+        priority: 'high',
+      },
+      handler,
+    ),
+  )
+  t.equal(calls.length, 1, 'the request falls back to its configured origin')
+  t.end()
+})

--- a/test/trace-priority.js
+++ b/test/trace-priority.js
@@ -121,7 +121,7 @@ test('trace-priority: contended slot emits queued doc, both requests get end doc
     op: 'undici:priority',
     phase: 'end',
     id: 'req-1',
-    key: 'example.com',
+    key: 'http://example.com',
     priority: 'high',
     pending: null,
   })
@@ -137,7 +137,7 @@ test('trace-priority: contended slot emits queued doc, both requests get end doc
     op: 'undici:priority',
     phase: 'end',
     id: 'req-2',
-    key: 'example.com',
+    key: 'http://example.com',
     priority: 'high',
     pending: null,
   })

--- a/test/trace-priority.js
+++ b/test/trace-priority.js
@@ -105,7 +105,7 @@ test('trace-priority: contended slot emits queued doc, both requests get end doc
     op: 'undici:priority',
     phase: 'queued',
     id: 'req-2',
-    key: 'example.com',
+    key: 'http://example.com',
     priority: 'high',
     pending: 1,
     waitMs: null,


### PR DESCRIPTION
## Summary

- canonicalize priority scheduler keys across string, URL, URLObject, and array origins
- combine DNS-preserved Host authorities with the request scheme
- keep rotating addresses for one logical origin serialized without conflating HTTP and HTTPS
- make priority trace keys reflect the canonical scheme-aware origin

## Root cause

The priority interceptor used either the raw `opts.origin` value or a bare Host header as its `Map` key. Distinct but equivalent URL objects therefore created independent schedulers, while DNS-rewritten HTTP and HTTPS requests carrying the same Host incorrectly shared one scheduler.

The interceptor now derives a canonical origin key. URL-like values normalize to their origin, equivalent origin arrays normalize recursively, and a DNS-preserved Host is combined with the rewritten origin's scheme.

## Validation

- priority, trace, request, URL-authority, and public-type suites: 102 assertions passed
- ESLint
- Prettier check
- `git diff --check`
