### PR TITLE
fix(types): declare trace deep import

### DIFF
--- a/lib/trace.d.ts
+++ b/lib/trace.d.ts
@@ -1,0 +1,7 @@
+import type { TraceWriter } from '@nxtedition/trace'
+
+export { installTrace, traceErr, traceSafe, traceWrite } from '@nxtedition/trace'
+
+export function validateTrace(trace: unknown): TraceWriter | null | undefined
+
+export function traceUrl(opts: { origin?: unknown; path?: unknown }): string | null

--- a/type-tests/trace-deep-import.ts
+++ b/type-tests/trace-deep-import.ts
@@ -1,0 +1,31 @@
+import type { TraceWriter } from '@nxtedition/trace'
+import {
+  installTrace,
+  traceErr,
+  traceSafe,
+  traceUrl,
+  traceWrite,
+  validateTrace,
+} from '../lib/trace.js'
+
+const writer: TraceWriter = {
+  write(obj, op) {
+    void obj
+    void op
+  },
+}
+
+installTrace(writer)
+installTrace(undefined)
+
+const validated: TraceWriter | null | undefined = validateTrace(writer)
+const write: TraceWriter['write'] = traceWrite(validated)
+const url: string | null = traceUrl({ origin: new URL('https://example.test'), path: '/path' })
+const tag: string = traceErr(new Error('boom'))
+
+if (write) {
+  traceSafe(write, { url, tag }, 'test')
+}
+
+// @ts-expect-error traceUrl requires an options object
+traceUrl('https://example.test')


### PR DESCRIPTION
## Summary

- add the missing declaration sibling for the shipped `lib/trace.js` entrypoint
- re-export the upstream trace helpers with their authoritative types
- declare nxt-undici's `validateTrace()` and `traceUrl()` helpers
- compile a strict deep-import consumer and verify the declaration is packed

## Validation

- public declarations and trace suites: 109/109 assertions
- strict TypeScript compile
- Prettier check
- `npm pack --dry-run`
- `git diff --check`