### PR TITLE
fix(response-error): retain capped body prefix

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -58,9 +58,11 @@ class Handler extends DecoratorHandler {
     }
 
     if (this.#decoder) {
-      this.#bodySize += chunk.byteLength
-      if (this.#bodySize <= MAX_ERROR_BODY_SIZE) {
-        this.#body += this.#decoder.decode(chunk, { stream: true })
+      const remaining = MAX_ERROR_BODY_SIZE - this.#bodySize
+      if (remaining > 0) {
+        const captured = chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk
+        this.#bodySize += captured.byteLength
+        this.#body += this.#decoder.decode(captured, { stream: true })
       }
     }
   }

--- a/test/response-error-body-prefix.js
+++ b/test/response-error-body-prefix.js
@@ -1,0 +1,50 @@
+import { test } from 'tap'
+import responseError from '../lib/interceptor/response-error.js'
+
+const LIMIT = 256 * 1024
+
+function captureBody(chunks) {
+  let error
+  const dispatch = responseError()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(500, { 'content-type': 'text/plain' }, () => {})
+    for (const chunk of chunks) {
+      handler.onData(chunk)
+    }
+    handler.onComplete({})
+  })
+
+  dispatch(
+    {
+      error: true,
+      origin: 'http://example.test',
+      path: '/',
+      method: 'GET',
+      headers: {},
+    },
+    {
+      onError(err) {
+        error = err
+      },
+    },
+  )
+  return error.body
+}
+
+test('response-error retains the prefix of a chunk crossing the body cap', (t) => {
+  const prefix = Buffer.alloc(LIMIT - 2, 0x61)
+  const body = captureBody([prefix, Buffer.from('WXYZ')])
+
+  t.equal(Buffer.byteLength(body), LIMIT)
+  t.equal(body.slice(-2), 'WX')
+  t.end()
+})
+
+test('response-error retains a capped prefix from one oversized chunk', (t) => {
+  const body = captureBody([Buffer.alloc(LIMIT + 1, 0x62)])
+
+  t.equal(Buffer.byteLength(body), LIMIT)
+  t.equal(body[0], 'b')
+  t.equal(body.at(-1), 'b')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- retain the bytes that fit when an error-body chunk crosses the 256 KiB capture limit
- cap a single oversized chunk to its diagnostic prefix instead of dropping it entirely
- add direct single- and multi-chunk boundary regressions

## Validation

- five response-error suites: 47/47 assertions
- ESLint
- Prettier check
- `git diff --check`