### PR TITLE
fix(pressure): count post-header transport errors

### DIFF
--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -453,7 +453,7 @@ class Handler extends DecoratorHandler {
     const isError =
       this.#clientAborted || err?.name === 'AbortError'
         ? false
-        : statusCode >= 200
+        : Number.isFinite(statusCode) && statusCode >= 200
           ? isErrorStatus(statusCode)
           : true
     this.#settle(isError)

--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -435,11 +435,12 @@ class Handler extends DecoratorHandler {
   }
 
   onError(err) {
-    // A status-bearing error is `responseError`'s decorated 4xx/5xx (when this
-    // interceptor sits outside it); classify by that status. A status-less
-    // error is a transport/connection failure (ECONNREFUSED, timeout, a sync
-    // dispatch throw) — count it, unless it's a client-initiated abort.
-    const statusCode = err?.statusCode ?? this.#statusCode
+    // An explicitly status-bearing error is `responseError`'s decorated 4xx/5xx
+    // (when this interceptor sits outside it); classify by that status. Merely
+    // observing response headers does not make a later status-less onError an
+    // HTTP response error: a reset/timeout after 200 or 404 is still a transport
+    // failure and must count, unless it was a client-initiated abort.
+    const statusCode = err?.statusCode
     const isError =
       this.#clientAborted || err?.name === 'AbortError'
         ? false

--- a/test/pressure-advanced.js
+++ b/test/pressure-advanced.js
@@ -396,7 +396,7 @@ test('pressure: degraded releases once responses recover', async (t) => {
   p.close()
 })
 
-test('pressure: a reconnect clears stale status so a later transport failure still counts', async (t) => {
+test('pressure: a reconnect clears stale status before a later completion', async (t) => {
   const p = makeInterceptor()
   const { dispatch, captured } = capturingDispatch()
   const wrapped = p(dispatch)
@@ -405,16 +405,16 @@ test('pressure: a reconnect clears stale status so a later transport failure sti
   wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
   const h = captured[0]
   h.onConnect(() => {})
-  h.onHeaders(200, {}, () => {}) // attempt 1 captured a (non-error) success status
+  h.onHeaders(503, {}, () => {}) // attempt 1 captured an overload status
   h.onConnect(() => {}) // retry -> fresh attempt; captured status must reset
-  h.onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+  h.onComplete()
 
-  // Without the per-connect reset, the stale 200 would mask the transport
-  // failure (200 -> not an error) and errored would be 0.
+  // Without the per-connect reset, the stale 503 would classify the later
+  // completion as an overload error even though the fresh attempt saw no 5xx.
   t.match(
     p.stats(ORIGIN),
-    { completed: 1, errored: 1 },
-    'transport failure counted, not masked by the prior attempt status',
+    { completed: 1, errored: 0 },
+    'completion is not classified by the prior attempt status',
   )
 
   p.close()

--- a/test/pressure-advanced.js
+++ b/test/pressure-advanced.js
@@ -396,7 +396,7 @@ test('pressure: degraded releases once responses recover', async (t) => {
   p.close()
 })
 
-test('pressure: a reconnect clears stale status before a later completion', async (t) => {
+test('pressure: a reconnect clears stale status so a later transport failure still counts', async (t) => {
   const p = makeInterceptor()
   const { dispatch, captured } = capturingDispatch()
   const wrapped = p(dispatch)
@@ -405,16 +405,16 @@ test('pressure: a reconnect clears stale status before a later completion', asyn
   wrapped({ origin: ORIGIN, path: '/' }, noopHandler)
   const h = captured[0]
   h.onConnect(() => {})
-  h.onHeaders(503, {}, () => {}) // attempt 1 captured an overload status
+  h.onHeaders(200, {}, () => {}) // attempt 1 captured a (non-error) success status
   h.onConnect(() => {}) // retry -> fresh attempt; captured status must reset
-  h.onComplete()
+  h.onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
 
-  // Without the per-connect reset, the stale 503 would classify the later
-  // completion as an overload error even though the fresh attempt saw no 5xx.
+  // Without the per-connect reset, the stale 200 would mask the transport
+  // failure (200 -> not an error) and errored would be 0.
   t.match(
     p.stats(ORIGIN),
-    { completed: 1, errored: 0 },
-    'completion is not classified by the prior attempt status',
+    { completed: 1, errored: 1 },
+    'transport failure counted, not masked by the prior attempt status',
   )
 
   p.close()

--- a/test/pressure-transport-errors.js
+++ b/test/pressure-transport-errors.js
@@ -1,0 +1,42 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'http://example.test'
+const handler = {}
+
+test('pressure: transport errors remain errors after response headers', (t) => {
+  t.plan(4)
+
+  const captured = []
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  t.teardown(() => pressure.close())
+  const dispatch = pressure((_opts, handler) => captured.push(handler))
+
+  const start = (statusCode) => {
+    dispatch({ origin: ORIGIN, path: '/' }, handler)
+    const current = captured.at(-1)
+    current.onConnect(() => {})
+    current.onHeaders(statusCode, {}, () => {})
+    return current
+  }
+
+  start(200).onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+  t.match(pressure.stats(ORIGIN), { completed: 1, errored: 1 }, 'reset after 200 counts')
+
+  start(404).onError(Object.assign(new Error('timeout'), { code: 'UND_ERR_BODY_TIMEOUT' }))
+  t.match(pressure.stats(ORIGIN), { completed: 2, errored: 2 }, 'timeout after 404 counts')
+
+  start(404).onError(Object.assign(new Error('not found'), { statusCode: 404 }))
+  t.match(
+    pressure.stats(ORIGIN),
+    { completed: 3, errored: 2 },
+    'an explicitly decorated 404 remains a non-overload response error',
+  )
+
+  start(503).onError(Object.assign(new Error('unavailable'), { statusCode: 503 }))
+  t.match(
+    pressure.stats(ORIGIN),
+    { completed: 4, errored: 3 },
+    'an explicitly decorated 503 remains an overload response error',
+  )
+})

--- a/test/pressure-transport-errors.js
+++ b/test/pressure-transport-errors.js
@@ -40,3 +40,37 @@ test('pressure: transport errors remain errors after response headers', (t) => {
     'an explicitly decorated 503 remains an overload response error',
   )
 })
+
+test('pressure: invalid error status values settle without coercion', (t) => {
+  const statusCodes = [
+    Symbol('status'),
+    503n,
+    NaN,
+    Infinity,
+    {
+      [Symbol.toPrimitive]() {
+        throw new Error('statusCode must not be coerced')
+      },
+    },
+  ]
+  t.plan(statusCodes.length * 2)
+
+  const captured = []
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  t.teardown(() => pressure.close())
+  const dispatch = pressure((_opts, handler) => captured.push(handler))
+
+  for (const [index, statusCode] of statusCodes.entries()) {
+    dispatch({ origin: ORIGIN, path: '/' }, handler)
+    const current = captured.at(-1)
+    current.onConnect(() => {})
+    const err = Object.assign(new Error('invalid status'), { statusCode })
+
+    t.doesNotThrow(() => current.onError(err), `value ${index + 1} is not coerced`)
+    t.match(
+      pressure.stats(ORIGIN),
+      { completed: index + 1, errored: index + 1 },
+      'invalid decorated status is classified as a transport failure',
+    )
+  }
+})


### PR DESCRIPTION
## Summary

- count status-less transport failures even after 200 or 404 response headers
- keep explicitly decorated finite HTTP statuses classified by their own status code
- treat non-finite, Symbol, BigInt, and coercion-bearing status values as transport failures without coercing them
- preserve client-abort exclusions and overload classification

## Root cause

Pressure accounting fell back from `err.statusCode` to the latest status observed by `onHeaders`. A later socket reset or timeout after ordinary 200/404 headers was therefore classified as a successful/client-error HTTP response instead of a transport failure, suppressing origin error pressure.

Only an explicit finite numeric `err.statusCode` now selects HTTP response classification. A missing or invalid status remains a transport failure regardless of prior headers unless the request was aborted by the client. This also prevents hostile values such as Symbols or coercion-throwing objects from escaping `onError` before the pressure gauges settle.

## Validation

- pressure, origin-key, pressure trace, upgrade, abort, async-dispatch, and public-type suites: 152 assertions passed
- ESLint
- Prettier check
- `git diff --check`