### PR TITLE
fix(types): declare errors deep import

### DIFF
--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -1,0 +1,17 @@
+export class UndiciError extends Error {
+  name: string
+  code: string
+  constructor(message?: string, options?: ErrorOptions)
+}
+
+export class InvalidArgumentError extends UndiciError {
+  constructor(message?: string)
+}
+
+export class AbortError extends UndiciError {
+  constructor(message?: string)
+}
+
+export class RequestAbortedError extends AbortError {
+  constructor(message?: string)
+}

--- a/type-tests/errors.ts
+++ b/type-tests/errors.ts
@@ -1,0 +1,23 @@
+import {
+  AbortError,
+  InvalidArgumentError,
+  RequestAbortedError,
+  UndiciError,
+} from '../lib/errors.js'
+
+const cause = new Error('cause')
+const undiciError: Error = new UndiciError('message', { cause })
+const invalidArgument: UndiciError = new InvalidArgumentError('invalid')
+const abort: UndiciError = new AbortError()
+const requestAbort: AbortError = new RequestAbortedError('aborted')
+
+const code: string = requestAbort.code
+const name: string = invalidArgument.name
+
+void undiciError
+void abort
+void code
+void name
+
+// @ts-expect-error error messages must be strings
+new InvalidArgumentError(42)


### PR DESCRIPTION
## Summary

- add the missing declaration sibling for the shipped `lib/errors.js` entrypoint
- type all four exported error classes and their constructors
- compile a strict deep-import consumer and verify the declaration is included in the packed artifact

## Validation

- runtime errors + public declaration suites: 13/13 assertions
- strict TypeScript compile
- Prettier check
- `npm pack --dry-run`
- `git diff --check`