### PR TITLE
fix(retry): prefer async body iteration

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -27,23 +27,18 @@ function isOneShotIterable(body) {
   }
 
   try {
-    const iteratorFactory = body[Symbol.iterator]
-    if (typeof iteratorFactory === 'function') {
-      const iterator = iteratorFactory.call(body)
-      if (iteratorFactory.call(body) === iterator) {
-        return true
-      }
-    }
-
+    // Async iteration takes precedence when both protocols are present. This
+    // must match the request body consumer: replayability is determined by
+    // the protocol that was actually consumed, not an unused fallback.
     const asyncIteratorFactory = body[Symbol.asyncIterator]
-    if (typeof asyncIteratorFactory === 'function') {
-      const iterator = asyncIteratorFactory.call(body)
-      if (asyncIteratorFactory.call(body) === iterator) {
-        return true
-      }
+    const iteratorFactory =
+      typeof asyncIteratorFactory === 'function' ? asyncIteratorFactory : body[Symbol.iterator]
+    if (typeof iteratorFactory !== 'function') {
+      return false
     }
 
-    return false
+    const iterator = iteratorFactory.call(body)
+    return iterator === body || iteratorFactory.call(body) === iterator
   } catch {
     // If asking for another iterator already fails, the body cannot be replayed.
     return true

--- a/test/review-retry-one-shot-body.js
+++ b/test/review-retry-one-shot-body.js
@@ -34,6 +34,36 @@ async function doesNotRetryOneShotBody(t, makeBody) {
   t.same(requestBodies, ['payload'], 'the consumed iterator was sent only once')
 }
 
+async function retriesReusableBody(t, makeBody) {
+  const requestBodies = []
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBodies.push(Buffer.concat(chunks).toString())
+      if (requestBodies.length === 1) {
+        res.writeHead(503)
+        res.end('unavailable')
+      } else {
+        res.end('ok')
+      }
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.teardown(server.close.bind(server))
+
+  const response = await request(`http://127.0.0.1:${server.address().port}`, {
+    method: 'PUT',
+    body: makeBody(),
+    retry: true,
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'ok')
+  t.same(requestBodies, ['payload', 'payload'], 'fresh iterator is replayed on retry')
+}
+
 test('503 does not retry a consumed generator body as empty', async (t) => {
   await doesNotRetryOneShotBody(t, function* () {
     yield 'payload'
@@ -73,39 +103,61 @@ test('503 does not retry an async iterable that reuses one cached iterator', asy
 })
 
 test('503 still retries a reusable iterable that also exposes next()', async (t) => {
-  const requestBodies = []
-  const server = createServer((req, res) => {
-    const chunks = []
-    req.on('data', (chunk) => chunks.push(chunk))
-    req.on('end', () => {
-      requestBodies.push(Buffer.concat(chunks).toString())
-      if (requestBodies.length === 1) {
-        res.writeHead(503)
-        res.end('unavailable')
-      } else {
-        res.end('ok')
-      }
-    })
-  })
-  server.listen(0)
-  await once(server, 'listening')
-  t.teardown(server.close.bind(server))
-
-  const reusableBody = {
+  await retriesReusableBody(t, () => ({
     next() {
       return { done: true }
     },
     *[Symbol.iterator]() {
       yield 'payload'
     },
-  }
-  const response = await request(`http://127.0.0.1:${server.address().port}`, {
-    method: 'PUT',
-    body: reusableBody,
-    retry: true,
-  })
+  }))
+})
 
-  t.equal(response.statusCode, 200)
-  t.equal(await response.body.text(), 'ok')
-  t.same(requestBodies, ['payload', 'payload'], 'fresh iterator is replayed on retry')
+test('503 uses a reusable async protocol when the sync protocol is one-shot', async (t) => {
+  await retriesReusableBody(t, () => {
+    const syncIterator = (function* () {
+      yield 'wrong protocol'
+    })()
+
+    return {
+      [Symbol.iterator]() {
+        return syncIterator
+      },
+      [Symbol.asyncIterator]() {
+        return (async function* () {
+          yield 'payload'
+        })()
+      },
+    }
+  })
+})
+
+test('503 does not call an unused sync protocol when the async protocol is reusable', async (t) => {
+  await retriesReusableBody(t, () => ({
+    [Symbol.iterator]() {
+      throw new Error('sync protocol must not be selected')
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        yield 'payload'
+      })()
+    },
+  }))
+})
+
+test('503 does not retry when the selected async protocol is one-shot', async (t) => {
+  await doesNotRetryOneShotBody(t, () => {
+    const asyncIterator = (async function* () {
+      yield 'payload'
+    })()
+
+    return {
+      *[Symbol.iterator]() {
+        yield 'wrong protocol'
+      },
+      [Symbol.asyncIterator]() {
+        return asyncIterator
+      },
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- make retry replayability checks prefer `Symbol.asyncIterator` when both iterator protocols exist
- keep the one-shot safeguard tied to the protocol the request body consumer actually uses
- align response retry with redirect replay behavior
- add dual-protocol regressions for reusable, throwing, and one-shot protocol combinations

## Root cause

Undici consumes a request body that exposes both iterator protocols through `Symbol.asyncIterator`, but response retry checked `Symbol.iterator` first. A one-shot or throwing unused sync protocol therefore suppressed a safe retry even when the consumed async protocol returned a fresh iterator for each attempt.

## Validation

- retry/body-related suite: 428 assertions passed; 1 existing no-tests skip
- focused one-shot body suite: 24 assertions passed
- ESLint
- Prettier
- `git diff --check`
