### PR TITLE
fix(redirect): preserve prototype-named headers

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -296,6 +296,19 @@ function shouldRemoveHeader(header, removeContent, unknownOrigin) {
   )
 }
 
+function setOwnHeader(headers, key, value) {
+  if (key === '__proto__') {
+    Object.defineProperty(headers, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  } else {
+    headers[key] = value
+  }
+}
+
 // https://tools.ietf.org/html/rfc7231#section-6.4
 function cleanRequestHeaders(headers, removeContent, unknownOrigin) {
   const ret = {}
@@ -309,7 +322,10 @@ function cleanRequestHeaders(headers, removeContent, unknownOrigin) {
   if (headers && typeof headers === 'object') {
     for (const key of Object.keys(headers)) {
       if (!shouldRemoveHeader(key, removeContent, unknownOrigin)) {
-        ret[key] = headers[key]
+        // `__proto__` is a valid header token. Assigning it onto `{}` invokes
+        // Object.prototype's legacy setter, which either drops a scalar value
+        // or replaces the accumulator prototype with an array value.
+        setOwnHeader(ret, key, headers[key])
       }
     }
   } else {

--- a/test/redirect-prototype-headers.js
+++ b/test/redirect-prototype-headers.js
@@ -1,0 +1,84 @@
+import { test } from 'tap'
+import redirect from '../lib/interceptor/redirect.js'
+
+function followRedirect(headers, location = '/redirected') {
+  let attempts = 0
+  let redirectedHeaders
+
+  const dispatch = redirect()((opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+
+    if (attempts === 1) {
+      handler.onHeaders(307, { location }, () => {})
+      handler.onComplete({})
+    } else {
+      redirectedHeaders = opts.headers
+      handler.onHeaders(200, {}, () => {})
+      handler.onComplete({})
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    dispatch(
+      {
+        origin: 'http://source.test',
+        path: '/start',
+        method: 'GET',
+        headers,
+        follow: 1,
+      },
+      {
+        onConnect() {},
+        onHeaders() {
+          return true
+        },
+        onComplete() {
+          resolve({ attempts, headers: redirectedHeaders })
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('redirect preserves repeated __proto__ and constructor headers safely', async (t) => {
+  const result = await followRedirect([
+    '__proto__',
+    'first',
+    '__proto__',
+    'second',
+    'constructor',
+    'ctor',
+    'host',
+    'spoofed.test',
+    'x-keep',
+    'yes',
+  ])
+
+  t.equal(result.attempts, 2)
+  t.equal(Object.getPrototypeOf(result.headers), Object.prototype)
+  t.equal(Object.hasOwn(result.headers, '__proto__'), true)
+  t.strictSame(result.headers.__proto__, ['first', 'second'])
+  t.equal(Object.hasOwn(result.headers, 'constructor'), true)
+  t.equal(result.headers.constructor, 'ctor')
+  t.equal(Object.hasOwn(result.headers, 'host'), false, 'redirect still strips Host')
+  t.equal(result.headers['x-keep'], 'yes')
+})
+
+test('cross-origin redirect strips credentials without dropping scalar __proto__', async (t) => {
+  const source = JSON.parse(
+    '{"__proto__":"single","constructor":"ctor","authorization":"secret","cookie":"session","host":"spoofed.test","x-keep":"yes"}',
+  )
+  const result = await followRedirect(source, 'http://other.test/redirected')
+
+  t.equal(result.attempts, 2)
+  t.equal(Object.getPrototypeOf(result.headers), Object.prototype)
+  t.equal(Object.hasOwn(result.headers, '__proto__'), true)
+  t.equal(result.headers.__proto__, 'single')
+  t.equal(result.headers.constructor, 'ctor')
+  t.equal(Object.hasOwn(result.headers, 'authorization'), false)
+  t.equal(Object.hasOwn(result.headers, 'cookie'), false)
+  t.equal(Object.hasOwn(result.headers, 'host'), false)
+  t.equal(result.headers['x-keep'], 'yes')
+})


### PR DESCRIPTION
## Summary

- preserve prototype-named headers across redirect cloning
- keep the ordinary object prototype even for repeated `__proto__` values
- retain Host and cross-origin credential stripping
- add focused flat-array and object regressions

## Root cause

`cleanRequestHeaders` copied retained fields with `ret[key] = value`. For `__proto__`, that invokes `Object.prototype`'s legacy setter: a scalar value is dropped, while an array value changes the clone's prototype instead of creating an own header property.

## Validation

- redirect-related suite: 158 assertions passed; 1 existing no-tests skip
- focused prototype-named header regressions: 17 assertions passed
- ESLint
- Prettier
- `git diff --check`
