### PR TITLE
fix(headers): accept array-of-pairs input

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,8 +28,14 @@ export interface BodyReadable extends Readable {
 }
 
 export type URLLike = string | URL | URLObject
+export type HeaderPair = readonly [
+  Buffer | string,
+  Buffer | string | readonly (Buffer | string | null | undefined)[] | null | undefined,
+]
 export type HeaderInput =
-  Record<string, string | string[] | null | undefined> | (Buffer | string | (Buffer | string)[])[]
+  | Record<string, string | string[] | null | undefined>
+  | (Buffer | string | (Buffer | string)[])[]
+  | readonly HeaderPair[]
 export type OriginLike = URLLike | readonly URLLike[]
 export type RequestSignal = AbortSignal | EventEmitter
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -743,6 +743,40 @@ function headerValueToString(value) {
   return Buffer.isBuffer(value) ? value.toString('latin1') : `${value}`
 }
 
+function appendHeader(obj, key2, val2) {
+  if (val2 == null) {
+    return
+  }
+
+  const key = util.headerNameToString(key2)
+
+  // Check own presence, not truthiness: an empty string is a valid value,
+  // while inherited names such as `constructor` are not existing headers.
+  // Define new keys as own data properties so `__proto__` cannot invoke
+  // Object.prototype's legacy setter and mutate the result's prototype.
+  if (Object.hasOwn(obj, key)) {
+    let val = obj[key]
+    if (!Array.isArray(val)) {
+      val = [val]
+      setOwnHeader(obj, key, val)
+    }
+
+    if (Array.isArray(val2)) {
+      val.push(...val2.filter((x) => x != null).map(headerValueToString))
+    } else {
+      val.push(headerValueToString(val2))
+    }
+  } else {
+    setOwnHeader(
+      obj,
+      key,
+      Array.isArray(val2)
+        ? val2.filter((x) => x != null).map(headerValueToString)
+        : headerValueToString(val2),
+    )
+  }
+}
+
 // Only objects owned by this package are recorded here. `parseHeaders()` is a
 // public copy API, so its ordinary results deliberately remain
 // untrusted: callers may mutate them at any time. Internal dispatch boundaries
@@ -766,84 +800,25 @@ export function parseHeaders(headers) {
   const obj = {}
 
   if (Array.isArray(headers)) {
-    if (headers.length % 2 !== 0) {
-      throw new errors.InvalidArgumentError('headers array must be even')
-    }
-
-    for (let i = 0; i < headers.length; i += 2) {
-      const key2 = headers[i]
-      const val2 = headers[i + 1]
-
-      // TODO (fix): assert key2 type?
-      // TODO (fix): assert val2 type?
-
-      if (val2 == null) {
-        continue
+    if (Array.isArray(headers[0])) {
+      for (const pair of headers) {
+        if (!Array.isArray(pair) || pair.length !== 2) {
+          throw new errors.InvalidArgumentError('headers array must contain [name, value] pairs')
+        }
+        appendHeader(obj, pair[0], pair[1])
+      }
+    } else {
+      if (headers.length % 2 !== 0) {
+        throw new errors.InvalidArgumentError('headers array must be even')
       }
 
-      const key = util.headerNameToString(key2)
-
-      // Check own presence, not truthiness: an empty string is a valid value,
-      // while inherited names such as `constructor` are not existing headers.
-      // Define new keys as own data properties so `__proto__` cannot invoke
-      // Object.prototype's legacy setter and mutate the result's prototype.
-      if (Object.hasOwn(obj, key)) {
-        let val = obj[key]
-        if (!Array.isArray(val)) {
-          val = [val]
-          setOwnHeader(obj, key, val)
-        }
-
-        if (Array.isArray(val2)) {
-          val.push(...val2.filter((x) => x != null).map(headerValueToString))
-        } else {
-          val.push(headerValueToString(val2))
-        }
-      } else {
-        setOwnHeader(
-          obj,
-          key,
-          Array.isArray(val2)
-            ? val2.filter((x) => x != null).map(headerValueToString)
-            : headerValueToString(val2),
-        )
+      for (let i = 0; i < headers.length; i += 2) {
+        appendHeader(obj, headers[i], headers[i + 1])
       }
     }
   } else if (typeof headers === 'object' && headers !== null) {
     for (const key2 of Object.keys(headers)) {
-      const val2 = headers[key2]
-
-      // TODO (fix): assert key2 type?
-      // TODO (fix): assert val2 type?
-
-      if (val2 == null) {
-        continue
-      }
-
-      const key = util.headerNameToString(key2)
-
-      // See the array branch above: presence check, not truthiness, so a
-      // stored empty string is not clobbered by a later duplicate.
-      if (Object.hasOwn(obj, key)) {
-        let val = obj[key]
-        if (!Array.isArray(val)) {
-          val = [val]
-          setOwnHeader(obj, key, val)
-        }
-        if (Array.isArray(val2)) {
-          val.push(...val2.filter((x) => x != null).map(headerValueToString))
-        } else {
-          val.push(headerValueToString(val2))
-        }
-      } else {
-        setOwnHeader(
-          obj,
-          key,
-          Array.isArray(val2)
-            ? val2.filter((x) => x != null).map(headerValueToString)
-            : headerValueToString(val2),
-        )
-      }
+      appendHeader(obj, key2, headers[key2])
     }
   } else if (headers != null) {
     throw new Error('invalid argument: headers')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -808,6 +808,15 @@ export function parseHeaders(headers) {
         appendHeader(obj, pair[0], pair[1])
       }
     } else {
+      // A pair appearing at any later name position is a mixed
+      // representation, not a flat header name. Detect it before the length
+      // check so both even and odd mixed arrays fail with the same diagnostic.
+      for (let i = 0; i < headers.length; i += 2) {
+        if (Array.isArray(headers[i])) {
+          throw new errors.InvalidArgumentError('headers array must contain [name, value] pairs')
+        }
+      }
+
       if (headers.length % 2 !== 0) {
         throw new errors.InvalidArgumentError('headers array must be even')
       }

--- a/test/parse-headers-pairs.js
+++ b/test/parse-headers-pairs.js
@@ -25,5 +25,7 @@ test('parseHeaders rejects malformed or mixed pair arrays', (t) => {
   t.throws(() => parseHeaders([['x-name']]), expected)
   t.throws(() => parseHeaders([['x-name', 'value', 'extra']]), expected)
   t.throws(() => parseHeaders([['x-name', 'value'], 'x-other']), expected)
+  t.throws(() => parseHeaders(['x-name', 'value', ['x-other', 'other']]), expected)
+  t.throws(() => parseHeaders(['x-name', 'value', ['x-other', 'other'], 'value']), expected)
   t.end()
 })

--- a/test/parse-headers-pairs.js
+++ b/test/parse-headers-pairs.js
@@ -1,0 +1,29 @@
+import { test } from 'tap'
+import { parseHeaders } from '../lib/index.js'
+
+test('parseHeaders accepts array-of-pairs input', (t) => {
+  const headers = parseHeaders([
+    [Buffer.from('Set-Cookie'), Buffer.from('a=1')],
+    ['set-cookie', [Buffer.from([0xe9]), 'ascii']],
+    ['__proto__', 'safe'],
+  ])
+
+  t.strictSame(headers['set-cookie'], ['a=1', 'é', 'ascii'])
+  t.equal(Object.hasOwn(headers, '__proto__'), true)
+  t.equal(headers.__proto__, 'safe')
+  t.equal(Object.getPrototypeOf(headers), Object.prototype)
+  t.end()
+})
+
+test('parseHeaders rejects malformed or mixed pair arrays', (t) => {
+  const expected = {
+    name: 'InvalidArgumentError',
+    code: 'UND_ERR_INVALID_ARG',
+    message: 'headers array must contain [name, value] pairs',
+  }
+
+  t.throws(() => parseHeaders([['x-name']]), expected)
+  t.throws(() => parseHeaders([['x-name', 'value', 'extra']]), expected)
+  t.throws(() => parseHeaders([['x-name', 'value'], 'x-other']), expected)
+  t.end()
+})

--- a/type-tests/header-input.ts
+++ b/type-tests/header-input.ts
@@ -1,9 +1,25 @@
-import { parseHeaders, type DispatchOptions, type HeaderInput } from '../lib/index.js'
+import {
+  parseHeaders,
+  type DispatchOptions,
+  type HeaderInput,
+  type HeaderPair,
+} from '../lib/index.js'
 
 const headers: HeaderInput = ['x-first', 'one', Buffer.from('x-second'), Buffer.from('two')]
 const options: DispatchOptions = { headers }
+const pairs: readonly HeaderPair[] = [
+  ['x-first', 'one'],
+  [Buffer.from('x-second'), [Buffer.from('two'), 'three']],
+]
+const pairOptions: DispatchOptions = { headers: pairs }
 
 parseHeaders()
 parseHeaders(null)
 parseHeaders(headers)
+parseHeaders(pairs)
+parseHeaders([
+  ['x-pair', 'value'],
+  [Buffer.from('x-repeated'), ['one', Buffer.from('two')]],
+])
 void options
+void pairOptions


### PR DESCRIPTION
## Summary

- address the unresolved review comment on #199 by supporting both Undici header array representations
- retain flat alternating arrays (`[name, value, ...]`) and add array-of-pairs (`[[name, value], ...]`)
- share normalization across pair, flat, and object inputs so duplicate, Latin-1 Buffer, array-valued, and prototype-named headers behave consistently
- reject malformed or mixed pair arrays deterministically
- declare and compile the public `HeaderPair` type

## Validation

- six header/utility/type suites: 128/128 assertions
- strict TypeScript declaration compile
- ESLint
- Prettier check
- `git diff --check`

Follow-up to #199 review thread r3564790931.