### PR TITLE
fix(retry): preserve response backpressure

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -212,7 +212,25 @@ class Handler extends DecoratorHandler {
   #aborted = false
   #reason
   #resume
+  #paused = false
+  #replay = null
   #retryAbortController = null
+
+  #downstreamResume = () => {
+    if (this.#aborted || this.#errorSent) {
+      return
+    }
+
+    // The consumer keeps the callback received with the original headers.
+    // Route it to the current retry attempt, but drain any buffered replay
+    // first so old and live chunks cannot be reordered.
+    this.#paused = false
+    if (this.#replay) {
+      this.#pumpReplay(true)
+    } else {
+      this.#resume?.()
+    }
+  }
 
   #pos
   #end
@@ -246,10 +264,13 @@ class Handler extends DecoratorHandler {
       this.#end = null
       this.#etag = null
       this.#resume = null
+      this.#paused = false
+      this.#replay = null
 
       super.onConnect((reason) => {
         if (!this.#aborted) {
           this.#aborted = true
+          this.#replay = null
           // Always remember the reason: a downstream abort can land during the
           // backoff wait between attempts, when #abort still points at the
           // finished attempt's abort which undici has made a no-op. Without
@@ -352,7 +373,9 @@ class Handler extends DecoratorHandler {
       this.#resume = resume
 
       this.#headersSent = true
-      return super.onHeaders(statusCode, headers, () => this.#resume?.())
+      const ret = super.onHeaders(statusCode, headers, this.#downstreamResume)
+      this.#paused = ret === false
+      return ret
     } else if (statusCode === 206 || (this.#pos === 0 && statusCode === 200)) {
       assert(this.#etag != null || !this.#pos)
 
@@ -395,7 +418,7 @@ class Handler extends DecoratorHandler {
         const contentLength = headers['content-length'] ? Number(headers['content-length']) : null
         this.#end = Number.isFinite(contentLength) ? contentLength : null
         this.#resume = resume
-        return true
+        return !this.#paused
       }
 
       const contentRange = parseContentRange(headers['content-range'])
@@ -415,9 +438,7 @@ class Handler extends DecoratorHandler {
       }
 
       this.#resume = resume
-
-      // TODO (fix): What if we were paused before the error?
-      return true
+      return !this.#paused
     } else {
       // A resume attempt landed on an unexpected status (e.g. a 503 while
       // resuming). #retryError describes the PREVIOUS failure — surfacing it
@@ -447,7 +468,7 @@ class Handler extends DecoratorHandler {
     }
 
     if (this.#statusCode < 400 || (this.#headersSent && !this.#errorSent)) {
-      return super.onData(chunk)
+      return this.#forwardData(chunk)
     }
 
     if (this.#body) {
@@ -463,15 +484,7 @@ class Handler extends DecoratorHandler {
         this.#body = null
         this.#bodySize = 0
 
-        this.#headersSent = true
-        let ret = super.onHeaders(this.#statusCode, this.#headers, () => this.#resume?.())
-        for (const buffered of body) {
-          if (this.#aborted) {
-            return false
-          }
-          ret = super.onData(buffered)
-        }
-        return ret
+        return this.#startReplay(body, false)
       }
     }
   }
@@ -496,6 +509,63 @@ class Handler extends DecoratorHandler {
     this.#maybeRetry(err)
   }
 
+  #forwardData(chunk) {
+    const ret = super.onData(chunk)
+    if (this.#aborted || this.#errorSent) {
+      return false
+    }
+    this.#paused = ret === false
+    return ret
+  }
+
+  #startReplay(body, complete) {
+    // `complete` means the inner response has already ended and its buffered
+    // body is now being delivered. Otherwise this is the buffer-cap transition:
+    // the live transport is still inside onData and must remain paused until
+    // every older buffered chunk has been accepted downstream.
+    this.#replay = { body, index: 0, complete, trailers: this.#trailers }
+    this.#headersSent = true
+
+    const ret = super.onHeaders(this.#statusCode, this.#headers, this.#downstreamResume)
+    if (this.#aborted || this.#errorSent) {
+      this.#replay = null
+      return false
+    }
+    if (ret === false) {
+      this.#paused = true
+      return false
+    }
+
+    this.#paused = false
+    return this.#pumpReplay(false)
+  }
+
+  #pumpReplay(resumeTransport) {
+    const replay = this.#replay
+    if (!replay) {
+      if (resumeTransport) {
+        this.#resume?.()
+      }
+      return true
+    }
+
+    while (replay.index < replay.body.length) {
+      const ret = this.#forwardData(replay.body[replay.index++])
+      if (ret === false) {
+        return false
+      }
+    }
+
+    this.#replay = null
+    if (replay.complete) {
+      super.onComplete(replay.trailers)
+      this.#maybeAbort(null)
+    } else if (resumeTransport) {
+      this.#resume?.()
+    }
+    return true
+  }
+
   #maybeAbort(err) {
     if (this.#abort && !this.#aborted) {
       this.#aborted = true
@@ -517,27 +587,19 @@ class Handler extends DecoratorHandler {
     }
 
     if (err != null) {
+      this.#replay = null
       if (!this.#errorSent) {
         this.#errorSent = true
         super.onError(err)
       }
     } else if (!this.#headersSent) {
-      super.onHeaders(this.#statusCode, this.#headers, noop)
-      if (this.#aborted) {
-        return
-      }
-
-      if (this.#body) {
-        for (const chunk of this.#body) {
-          super.onData(chunk)
-          if (this.#aborted) {
-            return
-          }
-        }
-      }
-
-      super.onComplete(this.#trailers)
+      const body = this.#body ?? []
+      this.#body = null
+      this.#bodySize = 0
+      this.#startReplay(body, true)
+      return
     } else {
+      this.#replay = null
       // Headers already sent but retry failed (e.g. etag mismatch, missing
       // content-range). The user is waiting for data/complete — send an error
       // so the response stream doesn't hang.

--- a/test/review-retry-backpressure.js
+++ b/test/review-retry-backpressure.js
@@ -1,0 +1,196 @@
+import { test } from 'tap'
+import responseRetry from '../lib/interceptor/response-retry.js'
+
+const opts = {
+  origin: 'http://example.test',
+  path: '/',
+  method: 'GET',
+  headers: {},
+}
+
+test('range retry stays paused until the original response is resumed', async (t) => {
+  const retryReady = Promise.withResolvers()
+  const completed = Promise.withResolvers()
+  const reset = Object.assign(new Error('socket reset'), { code: 'ECONNRESET' })
+  const chunks = []
+  let attempt = 0
+  let resumeResponse
+  let resumedTransport = false
+
+  const dispatch = responseRetry()((requestOpts, handler) => {
+    attempt++
+    handler.onConnect(() => {})
+
+    if (attempt === 1) {
+      t.equal(
+        handler.onHeaders(200, { 'content-length': '2', etag: '"v1"' }, () => {}),
+        true,
+      )
+      t.equal(handler.onData(Buffer.from('a')), false, 'the first attempt is paused')
+      handler.onError(reset)
+      return
+    }
+
+    const resume = () => {
+      resumedTransport = true
+      t.equal(handler.onData(Buffer.from('b')), true)
+      handler.onComplete({})
+    }
+    const ret = handler.onHeaders(206, { 'content-range': 'bytes 1-1/2', etag: '"v1"' }, resume)
+    retryReady.resolve(ret)
+  })
+
+  dispatch(
+    { ...opts, retry: () => true },
+    {
+      onConnect() {},
+      onHeaders(statusCode, headers, resume) {
+        t.equal(statusCode, 200)
+        resumeResponse = resume
+        return true
+      },
+      onData(chunk) {
+        chunks.push(chunk.toString())
+        return chunks.length !== 1
+      },
+      onComplete() {
+        completed.resolve()
+      },
+      onError: completed.reject,
+    },
+  )
+
+  t.equal(await retryReady.promise, false, 'the resumed transport inherits the pause')
+  t.equal(resumedTransport, false, 'the retry has not sent data while paused')
+  t.strictSame(chunks, ['a'])
+
+  resumeResponse()
+  await completed.promise
+
+  t.equal(resumedTransport, true)
+  t.strictSame(chunks, ['a', 'b'])
+  t.equal(attempt, 2)
+})
+
+test('buffered error replay stops at onData(false) and resumes at the next chunk', async (t) => {
+  const firstData = Promise.withResolvers()
+  const completed = Promise.withResolvers()
+  const chunks = []
+  let resumeResponse
+  let didComplete = false
+
+  const dispatch = responseRetry()((requestOpts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(404, { 'content-length': '2' }, () => {})
+    handler.onData(Buffer.from('a'))
+    handler.onData(Buffer.from('b'))
+    handler.onComplete({ trailer: 'value' })
+  })
+
+  dispatch(
+    { ...opts, retry: () => false },
+    {
+      onConnect() {},
+      onHeaders(statusCode, headers, resume) {
+        t.equal(statusCode, 404)
+        resumeResponse = resume
+        return true
+      },
+      onData(chunk) {
+        chunks.push(chunk.toString())
+        if (chunks.length === 1) {
+          firstData.resolve()
+          return false
+        }
+        return true
+      },
+      onComplete(trailers) {
+        didComplete = true
+        completed.resolve(trailers)
+      },
+      onError: completed.reject,
+    },
+  )
+
+  await firstData.promise
+  t.strictSame(chunks, ['a'])
+  t.equal(didComplete, false, 'completion waits for the consumer')
+
+  resumeResponse()
+  t.strictSame(await completed.promise, { trailer: 'value' })
+  t.strictSame(chunks, ['a', 'b'])
+})
+
+test('buffer-cap transition drains replay before resuming the live transport', async (t) => {
+  const firstData = Promise.withResolvers()
+  const completed = Promise.withResolvers()
+  const buffered = Buffer.alloc(256 * 1024, 0x61)
+  const chunks = []
+  let resumeResponse
+  let transportResumes = 0
+  let didComplete = false
+
+  const dispatch = responseRetry()((requestOpts, handler) => {
+    handler.onConnect(() => {})
+
+    const resumeTransport = () => {
+      transportResumes++
+      const ret = handler.onData(Buffer.from('c'))
+      if (ret !== false) {
+        handler.onComplete({})
+      }
+    }
+
+    handler.onHeaders(404, {}, resumeTransport)
+    handler.onData(buffered)
+    const ret = handler.onData(Buffer.from('b'))
+    if (ret !== false) {
+      resumeTransport()
+    }
+  })
+
+  dispatch(
+    { ...opts, retry: true },
+    {
+      onConnect() {},
+      onHeaders(statusCode, headers, resume) {
+        t.equal(statusCode, 404)
+        resumeResponse = resume
+        return true
+      },
+      onData(chunk) {
+        chunks.push(chunk)
+        if (chunks.length === 1) {
+          firstData.resolve()
+          return false
+        }
+        return true
+      },
+      onComplete() {
+        didComplete = true
+        completed.resolve()
+      },
+      onError: completed.reject,
+    },
+  )
+
+  await firstData.promise
+  t.strictSame(
+    chunks.map((chunk) => chunk.byteLength),
+    [buffered.byteLength],
+    'remaining buffered and live chunks wait',
+  )
+  t.equal(transportResumes, 0)
+  t.equal(didComplete, false)
+
+  resumeResponse()
+  await completed.promise
+
+  t.strictSame(
+    chunks.map((chunk) => chunk.byteLength),
+    [buffered.byteLength, 1, 1],
+  )
+  t.equal(chunks[1].toString(), 'b', 'buffered replay drains first')
+  t.equal(chunks[2].toString(), 'c', 'live transport resumes after replay')
+  t.equal(transportResumes, 1)
+})


### PR DESCRIPTION
## Summary

- retain downstream pause state across range-resume attempts
- route the original response's resume callback to the current transport attempt
- stop buffered error replay immediately when `onData()` returns `false`
- drain buffered cap-overflow chunks before resuming the live transport
- delay replay completion and trailers until every buffered chunk is accepted

## Root cause

The retry handler forwarded resumed response headers with an unconditional `true`, losing a pause established on the previous attempt. Its buffered-response paths also looped through every chunk without honoring `onData() === false`, and used a no-op resume callback after the inner response had completed. Consumers could therefore receive data and completion while paused, or see live transport data before older buffered chunks.

## Validation

- 21 retry/verification suites: 332 assertions passed, one existing `node:test` adapter skip
- focused range-resume, buffered replay, and cap-transition regressions: 23 assertions passed
- ESLint on the changed implementation and test
- Prettier check on the changed implementation and test
- `git diff --check`
