### PR TITLE
fix(body-factory): accept cross-realm ArrayBuffers

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -1,4 +1,5 @@
 import { Readable, finished } from 'node:stream'
+import { types } from 'node:util'
 import { DecoratorHandler, isStream } from '../utils.js'
 
 function noop() {}
@@ -47,7 +48,7 @@ class FactoryStream extends Readable {
           // as a buffer, extended to all ArrayBuffer views.
           if (ArrayBuffer.isView(body) && !Buffer.isBuffer(body)) {
             body = Buffer.from(body.buffer, body.byteOffset, body.byteLength)
-          } else if (body instanceof ArrayBuffer) {
+          } else if (types.isAnyArrayBuffer(body)) {
             body = Buffer.from(body)
           }
 

--- a/test/body-factory-cross-realm-arraybuffer.js
+++ b/test/body-factory-cross-realm-arraybuffer.js
@@ -1,0 +1,20 @@
+import vm from 'node:vm'
+import { test } from 'tap'
+import requestBodyFactory from '../lib/interceptor/request-body-factory.js'
+
+test('body factory accepts an ArrayBuffer from another realm', async (t) => {
+  const foreign = vm.runInNewContext('Uint8Array.from([0x66, 0x6f, 0x6f]).buffer')
+  t.notOk(foreign instanceof ArrayBuffer, 'fixture has a foreign ArrayBuffer prototype')
+
+  let body
+  const dispatch = requestBodyFactory()((opts) => {
+    body = opts.body
+  })
+  dispatch({ body: () => foreign }, {})
+
+  const chunks = []
+  for await (const chunk of body) {
+    chunks.push(chunk)
+  }
+  t.equal(Buffer.concat(chunks).toString(), 'foo')
+})


### PR DESCRIPTION
## Summary

- replace realm-sensitive `instanceof ArrayBuffer` detection with Node's `util.types.isAnyArrayBuffer()`
- allow body factories to return ArrayBuffers created in workers, VM contexts, and other realms
- add a real `node:vm` regression

## Validation

- four body-factory suites: 70/70 assertions
- ESLint
- Prettier check
- `git diff --check`