### PR TITLE
fix(retry): validate retry budgets

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -128,6 +128,8 @@ export interface DispatchOptions {
 }
 
 export interface RetryOptions {
+  /** Maximum retries after the initial attempt (default 8). Must be a
+   *  non-negative safe integer; invalid runtime values disable retries. */
   count?: number
   /** Cap on the exponential backoff between attempts, in milliseconds
    *  (default 60_000; clamped to the ~2^31−1 ms timer max). The first retry is

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -18,8 +18,32 @@ const { RequestAbortedError } = errors
 // the response is not retried. Larger bodies are passed straight through and
 // the response is not status-code retried.
 const MAX_ERROR_BODY_SIZE = 256 * 1024
+const DEFAULT_RETRY_COUNT = 8
 
 function noop() {}
+
+function getRetryCount(retry) {
+  let count
+
+  if (typeof retry === 'number') {
+    count = retry
+  } else if (retry === true || typeof retry === 'function') {
+    count = undefined
+  } else if (retry !== null && typeof retry === 'object' && !Array.isArray(retry)) {
+    count = retry.count
+  } else {
+    return 0
+  }
+
+  if (count === undefined) {
+    return DEFAULT_RETRY_COUNT
+  }
+
+  // Fail closed for invalid runtime input. In particular, comparisons against
+  // NaN or Infinity never reach the cap and otherwise turn an options object
+  // into an effectively unbounded retry policy.
+  return Number.isSafeInteger(count) && count >= 0 ? count : 0
+}
 
 function isOneShotIterable(body) {
   if (body == null || typeof body !== 'object') {
@@ -643,7 +667,7 @@ class Handler extends DecoratorHandler {
       if (
         typeof retry === 'function' &&
         isObjectRetry &&
-        this.#retryCount >= (retryOpts.count ?? 8)
+        this.#retryCount >= getRetryCount(retryOpts)
       ) {
         retryPromise = Promise.resolve(false)
       } else if (typeof retry === 'function') {
@@ -787,17 +811,13 @@ class Handler extends DecoratorHandler {
       return false
     }
 
-    let retryOpts = opts?.retry
+    const retryOpts = opts?.retry
 
     if (!retryOpts) {
       return false
     }
 
-    if (typeof retryOpts === 'number') {
-      retryOpts = { count: retryOpts }
-    }
-
-    const retryMax = retryOpts?.count ?? 8
+    const retryMax = getRetryCount(retryOpts)
 
     if (retryCount >= retryMax) {
       return false

--- a/test/retry-count-validation.js
+++ b/test/retry-count-validation.js
@@ -1,0 +1,108 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function respond(handler, statusCode, body) {
+  handler.onConnect(() => {})
+  handler.onHeaders(statusCode, { 'content-length': String(Buffer.byteLength(body)) }, () => {})
+  handler.onData(Buffer.from(body))
+  handler.onComplete({})
+}
+
+function run(retry) {
+  let attempts = 0
+  const dispatch = compose((opts, handler) => {
+    attempts++
+    respond(handler, attempts === 1 ? 503 : 200, attempts === 1 ? 'unavailable' : 'ok')
+  }, interceptors.responseRetry())
+
+  return new Promise((resolve, reject) => {
+    let statusCode
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry,
+      },
+      {
+        onConnect() {},
+        onHeaders(status) {
+          statusCode = status
+          return true
+        },
+        onData() {
+          return true
+        },
+        onComplete() {
+          resolve({ attempts, statusCode })
+        },
+        onError: reject,
+      },
+    )
+  })
+}
+
+test('invalid retry budgets disable retries', async (t) => {
+  const cases = [
+    ['numeric NaN', Number.NaN],
+    ['numeric Infinity', Number.POSITIVE_INFINITY],
+    ['numeric -Infinity', Number.NEGATIVE_INFINITY],
+    ['numeric negative', -1],
+    ['numeric fraction', 0.5],
+    ['numeric unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+    ['invalid retry type', '2'],
+    ['options NaN', { count: Number.NaN }],
+    ['options Infinity', { count: Number.POSITIVE_INFINITY }],
+    ['options -Infinity', { count: Number.NEGATIVE_INFINITY }],
+    ['options negative', { count: -1 }],
+    ['options fraction', { count: 0.5 }],
+    ['options unsafe integer', { count: Number.MAX_SAFE_INTEGER + 1 }],
+    ['options string', { count: '2' }],
+    ['options null', { count: null }],
+  ]
+
+  for (const [name, retry] of cases) {
+    const result = await run(retry)
+    t.same(result, { attempts: 1, statusCode: 503 }, name)
+  }
+})
+
+test('invalid object count caps a custom retry strategy before it is called', async (t) => {
+  let strategyCalls = 0
+  const result = await run({
+    count: Number.NaN,
+    retry() {
+      strategyCalls++
+      return true
+    },
+  })
+
+  t.equal(strategyCalls, 0)
+  t.same(result, { attempts: 1, statusCode: 503 })
+})
+
+test('valid retry forms retain their documented semantics', async (t) => {
+  const enabled = [
+    ['true uses the default budget', true],
+    ['numeric shorthand', 1],
+    ['options count', { count: 1 }],
+    ['omitted options count uses the default', { maxDelay: 0 }],
+    ['maximum safe integer is valid', Number.MAX_SAFE_INTEGER],
+    ['bare strategy controls retrying', () => true],
+  ]
+
+  for (const [name, retry] of enabled) {
+    const result = await run(retry)
+    t.same(result, { attempts: 2, statusCode: 200 }, name)
+  }
+
+  for (const [name, retry] of [
+    ['false disables retries', false],
+    ['zero shorthand disables retries', 0],
+    ['zero options count disables retries', { count: 0 }],
+  ]) {
+    const result = await run(retry)
+    t.same(result, { attempts: 1, statusCode: 503 }, name)
+  }
+})


### PR DESCRIPTION
## Summary

- normalize retry budgets through one validation path
- fail closed to zero retries for NaN, non-finite, fractional, unsafe, negative, and wrong-type budgets
- apply the same cap before object-form custom retry strategies run
- preserve `true`, non-negative safe-integer shorthand, options defaults/counts, zero, false, and bare-strategy semantics
- document the runtime count constraint in the public declaration

## Root cause

Retry caps were compared directly with `retryCount`. Comparisons such as `retryCount >= NaN` and `retryCount >= Infinity` never become true, so invalid object counts could turn both default and custom retry policies into unbounded retry loops.

## Validation

- retry-related suite: 347 assertions passed; 1 existing no-tests skip
- focused retry-budget suite: 26 assertions passed
- ESLint
- Prettier
- `git diff --check`
- `tsc --noEmit` attempted; the repository baseline is currently not clean and reports existing JSDoc/type errors across cache and interceptor files
