### PR TITLE
fix(log): redact decorated errors

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -141,6 +141,8 @@ function sanitizeErrorResponse(res) {
 // structured HTTP metadata, recursively strip custom cause/AggregateError
 // payloads, and leave the original error untouched for trace/downstream use.
 function sanitizeError(err, seen = new WeakSet()) {
+  let tracked = false
+
   try {
     if ((typeof err !== 'object' && typeof err !== 'function') || err === null) {
       return new Error(String(err))
@@ -150,6 +152,7 @@ function sanitizeError(err, seen = new WeakSet()) {
       return new Error('Circular error reference')
     }
     seen.add(err)
+    tracked = true
 
     const cause =
       Object.hasOwn(err, 'cause') && err.cause != null ? sanitizeError(err.cause, seen) : undefined
@@ -210,6 +213,10 @@ function sanitizeError(err, seen = new WeakSet()) {
     // A poisoned getter/proxy must not turn logging into a second request
     // failure or make us fall back to serializing the unsafe original.
     return new Error('Error details unavailable')
+  } finally {
+    if (tracked) {
+      seen.delete(err)
+    }
   }
 }
 

--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -8,6 +8,17 @@ const REDACTED = '[redacted]'
 
 // Header names (lowercase) whose values must never reach the logs.
 const SECRET_HEADERS = new Set(['authorization', 'proxy-authorization', 'cookie', 'set-cookie'])
+const SAFE_ERROR_FIELDS = [
+  'code',
+  'statusCode',
+  'status',
+  'errno',
+  'syscall',
+  'hostname',
+  'address',
+  'port',
+]
+const REDACTED_ERROR_FIELDS = ['body', 'reason', 'error']
 
 // Return a stable log snapshot of `headers` with credential values replaced by
 // a redaction marker. The wire object must stay untouched, while the snapshot
@@ -94,6 +105,111 @@ function sanitizeRequest(opts) {
     method: opts.method,
     headers: sanitizeHeaders(opts.headers),
     body: describeBody(opts.body),
+  }
+}
+
+function sanitizeErrorRequest(req) {
+  if (req == null || typeof req !== 'object') {
+    return undefined
+  }
+
+  return {
+    path: req.path,
+    origin: sanitizeOrigin(req.origin),
+    method: req.method,
+    headers: sanitizeHeaders(req.headers),
+  }
+}
+
+function sanitizeErrorResponse(res) {
+  if (res == null || typeof res !== 'object') {
+    return undefined
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: sanitizeHeaders(res.headers),
+    trailers: sanitizeHeaders(res.trailers),
+  }
+}
+
+// Pino's standard error serializer copies every enumerable property. Errors
+// decorated by response-retry/response-error carry the full request headers,
+// response headers/trailers and captured response body, so logging the live
+// error bypasses the ureq/ures redaction above. Build an isolated Error clone
+// from an allowlist instead: retain diagnostics used for operations, sanitize
+// structured HTTP metadata, recursively strip custom cause/AggregateError
+// payloads, and leave the original error untouched for trace/downstream use.
+function sanitizeError(err, seen = new WeakSet()) {
+  try {
+    if ((typeof err !== 'object' && typeof err !== 'function') || err === null) {
+      return new Error(String(err))
+    }
+
+    if (seen.has(err)) {
+      return new Error('Circular error reference')
+    }
+    seen.add(err)
+
+    const cause =
+      Object.hasOwn(err, 'cause') && err.cause != null ? sanitizeError(err.cause, seen) : undefined
+    const message = typeof err.message === 'string' ? err.message : 'Unknown error'
+    const sanitized =
+      Object.hasOwn(err, 'errors') && Array.isArray(err.errors)
+        ? new AggregateError(
+            err.errors.map((item) => sanitizeError(item, seen)),
+            message,
+            cause === undefined ? undefined : { cause },
+          )
+        : new Error(message, cause === undefined ? undefined : { cause })
+
+    if (typeof err.name === 'string') {
+      sanitized.name = err.name
+    }
+    if (typeof err.stack === 'string') {
+      sanitized.stack = err.stack
+    }
+
+    for (const field of SAFE_ERROR_FIELDS) {
+      if (!Object.hasOwn(err, field)) {
+        continue
+      }
+
+      const value = err[field]
+      if (
+        value == null ||
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+      ) {
+        sanitized[field] = value
+      }
+    }
+
+    if (Object.hasOwn(err, 'req')) {
+      sanitized.req = sanitizeErrorRequest(err.req)
+    }
+    if (Object.hasOwn(err, 'res')) {
+      sanitized.res = sanitizeErrorResponse(err.res)
+    }
+    if (Object.hasOwn(err, 'headers')) {
+      sanitized.headers = sanitizeHeaders(err.headers)
+    }
+    if (Object.hasOwn(err, 'trailers')) {
+      sanitized.trailers = sanitizeHeaders(err.trailers)
+    }
+
+    for (const field of REDACTED_ERROR_FIELDS) {
+      if (Object.hasOwn(err, field)) {
+        sanitized[field] = REDACTED
+      }
+    }
+
+    return sanitized
+  } catch {
+    // A poisoned getter/proxy must not turn logging into a second request
+    // failure or make us fall back to serializing the unsafe original.
+    return new Error('Error details unavailable')
   }
 }
 
@@ -284,7 +400,7 @@ class Handler extends DecoratorHandler {
               : 0,
         },
         elapsedTime: this.#timing.end,
-        err,
+        err: sanitizeError(err),
       }
 
       if (this.#aborted) {
@@ -349,7 +465,10 @@ class Handler extends DecoratorHandler {
 
     this.#timing.end = performance.now() - this.#created
 
-    this.#logger?.error({ err, elapsedTime: this.#timing.end }, 'upstream request failed')
+    this.#logger?.error(
+      { err: sanitizeError(err), elapsedTime: this.#timing.end },
+      'upstream request failed',
+    )
 
     this.onDone(err)
   }

--- a/test/log-error-redaction.js
+++ b/test/log-error-redaction.js
@@ -1,0 +1,188 @@
+import { Writable } from 'node:stream'
+import pino from 'pino'
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function captureLogger() {
+  let output = ''
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk
+      callback()
+    },
+  })
+
+  return {
+    logger: pino({ level: 'debug', base: null, timestamp: false }, stream),
+    records() {
+      return output
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+    },
+    output() {
+      return output
+    },
+  }
+}
+
+function makeSensitiveCause() {
+  return Object.assign(new Error('safe nested cause message'), {
+    code: 'ECAUSE',
+    token: 'nested-arbitrary-secret',
+    body: 'nested-body-secret',
+    req: { headers: { authorization: 'Bearer nested-request-secret' } },
+    res: {
+      headers: { 'set-cookie': 'nested-response-secret' },
+      trailers: { 'set-cookie': 'nested-trailer-secret' },
+    },
+  })
+}
+
+test('log sanitizes response-retry decorated errors without mutating them', async (t) => {
+  const capture = captureLogger()
+  const payload = JSON.stringify({
+    code: 'UPSTREAM_FAILURE',
+    reason: 'promoted-reason-secret',
+    error: 'promoted-error-secret',
+    payload: 'captured-body-secret',
+  })
+  let decoratedError
+
+  const dispatch = compose(
+    (_opts, handler) => {
+      handler.onConnect(() => {})
+      handler.onHeaders(
+        503,
+        {
+          'content-type': 'application/json',
+          'set-cookie': 'session=response-cookie-secret',
+        },
+        () => {},
+      )
+      handler.onData(Buffer.from(payload))
+      handler.onComplete({ 'set-cookie': 'session=response-trailer-secret' })
+    },
+    interceptors.responseRetry(),
+    interceptors.log(),
+  )
+
+  const receivedError = await new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {
+          authorization: 'Bearer request-authorization-secret',
+          cookie: 'session=request-cookie-secret',
+        },
+        retry(error) {
+          decoratedError = error
+          error.cause = makeSensitiveCause()
+          throw error
+        },
+        logger: capture.logger,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          reject(new Error('unexpected response headers'))
+        },
+        onComplete() {
+          reject(new Error('unexpected completion'))
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  const failed = capture.records().find((record) => record.msg === 'upstream request failed')
+
+  t.equal(receivedError, decoratedError, 'the original decorated error is delivered downstream')
+  t.equal(
+    decoratedError.req.headers.authorization,
+    'Bearer request-authorization-secret',
+    'logging does not mutate request metadata on the original error',
+  )
+  t.equal(
+    decoratedError.res.headers['set-cookie'],
+    'session=response-cookie-secret',
+    'logging does not mutate response metadata on the original error',
+  )
+  t.equal(decoratedError.body.payload, 'captured-body-secret', 'the caller retains the error body')
+
+  t.equal(failed.err.code, 'UPSTREAM_FAILURE', 'keeps the operational error code')
+  t.equal(failed.err.statusCode, 503, 'keeps the response status')
+  t.type(failed.err.message, 'string', 'keeps the error message')
+  t.type(failed.err.stack, 'string', 'keeps the error stack')
+  t.equal(failed.err.req.headers.authorization, '[redacted]')
+  t.equal(failed.err.req.headers.cookie, '[redacted]')
+  t.equal(failed.err.res.headers['set-cookie'], '[redacted]')
+  t.equal(failed.err.res.trailers['set-cookie'], '[redacted]')
+  t.equal(failed.err.body, '[redacted]')
+  t.equal(failed.err.reason, '[redacted]')
+  t.equal(failed.err.error, '[redacted]')
+  t.match(failed.err.message, /safe nested cause message/, 'keeps a safe cause summary')
+
+  for (const secret of [
+    'request-authorization-secret',
+    'request-cookie-secret',
+    'response-cookie-secret',
+    'response-trailer-secret',
+    'captured-body-secret',
+    'promoted-reason-secret',
+    'promoted-error-secret',
+    'nested-arbitrary-secret',
+    'nested-body-secret',
+    'nested-request-secret',
+    'nested-response-secret',
+    'nested-trailer-secret',
+  ]) {
+    t.notMatch(capture.output(), new RegExp(secret), `${secret} is absent from Pino output`)
+  }
+})
+
+test('log sanitizes errors thrown synchronously by an inner dispatch', (t) => {
+  const capture = captureLogger()
+  const failure = Object.assign(new Error('synchronous dispatch failure'), {
+    code: 'ESYNC',
+    statusCode: 502,
+    req: { headers: { authorization: 'Bearer sync-request-secret' } },
+    res: { headers: { 'set-cookie': 'sync-response-secret' }, trailers: null },
+    body: 'sync-body-secret',
+    cause: makeSensitiveCause(),
+  })
+  const dispatch = interceptors.log()(() => {
+    throw failure
+  })
+
+  t.throws(
+    () =>
+      dispatch(
+        {
+          origin: 'http://example.test',
+          path: '/',
+          method: 'GET',
+          headers: {},
+          logger: capture.logger,
+        },
+        {},
+      ),
+    failure,
+    'the original error is rethrown',
+  )
+
+  const failed = capture.records().find((record) => record.msg === 'upstream request failed')
+  t.equal(failed.err.code, 'ESYNC')
+  t.equal(failed.err.statusCode, 502)
+  t.equal(failed.err.req.headers.authorization, '[redacted]')
+  t.equal(failed.err.res.headers['set-cookie'], '[redacted]')
+  t.equal(failed.err.body, '[redacted]')
+  t.notMatch(capture.output(), /sync-request-secret/)
+  t.notMatch(capture.output(), /sync-response-secret/)
+  t.notMatch(capture.output(), /sync-body-secret/)
+  t.notMatch(capture.output(), /nested-arbitrary-secret/)
+  t.end()
+})

--- a/test/log-error-redaction.js
+++ b/test/log-error-redaction.js
@@ -186,3 +186,38 @@ test('log sanitizes errors thrown synchronously by an inner dispatch', (t) => {
   t.notMatch(capture.output(), /nested-arbitrary-secret/)
   t.end()
 })
+
+test('log preserves repeated AggregateError diagnostics without treating them as cycles', (t) => {
+  const capture = captureLogger()
+  const shared = Object.assign(new Error('shared diagnostic'), {
+    token: 'shared-aggregate-secret',
+  })
+  const failure = new AggregateError([shared, shared], 'aggregate dispatch failure')
+  const dispatch = interceptors.log()(() => {
+    throw failure
+  })
+
+  t.throws(
+    () =>
+      dispatch(
+        {
+          origin: 'http://example.test',
+          path: '/',
+          method: 'GET',
+          headers: {},
+          logger: capture.logger,
+        },
+        {},
+      ),
+    failure,
+  )
+
+  t.match(capture.output(), /shared diagnostic/, 'retains diagnostics from a shared error')
+  t.notMatch(
+    capture.output(),
+    /Circular error reference/,
+    'does not misclassify a repeated sibling',
+  )
+  t.notMatch(capture.output(), /shared-aggregate-secret/, 'still strips custom sibling data')
+  t.end()
+})

--- a/test/review-bugfixes-6-log-async-dispatch.js
+++ b/test/review-bugfixes-6-log-async-dispatch.js
@@ -37,5 +37,6 @@ test('log: an asynchronous dispatch rejection finalizes the in-flight handler', 
   t.equal(globalThis[kGlobalArray]?.length ?? 0, before, 'no in-flight registry entry leaks')
   t.equal(onErrorCalls, 0, 'the log layer does not double-deliver the outer error path')
   t.equal(errors.length, 1, 'the rejection receives one terminal failure log')
-  t.equal(errors[0][0].err, failure)
+  t.not(errors[0][0].err, failure, 'the logger receives an isolated error snapshot')
+  t.equal(errors[0][0].err.message, failure.message, 'the snapshot keeps useful diagnostics')
 })


### PR DESCRIPTION
## Summary

- prevent Pino from serializing live errors decorated with request/response metadata and captured response bodies
- log an isolated diagnostic error snapshot that redacts Authorization, Cookie, Set-Cookie, trailers, body/reason/error payloads, and arbitrary nested cause data
- preserve useful error fields and the original error object for downstream handling and tracing
- cover decorated retry failures and synchronous dispatch failures with real-Pino output assertions

## Validation

- 10 focused TAP suites: 290 assertions passed
- ESLint
- Prettier check
- `git diff --check`