### PR TITLE
fix(dns): validate and honor TTL timing

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -180,9 +180,12 @@ export interface VerifyOptions {
 }
 
 export interface DnsOptions {
+  /** How long (ms) successful lookup records remain cached (default 2000).
+   *  Must be finite and non-negative; 0 disables positive caching. */
   ttl?: number
   /** How long (ms) a failed lookup is negative-cached; requests inside this
-   *  window fail fast without hitting the resolver again (default 1000). */
+   *  window fail fast without hitting the resolver again (default 1000).
+   *  Must be finite and non-negative; 0 disables negative caching. */
   negativeTTL?: number
   balance?: 'hash'
   /** Custom resolver, `dns.lookup`-compatible (called with `{ all: true }`). */

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -297,8 +297,8 @@ export default () => (dispatch) => {
         return await dispatch(opts, wrapped)
       }
 
-      const ttl = opts.dns.ttl ?? 2e3
-      const negativeTTL = opts.dns.negativeTTL ?? 1e3
+      const ttl = opts.dns.ttl === undefined ? 2e3 : opts.dns.ttl
+      const negativeTTL = opts.dns.negativeTTL === undefined ? 1e3 : opts.dns.negativeTTL
       validateTTL('ttl', ttl)
       validateTTL('negativeTTL', negativeTTL)
       const lookup = opts.dns.lookup ?? dns.lookup

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -1,6 +1,6 @@
 import net from 'node:net'
 import * as dns from 'node:dns'
-import { buildURL, DecoratorHandler, getFastNow, parseHeaders } from '../utils.js'
+import { buildURL, DecoratorHandler, parseHeaders } from '../utils.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
 import xxhash from 'xxhash-wasm'
 
@@ -44,6 +44,15 @@ class Handler extends DecoratorHandler {
 }
 
 const SWEEP_INTERVAL = 30e3
+
+function validateTTL(name, value) {
+  if (typeof value !== 'number') {
+    throw new TypeError(`opts.dns.${name} must be a number`)
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`opts.dns.${name} must be a finite number greater than or equal to 0`)
+  }
+}
 
 // A cached (or in-flight-shared) lookup error must never be handed to more
 // than one caller as-is: downstream decorateError call sites (response-retry,
@@ -194,7 +203,7 @@ export default () => (dispatch) => {
                 })
               }
 
-              const now = getFastNow()
+              const now = Date.now()
               val = records.map((record) => {
                 const address = record?.address
                 if (typeof address !== 'string' || net.isIP(address) === 0) {
@@ -232,14 +241,22 @@ export default () => (dispatch) => {
             // needs to absorb a retry burst, and a short TTL keeps recovery
             // fast either way.
             if (shouldCacheNegative) {
-              negatives.set(hostname, { err, expires: getFastNow() + negativeTTL })
+              if (negativeTTL === 0) {
+                negatives.delete(hostname)
+              } else {
+                negatives.set(hostname, { err, expires: Date.now() + negativeTTL })
+              }
             } else {
               negatives.delete(hostname)
             }
             resolve([err, null])
           } else {
             negatives.delete(hostname)
-            cache.set(hostname, val)
+            if (ttl === 0) {
+              cache.delete(hostname)
+            } else {
+              cache.set(hostname, val)
+            }
 
             resolve([null, val])
           }
@@ -282,6 +299,8 @@ export default () => (dispatch) => {
 
       const ttl = opts.dns.ttl ?? 2e3
       const negativeTTL = opts.dns.negativeTTL ?? 1e3
+      validateTTL('ttl', ttl)
+      validateTTL('negativeTTL', negativeTTL)
       const lookup = opts.dns.lookup ?? dns.lookup
       if (typeof lookup !== 'function') {
         throw new TypeError('opts.dns.lookup must be a function')
@@ -304,7 +323,7 @@ export default () => (dispatch) => {
 
       const state = getResolverState(lookup)
       const { cache, negatives, promises } = state
-      const now = getFastNow()
+      const now = Date.now()
 
       sweep(now)
 
@@ -463,7 +482,7 @@ export default () => (dispatch) => {
             // eviction stays allocation-free while tracing is off.
             const write = traceWrite(opts.trace)
             if (write !== null) {
-              const evictedAt = getFastNow()
+              const evictedAt = Date.now()
               let siblings = 0
               for (const x of records) {
                 if (x.expires >= evictedAt) {

--- a/test/dns-resolver-errors.js
+++ b/test/dns-resolver-errors.js
@@ -1,5 +1,4 @@
 import { test } from 'tap'
-import { setTimeout as sleep } from 'node:timers/promises'
 import { interceptors } from '../lib/index.js'
 
 function request(dispatch, dns) {
@@ -46,10 +45,6 @@ test('dns: a synchronously throwing resolver is cleared and can recover', async 
   const dns = { lookup, negativeTTL: 0 }
 
   await t.rejects(request(dispatch, dns), /resolver exploded/)
-
-  // getFastNow() advances once per second. Wait for a tick so the zero-length
-  // negative-cache entry is expired before checking that resolution retries.
-  await sleep(1500)
 
   t.equal(await request(dispatch, dns), 200)
   t.equal(calls, 2, 'the rejected in-flight promise was not retained forever')

--- a/test/dns-ttl-validation.js
+++ b/test/dns-ttl-validation.js
@@ -44,6 +44,8 @@ test('dns: rejects invalid TTL option values before lookup', async (t) => {
   const cases = [
     ['ttl', '1000', 'TypeError', 'must be a number'],
     ['negativeTTL', '1000', 'TypeError', 'must be a number'],
+    ['ttl', null, 'TypeError', 'must be a number'],
+    ['negativeTTL', null, 'TypeError', 'must be a number'],
     ['ttl', NaN, 'RangeError', 'must be a finite number greater than or equal to 0'],
     ['ttl', Infinity, 'RangeError', 'must be a finite number greater than or equal to 0'],
     ['ttl', -1, 'RangeError', 'must be a finite number greater than or equal to 0'],

--- a/test/dns-ttl-validation.js
+++ b/test/dns-ttl-validation.js
@@ -1,0 +1,136 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'http://ttl.test'
+
+function run(dispatch, dns) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(
+      { origin: ORIGIN, path: '/', method: 'GET', headers: {}, dns },
+      {
+        onConnect() {},
+        onHeaders(value) {
+          statusCode = value
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve(statusCode)
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+function makeDispatch(origins = []) {
+  return interceptors.dns()((opts, handler) => {
+    origins.push(opts.origin)
+    handler.onConnect(() => {})
+    handler.onHeaders(200, {}, () => {})
+    handler.onComplete([])
+  })
+}
+
+function notFound(hostname) {
+  return Object.assign(new Error(`getaddrinfo ENOTFOUND ${hostname}`), {
+    code: 'ENOTFOUND',
+    hostname,
+  })
+}
+
+test('dns: rejects invalid TTL option values before lookup', async (t) => {
+  const cases = [
+    ['ttl', '1000', 'TypeError', 'must be a number'],
+    ['negativeTTL', '1000', 'TypeError', 'must be a number'],
+    ['ttl', NaN, 'RangeError', 'must be a finite number greater than or equal to 0'],
+    ['ttl', Infinity, 'RangeError', 'must be a finite number greater than or equal to 0'],
+    ['ttl', -1, 'RangeError', 'must be a finite number greater than or equal to 0'],
+    ['negativeTTL', NaN, 'RangeError', 'must be a finite number greater than or equal to 0'],
+    ['negativeTTL', Infinity, 'RangeError', 'must be a finite number greater than or equal to 0'],
+    ['negativeTTL', -1, 'RangeError', 'must be a finite number greater than or equal to 0'],
+  ]
+  let lookups = 0
+  const lookup = () => lookups++
+  const dispatch = makeDispatch()
+
+  for (const [name, value, errorName, message] of cases) {
+    await t.rejects(run(dispatch, { lookup, [name]: value }), {
+      name: errorName,
+      message: `opts.dns.${name} ${message}`,
+    })
+  }
+  t.equal(lookups, 0, 'invalid cache policy never reaches the resolver')
+})
+
+test('dns: zero and sub-second TTLs use the real millisecond clock', async (t) => {
+  const originalNow = Date.now
+  let now = 10_000
+  Date.now = () => now
+  t.teardown(() => {
+    Date.now = originalNow
+  })
+
+  let positiveLookups = 0
+  const positiveOrigins = []
+  const positiveLookup = (hostname, options, callback) => {
+    positiveLookups++
+    callback(null, [{ address: `192.0.2.${positiveLookups}`, family: 4 }])
+  }
+  const positiveDispatch = makeDispatch(positiveOrigins)
+  const positiveDNS = { lookup: positiveLookup, ttl: 100 }
+
+  await run(positiveDispatch, positiveDNS)
+  now += 49
+  await run(positiveDispatch, positiveDNS)
+  t.equal(positiveLookups, 1, 'positive record remains cached before its half-life')
+
+  now += 52
+  await run(positiveDispatch, positiveDNS)
+  t.equal(positiveLookups, 2, 'positive record expires after 100 real milliseconds')
+  t.same(positiveOrigins, ['http://192.0.2.1', 'http://192.0.2.1', 'http://192.0.2.2'])
+
+  let zeroLookups = 0
+  const zeroLookup = (hostname, options, callback) => {
+    zeroLookups++
+    callback(null, [{ address: '192.0.2.10', family: 4 }])
+  }
+  const zeroDispatch = makeDispatch()
+  await run(zeroDispatch, { lookup: zeroLookup, ttl: 0 })
+  await run(zeroDispatch, { lookup: zeroLookup, ttl: 0 })
+  t.equal(zeroLookups, 2, 'ttl: 0 does not cache sequential successful lookups')
+
+  let negativeLookups = 0
+  const recoveringLookup = (hostname, options, callback) => {
+    negativeLookups++
+    if (negativeLookups === 1) {
+      callback(notFound(hostname))
+    } else {
+      callback(null, [{ address: '192.0.2.20', family: 4 }])
+    }
+  }
+  const negativeDispatch = makeDispatch()
+  const negativeDNS = { lookup: recoveringLookup, negativeTTL: 100 }
+
+  now = 20_000
+  await t.rejects(run(negativeDispatch, negativeDNS), { code: 'ENOTFOUND' })
+  now += 49
+  await t.rejects(run(negativeDispatch, negativeDNS), { code: 'ENOTFOUND' })
+  t.equal(negativeLookups, 1, 'negative result remains cached before expiry')
+
+  now += 52
+  t.equal(await run(negativeDispatch, negativeDNS), 200)
+  t.equal(negativeLookups, 2, 'negative result expires after 100 real milliseconds')
+
+  let zeroNegativeLookups = 0
+  const failingLookup = (hostname, options, callback) => {
+    zeroNegativeLookups++
+    callback(notFound(hostname))
+  }
+  const zeroNegativeDispatch = makeDispatch()
+  const zeroNegativeDNS = { lookup: failingLookup, negativeTTL: 0 }
+  await t.rejects(run(zeroNegativeDispatch, zeroNegativeDNS), { code: 'ENOTFOUND' })
+  await t.rejects(run(zeroNegativeDispatch, zeroNegativeDNS), { code: 'ENOTFOUND' })
+  t.equal(zeroNegativeLookups, 2, 'negativeTTL: 0 does not cache sequential failures')
+})

--- a/test/review-bugfixes-4-dns-negative-cache.js
+++ b/test/review-bugfixes-4-dns-negative-cache.js
@@ -55,8 +55,7 @@ test('dns: lookup failures are negative-cached (one lookup per window)', async (
     t.fail('dispatch must not be reached when lookup fails')
   })
 
-  // getFastNow() (the interceptor clock) only ticks once per second, so use a
-  // window comfortably larger than the test's runtime plus one tick.
+  // Keep the window comfortably larger than the test's runtime.
   const dns = { negativeTTL: 5000, lookup }
 
   for (let i = 0; i < 5; i++) {
@@ -104,10 +103,9 @@ test('dns: negative entry expires after negativeTTL and the next lookup recovers
   )
   t.equal(lookups, 1, 'first request performed the lookup')
 
-  // getFastNow() advances only once per second, so sleep long enough to
-  // guarantee at least one tick lands past the 50 ms expiry.
+  // DNS expiry uses the real millisecond clock; wait just past the 50 ms TTL.
   failing = false
-  await sleep(1500)
+  await sleep(75)
 
   const status = await run(dispatch, { origin: 'http://recovers.invalid', dns })
   t.equal(status, 200, 'request succeeds once DNS recovers')

--- a/test/trace-dns.js
+++ b/test/trace-dns.js
@@ -148,40 +148,33 @@ test('trace-dns: pre-emptive refresh emits a refresh doc', async (t) => {
   const port = server.address().port
 
   const lookup = (hostname, opts, cb) => cb(null, [{ address: '127.0.0.1' }])
+  const writer = makeWriter()
+  const dispatcher = makeDispatcher(t)
 
-  // A ttl:1 request populates the cache with records expiring 1ms past the
-  // coarse getFastNow() sample; a same-tick ttl:1000 request then hits the
-  // cache AND sees the records past half their (new) TTL, firing the
-  // fire-and-forget refresh. If a fastNow tick lands between the two requests
-  // the second becomes a plain miss instead — retry with a fresh dispatcher
-  // (fresh dns cache) up to a bounded number of attempts.
+  // The first entry remains fresh for 10 seconds. A subsequent 30-second TTL
+  // puts that entry deterministically past the requesting policy's half-life,
+  // without depending on requests landing inside one coarse clock tick.
+  const first = await request(`http://localhost:${port}`, {
+    trace: writer,
+    dns: { ttl: 10_000, lookup },
+    dispatcher,
+  })
+  await first.body.dump()
+
+  const second = await request(`http://localhost:${port}`, {
+    trace: writer,
+    dns: { ttl: 30_000, lookup },
+    dispatcher,
+  })
+  await second.body.dump()
+
+  // The side-observer settles on a microtask; poll briefly, bounded.
   let refresh = null
-  let writer = null
-  for (let attempt = 0; attempt < 5 && refresh == null; attempt++) {
-    writer = makeWriter()
-    const dispatcher = makeDispatcher(t)
-
-    const first = await request(`http://localhost:${port}`, {
-      trace: writer,
-      dns: { ttl: 1, lookup },
-      dispatcher,
-    })
-    await first.body.dump()
-
-    const second = await request(`http://localhost:${port}`, {
-      trace: writer,
-      dns: { ttl: 1000, lookup },
-      dispatcher,
-    })
-    await second.body.dump()
-
-    // The side-observer settles on a microtask; poll briefly, bounded.
-    const deadline = Date.now() + 1000
-    while (refresh == null && Date.now() < deadline) {
-      refresh = writer.docs.find((d) => d.op === 'undici:dns' && d.source === 'refresh')
-      if (refresh == null) {
-        await new Promise((resolve) => setImmediate(resolve))
-      }
+  const deadline = Date.now() + 1000
+  while (refresh == null && Date.now() < deadline) {
+    refresh = writer.docs.find((d) => d.op === 'undici:dns' && d.source === 'refresh')
+    if (refresh == null) {
+      await new Promise((resolve) => setImmediate(resolve))
     }
   }
 
@@ -205,76 +198,64 @@ test('trace-dns: concurrent refresh triggers emit one doc per lookup', async (t)
   t.teardown(server.close.bind(server))
   const port = server.address().port
 
-  // Same coarse-tick window trick as the refresh test above (bounded retries
-  // absorb a fastNow tick slipping between requests). The refresh lookup
-  // hangs until released so both triggering requests provably share ONE
-  // in-flight resolution; a tick-slip miss also awaits it, so the release is
-  // timer-driven rather than awaited behind the requests (no deadlock).
-  let done = false
-  for (let attempt = 0; attempt < 5 && !done; attempt++) {
-    const writer = makeWriter()
-    const dispatcher = makeDispatcher(t)
+  const writer = makeWriter()
+  const dispatcher = makeDispatcher(t)
 
-    let lookups = 0
-    let release = null
-    const lookup = (hostname, opts, cb) => {
-      lookups++
-      if (lookups === 1) {
-        cb(null, [{ address: '127.0.0.1' }])
-      } else {
-        release = () => cb(null, [{ address: '127.0.0.1' }])
-      }
+  // As above, the TTL pair creates a deterministic refresh window. Hold that
+  // refresh open so both requests provably join one in-flight lookup.
+  let lookups = 0
+  let release = null
+  const lookup = (hostname, opts, cb) => {
+    lookups++
+    if (lookups === 1) {
+      cb(null, [{ address: '127.0.0.1' }])
+    } else {
+      release = () => cb(null, [{ address: '127.0.0.1' }])
     }
-
-    const first = await request(`http://localhost:${port}`, {
-      trace: writer,
-      dns: { ttl: 1, lookup },
-      dispatcher,
-    })
-    await first.body.dump()
-
-    const pa = request(`http://localhost:${port}`, {
-      trace: writer,
-      dns: { ttl: 1000, lookup },
-      dispatcher,
-    })
-    const pb = request(`http://localhost:${port}`, {
-      trace: writer,
-      dns: { ttl: 1000, lookup },
-      dispatcher,
-    })
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    release?.()
-    for (const p of await Promise.all([pa, pb])) {
-      await p.body.dump()
-    }
-
-    // Valid window: both follow-ups stayed on the cached-records path (one
-    // miss doc total, from the first request) and exactly one refresh lookup
-    // actually fired.
-    const misses = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'miss')
-    if (misses.length !== 1 || lookups !== 2) {
-      continue
-    }
-
-    // The side-observer settles on a microtask; poll briefly, bounded.
-    const deadline = Date.now() + 1000
-    let refreshes = []
-    while (refreshes.length === 0 && Date.now() < deadline) {
-      refreshes = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'refresh')
-      if (refreshes.length === 0) {
-        await new Promise((resolve) => setImmediate(resolve))
-      }
-    }
-    // Settle any stragglers before counting.
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    refreshes = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'refresh')
-
-    t.equal(refreshes.length, 1, 'one refresh doc per deduped lookup')
-    t.equal(refreshes[0].records, 1)
-    t.equal(refreshes[0].err, null)
-    done = true
   }
 
-  t.ok(done, 'deterministic refresh window achieved within bounded attempts')
+  const first = await request(`http://localhost:${port}`, {
+    trace: writer,
+    dns: { ttl: 10_000, lookup },
+    dispatcher,
+  })
+  await first.body.dump()
+
+  const pa = request(`http://localhost:${port}`, {
+    trace: writer,
+    dns: { ttl: 30_000, lookup },
+    dispatcher,
+  })
+  const pb = request(`http://localhost:${port}`, {
+    trace: writer,
+    dns: { ttl: 30_000, lookup },
+    dispatcher,
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+  t.type(release, 'function', 'refresh lookup started')
+  release?.()
+  for (const p of await Promise.all([pa, pb])) {
+    await p.body.dump()
+  }
+
+  const misses = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'miss')
+  t.equal(misses.length, 1, 'follow-ups stayed on the cached-record path')
+  t.equal(lookups, 2, 'both follow-ups shared one refresh lookup')
+
+  // The side-observer settles on a microtask; poll briefly, bounded.
+  const deadline = Date.now() + 1000
+  let refreshes = []
+  while (refreshes.length === 0 && Date.now() < deadline) {
+    refreshes = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'refresh')
+    if (refreshes.length === 0) {
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+  // Settle any stragglers before counting.
+  await new Promise((resolve) => setImmediate(resolve))
+  refreshes = writer.docs.filter((d) => d.op === 'undici:dns' && d.source === 'refresh')
+
+  t.equal(refreshes.length, 1, 'one refresh doc per deduped lookup')
+  t.equal(refreshes[0].records, 1)
+  t.equal(refreshes[0].err, null)
 })

--- a/test/trace-dns.js
+++ b/test/trace-dns.js
@@ -231,7 +231,10 @@ test('trace-dns: concurrent refresh triggers emit one doc per lookup', async (t)
     dns: { ttl: 30_000, lookup },
     dispatcher,
   })
-  await new Promise((resolve) => setImmediate(resolve))
+  const releaseDeadline = Date.now() + 1000
+  while (release == null && Date.now() < releaseDeadline) {
+    await new Promise((resolve) => setImmediate(resolve))
+  }
   t.type(release, 'function', 'refresh lookup started')
   release?.()
   for (const p of await Promise.all([pa, pb])) {

--- a/type-tests/dispatcher-options.ts
+++ b/type-tests/dispatcher-options.ts
@@ -4,6 +4,10 @@ declare const dispatcher: Dispatcher
 declare const handler: DispatchHandler
 
 dispatcher.dispatch({ origin: 'https://example.test', method: 'GET' }, handler)
+dispatcher.dispatch({ origin: 'https://example.test', dns: { ttl: 0, negativeTTL: 0 } }, handler)
 
 // @ts-expect-error Dispatcher options use the public DispatchOptions contract.
 dispatcher.dispatch({ unknownOption: true }, handler)
+
+// @ts-expect-error DNS TTL options are numeric.
+dispatcher.dispatch({ origin: 'https://example.test', dns: { ttl: '1000' } }, handler)


### PR DESCRIPTION
## Summary

- reject non-number, non-finite, and negative `ttl` / `negativeTTL` values before lookup
- use the real millisecond clock for DNS expiry, so sub-second policies are not stretched by the shared one-second fast clock
- make zero positive and negative TTLs skip persistent cache insertion while retaining in-flight lookup deduplication
- document TTL domains and add compile-time numeric coverage
- replace coarse-clock retry/sleep tests with deterministic refresh windows and fake-clock expiry regressions

## Root cause

DNS records and failures were timestamped and checked with a clock updated only once per second. A 100 ms TTL could therefore remain usable for nearly a full second, while a zero TTL remained cached until the next clock tick. NaN expiries also failed every comparison and could wedge entries in cache/sweep state; Infinity and negative values had similarly invalid semantics.

DNS expiry now uses `Date.now()`, and zero TTLs are not inserted into the persistent positive or negative maps. Validation reports `TypeError` for non-number values and `RangeError` for invalid numeric domains. Optional `undefined` values use defaults; `null` is rejected.

This PR does not change first-caller cache-policy ownership or abort/error penalty behavior.

## Validation

- all DNS, authority, resolver, trace, negative-cache, async-dispatch, and public-type suites: 195 assertions across 49 suites
- `npx eslint lib/interceptor/dns.js test/dns-ttl-validation.js test/dns-resolver-errors.js test/review-bugfixes-4-dns-negative-cache.js test/trace-dns.js`
- Prettier check for all changed source, declaration, type-test, and runtime-test files
- `git diff --check`