### PR TITLE
fix(dns): exclude caller aborts from penalties

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -9,10 +9,19 @@ let HASHER
 class Handler extends DecoratorHandler {
   #callback
   #statusCode
+  #clientAborted = false
 
   constructor(handler, callback) {
     super(handler)
     this.#callback = callback
+  }
+
+  onConnect(abort) {
+    this.#clientAborted = false
+    super.onConnect((reason) => {
+      this.#clientAborted = true
+      abort(reason)
+    })
   }
 
   onHeaders(statusCode, headers, resume) {
@@ -28,17 +37,17 @@ class Handler extends DecoratorHandler {
     // hostname against sweep() (it requires pending === 0). onHeaders is not
     // guaranteed to run before onUpgrade, so settle with the upgrade status;
     // 101 < 500, so this only decrements pending without bumping `errored`.
-    this.#callback(null, statusCode)
+    this.#callback(null, statusCode, this.#clientAborted)
     super.onUpgrade(statusCode, headers, socket)
   }
 
   onComplete(trailers) {
-    this.#callback(null, this.#statusCode)
+    this.#callback(null, this.#statusCode, this.#clientAborted)
     super.onComplete(trailers)
   }
 
   onError(err) {
-    this.#callback(err, this.#statusCode)
+    this.#callback(err, this.#statusCode, this.#clientAborted)
     super.onError(err)
   }
 }
@@ -447,12 +456,20 @@ export default () => (dispatch) => {
       // if dispatch throws synchronously (otherwise record.pending would leak
       // and skew load balancing toward the wrongly-busy record).
       let settled = false
-      const onSettle = (err, statusCode) => {
+      const onSettle = (err, statusCode, clientAborted = false) => {
         if (settled) {
           return
         }
         settled = true
         record.pending--
+
+        // Abort reasons are caller-owned and may be any JavaScript value. Use
+        // lifecycle provenance rather than reason.name so custom Errors (even
+        // ones carrying connection-like codes) and falsy reasons cannot
+        // penalize or evict a healthy selected address.
+        if (clientAborted) {
+          return
+        }
 
         if (err != null && err.name !== 'AbortError') {
           if (err.code != null && CONNECTION_ERROR_CODES.has(err.code)) {

--- a/test/dns-client-abort-accounting.js
+++ b/test/dns-client-abort-accounting.js
@@ -1,0 +1,159 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+const ORIGIN = 'http://abort-accounting.test'
+
+function makeWriter() {
+  const docs = []
+  return {
+    docs,
+    write(obj, op) {
+      docs.push({ ...obj, op })
+    },
+  }
+}
+
+function request(dispatch, dns, { abort = false, reason } = {}) {
+  return new Promise((resolve) => {
+    let statusCode
+    dispatch(
+      { origin: ORIGIN, path: '/', method: 'GET', headers: {}, dns },
+      {
+        onConnect(abortRequest) {
+          if (abort) {
+            abortRequest(reason)
+          }
+        },
+        onHeaders(value) {
+          statusCode = value
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve({ type: 'complete', value: statusCode })
+        },
+        onError(err) {
+          resolve({ type: 'error', value: err })
+        },
+      },
+    )
+  })
+}
+
+async function verifyReason(t, reason, label) {
+  const origins = []
+  let lookups = 0
+  const lookup = (hostname, options, callback) => {
+    lookups++
+    callback(null, [
+      { address: '192.0.2.1', family: 4 },
+      { address: '192.0.2.2', family: 4 },
+    ])
+  }
+  const writer = makeWriter()
+  const dns = { lookup, ttl: 60_000 }
+  const dispatch = interceptors.dns()((opts, handler) => {
+    origins.push(opts.origin)
+    let aborted = false
+    handler.onConnect((value) => {
+      aborted = true
+      handler.onError(value)
+    })
+    if (!aborted) {
+      handler.onHeaders(200, {}, () => {})
+      handler.onComplete([])
+    }
+  })
+
+  const aborted = await request(dispatch, { ...dns, trace: writer }, { abort: true, reason })
+  t.equal(aborted.type, 'error', `${label}: abort reaches the terminal handler`)
+  t.equal(aborted.value, reason, `${label}: reason identity is preserved`)
+
+  t.same(await request(dispatch, dns), { type: 'complete', value: 200 })
+  t.same(await request(dispatch, dns), { type: 'complete', value: 200 })
+
+  t.same(
+    origins,
+    ['http://192.0.2.1', 'http://192.0.2.2', 'http://192.0.2.1'],
+    `${label}: aborted address remains healthy in load balancing`,
+  )
+  t.equal(lookups, 1, `${label}: client abort did not evict and re-resolve the address`)
+  t.notOk(
+    writer.docs.some((doc) => doc.op === 'undici:dns-evict'),
+    `${label}: client abort emitted no eviction trace`,
+  )
+}
+
+test('dns: custom client abort errors do not penalize or evict the selected address', async (t) => {
+  await verifyReason(t, new Error('cancelled by caller'), 'ordinary Error')
+  await verifyReason(
+    t,
+    Object.assign(new Error('cancelled by caller'), { code: 'ECONNRESET' }),
+    'connection-shaped Error',
+  )
+})
+
+test('dns: falsy client abort reasons do not penalize the selected address', async (t) => {
+  for (const [label, reason] of [
+    ['undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['zero', 0],
+    ['empty string', ''],
+  ]) {
+    await verifyReason(t, reason, label)
+  }
+})
+
+test('dns: client-abort provenance does not leak across reconnects', async (t) => {
+  const origins = []
+  let lookups = 0
+  const lookup = (hostname, options, callback) => {
+    lookups++
+    callback(null, [
+      { address: '192.0.2.1', family: 4 },
+      { address: '192.0.2.2', family: 4 },
+    ])
+  }
+  let firstRequest = true
+  const dispatch = interceptors.dns()((opts, handler) => {
+    origins.push(opts.origin)
+    if (firstRequest) {
+      firstRequest = false
+      handler.onConnect(() => {})
+      handler.onConnect(() => {})
+      handler.onError(new Error('second attempt transport failure'))
+    } else {
+      handler.onConnect(() => {})
+      handler.onHeaders(200, {}, () => {})
+      handler.onComplete([])
+    }
+  })
+  const dns = { lookup, ttl: 60_000 }
+
+  let connections = 0
+  const first = await new Promise((resolve) => {
+    dispatch(
+      { origin: ORIGIN, path: '/', method: 'GET', headers: {}, dns },
+      {
+        onConnect(abort) {
+          connections++
+          if (connections === 1) {
+            abort(new Error('first attempt cancelled'))
+          }
+        },
+        onError: resolve,
+      },
+    )
+  })
+  t.match(first, { message: 'second attempt transport failure' })
+
+  await request(dispatch, dns)
+  await request(dispatch, dns)
+  t.same(
+    origins,
+    ['http://192.0.2.1', 'http://192.0.2.2', 'http://192.0.2.2'],
+    'the later transport failure still penalizes the reconnected address',
+  )
+  t.equal(lookups, 1)
+})

--- a/test/dns-client-abort-accounting.js
+++ b/test/dns-client-abort-accounting.js
@@ -13,11 +13,11 @@ function makeWriter() {
   }
 }
 
-function request(dispatch, dns, { abort = false, reason } = {}) {
+function request(dispatch, dns, { abort = false, reason, trace } = {}) {
   return new Promise((resolve) => {
     let statusCode
     dispatch(
-      { origin: ORIGIN, path: '/', method: 'GET', headers: {}, dns },
+      { origin: ORIGIN, path: '/', method: 'GET', headers: {}, dns, trace },
       {
         onConnect(abortRequest) {
           if (abort) {
@@ -65,7 +65,7 @@ async function verifyReason(t, reason, label) {
     }
   })
 
-  const aborted = await request(dispatch, { ...dns, trace: writer }, { abort: true, reason })
+  const aborted = await request(dispatch, dns, { abort: true, reason, trace: writer })
   t.equal(aborted.type, 'error', `${label}: abort reaches the terminal handler`)
   t.equal(aborted.value, reason, `${label}: reason identity is preserved`)
 


### PR DESCRIPTION
## Summary

- record whether the selected DNS request was aborted through its downstream abort callback
- exclude caller-originated aborts from address error penalties and connection-code eviction
- preserve arbitrary abort reason identity, including ordinary Errors, connection-shaped Errors, and falsy values
- reset abort provenance on reconnect so later genuine transport failures still penalize normally

## Root cause

DNS accounting inferred cancellation only from `err.name === 'AbortError'`. Abort reasons are caller-owned JavaScript values, so `controller.abort(new Error(...))`, `false`, `0`, or an Error carrying a connection-like code could increment `record.errored` or evict a healthy selected IP.

The handler now records abort provenance at the lifecycle boundary before forwarding the reason. Settlement always releases the pending gauge, but skips address classification when that lifecycle bit is set.

This PR does not change TTL/cache-policy ownership.

## Validation

- all DNS, authority, resolver, trace, negative-cache, async-dispatch, and public-type suites: 222 assertions across 50 suites
- focused coverage verifies reason identity, ordinary and connection-shaped Errors, undefined/null/false/zero/empty-string reasons, address rotation, no eviction traces, and reconnect reset
- `npx eslint lib/interceptor/dns.js test/dns-client-abort-accounting.js`
- `npx prettier --check lib/interceptor/dns.js test/dns-client-abort-accounting.js`
- `git diff --check`