### PR TITLE
fix(request-id): ignore empty parent arrays

### DIFF
--- a/lib/interceptor/request-id.js
+++ b/lib/interceptor/request-id.js
@@ -13,6 +13,13 @@ function genReqId() {
   return `req-${nextReqId.toString(36)}`
 }
 
+function normalizeParentId(value) {
+  if (Array.isArray(value)) {
+    value = value.filter((item) => item != null && item !== '').join(',')
+  }
+  return value == null || value === '' ? null : String(value)
+}
+
 export default () => (dispatch) => (opts, handler) => {
   // The standalone interceptor accepts the same object/flat-array header
   // shapes as undici. Normalize first so mixed-case or array-form request-id
@@ -24,11 +31,8 @@ export default () => (dispatch) => (opts, handler) => {
   // chaining test (the old `??`-vs-truthy split kept a falsy opts.id, skipped
   // the request-id header fallback, then dropped it anyway — losing a real
   // parent id and breaking trace correlation).
-  let prevId = opts.id
-  if (prevId == null || prevId === '') {
-    prevId = headers['request-id']
-  }
-  const nextId = prevId != null && prevId !== '' ? `${prevId},${genReqId()}` : genReqId()
+  const prevId = normalizeParentId(opts.id) ?? normalizeParentId(headers['request-id'])
+  const nextId = prevId == null ? genReqId() : `${prevId},${genReqId()}`
   headers['request-id'] = nextId
   return dispatch(
     {

--- a/test/request-id-empty-arrays.js
+++ b/test/request-id-empty-arrays.js
@@ -1,0 +1,34 @@
+import { test } from 'tap'
+import requestId from '../lib/interceptor/request-id.js'
+
+function capture(opts) {
+  let captured
+  requestId()((value) => {
+    captured = value
+  })(opts, {})
+  return captured
+}
+
+test('request-id treats an empty repeated header as absent', (t) => {
+  const opts = capture({ headers: { 'request-id': [] } })
+
+  t.match(opts.id, /^req-/)
+  t.equal(opts.headers['request-id'], opts.id)
+  t.notMatch(opts.id, /^,/)
+  t.end()
+})
+
+test('request-id removes empty values from a repeated parent chain', (t) => {
+  const opts = capture({ headers: { 'request-id': ['', 'parent', ''] } })
+
+  t.match(opts.id, /^parent,req-/)
+  t.equal(opts.headers['request-id'], opts.id)
+  t.end()
+})
+
+test('request-id lets an empty runtime opts.id array fall back to the header', (t) => {
+  const opts = capture({ id: [], headers: { 'request-id': 'parent' } })
+
+  t.match(opts.id, /^parent,req-/)
+  t.end()
+})


### PR DESCRIPTION
## Summary

- normalize repeated request-id parents before building the child chain
- treat empty arrays and empty repeated values as absent instead of producing IDs with a leading comma
- preserve non-empty parent ordering and opts.id-to-header fallback behavior

## Validation

- four request-id/core suites: 40/40 assertions
- ESLint
- Prettier check
- `git diff --check`