### PR TITLE
fix(pressure): canonicalize origin state keys

### DIFF
--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -1,5 +1,5 @@
 import { parsePriority, Scheduler } from '@nxtedition/scheduler'
-import { DecoratorHandler } from '../utils.js'
+import { DecoratorHandler, parseURL } from '../utils.js'
 import { traceSafe, traceUrl, traceWrite, validateTrace } from '../trace.js'
 
 // Reconstruct a PSI-style pressure signal per origin from the request lifecycle
@@ -61,6 +61,15 @@ function isDiscretionary(priority) {
   } catch {
     return false
   }
+}
+
+function canonicalOrigin(origin) {
+  if (Array.isArray(origin)) {
+    const origins = [...new Set(origin.map(canonicalOrigin))].toSorted()
+    return origins.length === 1 ? origins[0] : JSON.stringify(origins)
+  }
+
+  return parseURL(origin).origin
 }
 
 class PressureMonitor {
@@ -475,10 +484,13 @@ export default (opts) => {
       return dispatch(opts, handler)
     }
 
-    // Key on opts.origin — the logical origin the caller knows and queries by.
-    // Compose this interceptor *ahead of* (outer to) `dns()` so opts.origin is
-    // still the logical host rather than a rotating resolved IP.
-    const key = opts.origin
+    // Key on a canonical string rather than URL/URLObject identity so
+    // equivalent spellings share one pressure record and stats always expose
+    // the documented string origin. Origin pools are set-like and sorted so
+    // their key is independent of array order. Compose this interceptor ahead
+    // of (outer to) `dns()` so the value is still the logical origin rather
+    // than a rotating resolved IP.
+    const key = canonicalOrigin(opts.origin)
 
     const rec = monitor.track(key)
     // Construct before the try: a handler that fails validation throws straight

--- a/test/pressure-origin-key.js
+++ b/test/pressure-origin-key.js
@@ -1,0 +1,88 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const handler = {}
+
+function capturingPressure() {
+  const calls = []
+  const pressure = interceptors.pressure({ sampleInterval: 0 })
+  const dispatch = pressure((opts, handler) => {
+    calls.push({ opts, handler })
+  })
+  return { calls, dispatch, pressure }
+}
+
+test('pressure: equivalent URL-like origins share one string-keyed record', (t) => {
+  t.plan(4)
+  const { calls, dispatch, pressure } = capturingPressure()
+  t.teardown(() => pressure.close())
+
+  dispatch({ origin: new URL('http://EXAMPLE.test:80/one') }, handler)
+  dispatch({ origin: 'http://example.test/two' }, handler)
+  dispatch(
+    {
+      origin: { protocol: 'http:', hostname: 'example.test', port: 80, pathname: '/three' },
+    },
+    handler,
+  )
+
+  t.equal(calls.length, 3, 'all requests reach the underlying dispatcher')
+  t.equal(pressure.stats().length, 1, 'equivalent values do not fragment pressure state')
+  t.match(pressure.stats('http://example.test'), { pending: 3 })
+  t.same(
+    pressure.stats().map(({ origin }) => origin),
+    ['http://example.test'],
+    'stats expose a canonical string rather than the first URL object',
+  )
+})
+
+test('pressure: equivalent origin pools have one deterministic key', (t) => {
+  t.plan(4)
+  const { dispatch, pressure } = capturingPressure()
+  t.teardown(() => pressure.close())
+
+  dispatch(
+    {
+      origin: [new URL('https://two.test/a'), { protocol: 'https:', hostname: 'one.test' }],
+    },
+    handler,
+  )
+  dispatch(
+    {
+      origin: [
+        { protocol: 'https:', hostname: 'one.test', port: 443, pathname: '/b' },
+        new URL('https://two.test/c'),
+        'https://one.test/d',
+      ],
+    },
+    handler,
+  )
+
+  const key = JSON.stringify(['https://one.test', 'https://two.test'])
+  const stats = pressure.stats()
+  t.equal(stats.length, 1, 'order, value identity, and duplicate members do not fragment state')
+  t.equal(stats[0].origin, key, 'the pool key has stable sorted serialization')
+  t.type(stats[0].origin, 'string')
+  t.match(pressure.stats(key), { pending: 2 })
+})
+
+test('pressure: scalar and singleton-pool origins share state without conflating protocols', (t) => {
+  t.plan(4)
+  const { dispatch, pressure } = capturingPressure()
+  t.teardown(() => pressure.close())
+
+  dispatch({ origin: 'http://service.test' }, handler)
+  dispatch({ origin: [new URL('http://SERVICE.test:80/a')] }, handler)
+  dispatch({ origin: 'https://service.test' }, handler)
+
+  t.equal(pressure.stats().length, 2, 'HTTP and HTTPS retain separate pressure records')
+  t.match(pressure.stats('http://service.test'), { pending: 2 })
+  t.match(pressure.stats('https://service.test'), { pending: 1 })
+  t.same(
+    pressure
+      .stats()
+      .map(({ origin }) => origin)
+      .toSorted(),
+    ['http://service.test', 'https://service.test'],
+  )
+})


### PR DESCRIPTION
## Summary

- canonicalize every tracked pressure `OriginLike` to a stable string key
- make equivalent URL, URLObject, and string spellings share pressure state
- serialize multi-origin pools in sorted, de-duplicated order while keeping singleton pools equivalent to scalars
- keep protocol-distinct origins separate and align runtime stats with the existing string-key declaration

## Root cause

The pressure monitor keyed its map directly by `opts.origin`. URL and URLObject inputs therefore used object identity, and arrays used array identity, so equivalent requests fragmented gauges and EWMAs across independent records. `stats()` could also return a URL or array object even though the public type promises `origin: string`.

## Validation

- `node --test test/pressure-advanced.js test/pressure-origin-key.js test/review-bugfixes-4-pressure-upgrade.js test/review-bugfixes-6-pressure-abort-reason.js test/review-bugfixes-6-pressure-async-dispatch.js test/trace-pressure.js test/public-types.js` (138 assertions, 32 suites)
- `npx eslint lib/interceptor/pressure.js test/pressure-origin-key.js`
- `npx prettier --check lib/interceptor/pressure.js test/pressure-origin-key.js`
- `git diff --check`
