### PR TITLE
fix(query): replace malformed Unicode

### DIFF
--- a/lib/interceptor/query.js
+++ b/lib/interceptor/query.js
@@ -21,7 +21,34 @@ function serializePathWithQuery(url, queryParams) {
     throw new Error('Query params cannot be passed when url already contains "?" or "#".')
   }
 
-  let stringified = stringify(queryParams)
+  let normalized = queryParams
+  if (queryParams != null && typeof queryParams === 'object') {
+    normalized = Object.create(null)
+    for (const key of Object.keys(queryParams)) {
+      const normalizedKey = key.toWellFormed()
+      const value = queryParams[key]
+      const normalizedValue = Array.isArray(value)
+        ? value.map((item) => (typeof item === 'string' ? item.toWellFormed() : item))
+        : typeof value === 'string'
+          ? value.toWellFormed()
+          : value
+
+      // Distinct malformed keys can normalize to the same replacement string.
+      // Preserve both fields as repeated values instead of silently overwriting
+      // one while constructing the normalized object.
+      if (Object.hasOwn(normalized, normalizedKey)) {
+        const previous = normalized[normalizedKey]
+        normalized[normalizedKey] = [
+          ...(Array.isArray(previous) ? previous : [previous]),
+          ...(Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue]),
+        ]
+      } else {
+        normalized[normalizedKey] = normalizedValue
+      }
+    }
+  }
+
+  let stringified = stringify(normalized)
 
   // fast-querystring emits separators for keys whose value is an empty array,
   // even though it emits no field for the key itself. Encoded names/values

--- a/test/query-well-formed-unicode.js
+++ b/test/query-well-formed-unicode.js
@@ -1,0 +1,32 @@
+import { test } from 'tap'
+import query from '../lib/interceptor/query.js'
+
+function serialize(queryParams) {
+  let path
+  const dispatch = query()((opts) => {
+    path = opts.path
+  })
+
+  dispatch({ path: '/', query: queryParams }, {})
+  return path
+}
+
+test('query replaces lone surrogates in keys and values', (t) => {
+  t.equal(
+    serialize({
+      '\ud800key': '\udc00',
+      values: ['valid', '\ud800'],
+      emoji: '\ud83d\ude00',
+    }),
+    '/?%EF%BF%BDkey=%EF%BF%BD&values=valid&values=%EF%BF%BD&emoji=%F0%9F%98%80',
+  )
+  t.end()
+})
+
+test('query preserves fields whose malformed keys normalize equally', (t) => {
+  t.equal(
+    serialize({ '\ud800': 'first', '\ud801': 'second' }),
+    '/?%EF%BF%BD=first&%EF%BF%BD=second',
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary

- normalize query keys and string values with Node 26's native `String.prototype.toWellFormed()`
- replace lone UTF-16 surrogates before percent encoding instead of throwing or corrupting adjacent key text
- preserve distinct fields when malformed keys normalize to the same replacement string

## Validation

- `npx tap --disable-coverage --reporter=terse test/query-well-formed-unicode.js test/query.js test/review-bugfixes-2-core.js test/review-bugfixes-4-request-defaults.js` (38/38 assertions)
- ESLint
- Prettier check
- `git diff --check`