### PR TITLE
fix(retry): observe async dispatch rejections

### DIFF
--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -249,17 +249,42 @@ class Handler extends DecoratorHandler {
     }
   }
 
-  get terminalCount() {
-    return this.#terminalCount
-  }
-
-  onConnect(abort) {
+  #resetAttempt() {
     this.#attemptTerminated = false
     this.#statusCode = 0
     this.#headers = null
     this.#body = null
     this.#bodySize = 0
     this.#trailers = null
+  }
+
+  dispatch(opts) {
+    this.#resetAttempt()
+    const terminalCount = this.#terminalCount
+    const result = this.#dispatch(opts, this)
+
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+      // Callback-style dispatchers normally report failures through onError,
+      // but a directly composed async dispatcher can reject instead. Assimilate
+      // possible thenables without reading `.then` directly (the getter itself
+      // may throw), while preserving the original dispatch return contract.
+      Promise.resolve(result).catch((err) => {
+        try {
+          if (this.#terminalCount === terminalCount) {
+            this.onError(err)
+          }
+        } catch {
+          // A downstream onError hook must not turn this detached observer into
+          // a second, unhandled rejection.
+        }
+      })
+    }
+
+    return result
+  }
+
+  onConnect(abort) {
+    this.#resetAttempt()
 
     if (!this.#headersSent) {
       this.#pos = null
@@ -704,7 +729,8 @@ class Handler extends DecoratorHandler {
           this.#retryCount++
           this.#retryError = err
 
-          return this.#dispatch(this.#opts, this)
+          this.dispatch(this.#opts)
+          return
         } else {
           assert(Number.isFinite(this.#pos))
           assert(this.#end == null || (Number.isFinite(this.#end) && this.#end > 0))
@@ -739,7 +765,8 @@ class Handler extends DecoratorHandler {
           this.#retryCount++
           this.#retryError = err
 
-          return this.#dispatch(this.#opts, this)
+          this.dispatch(this.#opts)
+          return
         }
       })
       .catch((err) => {
@@ -895,24 +922,5 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  const retryHandler = new Handler(opts, { handler, dispatch })
-  const terminalCount = retryHandler.terminalCount
-  const result = dispatch(opts, retryHandler)
-  if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
-    // Callback-style dispatchers normally report failures through onError,
-    // but a directly composed async dispatcher can reject instead. Assimilate
-    // possible thenables without reading `.then` directly (the getter itself
-    // may throw), while preserving the original dispatch return contract.
-    Promise.resolve(result).catch((err) => {
-      try {
-        if (retryHandler.terminalCount === terminalCount) {
-          retryHandler.onError(err)
-        }
-      } catch {
-        // A downstream onError hook must not turn this detached observer into
-        // a second, unhandled rejection.
-      }
-    })
-  }
-  return result
+  return new Handler(opts, { handler, dispatch }).dispatch(opts)
 }

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -210,6 +210,8 @@ class Handler extends DecoratorHandler {
   #paused = false
   #replay = null
   #retryAbortController = null
+  #attemptTerminated = false
+  #terminalCount = 0
 
   #downstreamResume = () => {
     if (this.#aborted || this.#errorSent) {
@@ -247,7 +249,12 @@ class Handler extends DecoratorHandler {
     }
   }
 
+  get terminalCount() {
+    return this.#terminalCount
+  }
+
   onConnect(abort) {
+    this.#attemptTerminated = false
     this.#statusCode = 0
     this.#headers = null
     this.#body = null
@@ -485,6 +492,11 @@ class Handler extends DecoratorHandler {
   }
 
   onComplete(trailers) {
+    if (this.#attemptTerminated) {
+      return
+    }
+    this.#attemptTerminated = true
+    this.#terminalCount++
     this.#trailers = trailers
 
     if (this.#statusCode < 400) {
@@ -501,6 +513,11 @@ class Handler extends DecoratorHandler {
   }
 
   onError(err) {
+    if (this.#attemptTerminated) {
+      return
+    }
+    this.#attemptTerminated = true
+    this.#terminalCount++
     this.#maybeRetry(err)
   }
 
@@ -879,14 +896,18 @@ export default () => (dispatch) => (opts, handler) => {
   }
 
   const retryHandler = new Handler(opts, { handler, dispatch })
+  const terminalCount = retryHandler.terminalCount
   const result = dispatch(opts, retryHandler)
-  if (result != null && typeof result.then === 'function') {
+  if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
     // Callback-style dispatchers normally report failures through onError,
-    // but a directly composed async dispatcher can reject instead. Observe
-    // the original Promise without replacing the dispatch return contract.
+    // but a directly composed async dispatcher can reject instead. Assimilate
+    // possible thenables without reading `.then` directly (the getter itself
+    // may throw), while preserving the original dispatch return contract.
     Promise.resolve(result).catch((err) => {
       try {
-        retryHandler.onError(err)
+        if (retryHandler.terminalCount === terminalCount) {
+          retryHandler.onError(err)
+        }
       } catch {
         // A downstream onError hook must not turn this detached observer into
         // a second, unhandled rejection.

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -868,10 +868,30 @@ class Handler extends DecoratorHandler {
   }
 }
 
-export default () => (dispatch) => (opts, handler) =>
-  opts.retry !== false &&
-  !opts.upgrade &&
-  (/^(HEAD|GET|PUT|PATCH|QUERY)$/.test(opts.method) || opts.idempotent) &&
-  opts.idempotent !== false
-    ? dispatch(opts, new Handler(opts, { handler, dispatch }))
-    : dispatch(opts, handler)
+export default () => (dispatch) => (opts, handler) => {
+  if (
+    opts.retry === false ||
+    opts.upgrade ||
+    (!/^(HEAD|GET|PUT|PATCH|QUERY)$/.test(opts.method) && !opts.idempotent) ||
+    opts.idempotent === false
+  ) {
+    return dispatch(opts, handler)
+  }
+
+  const retryHandler = new Handler(opts, { handler, dispatch })
+  const result = dispatch(opts, retryHandler)
+  if (result != null && typeof result.then === 'function') {
+    // Callback-style dispatchers normally report failures through onError,
+    // but a directly composed async dispatcher can reject instead. Observe
+    // the original Promise without replacing the dispatch return contract.
+    Promise.resolve(result).catch((err) => {
+      try {
+        retryHandler.onError(err)
+      } catch {
+        // A downstream onError hook must not turn this detached observer into
+        // a second, unhandled rejection.
+      }
+    })
+  }
+  return result
+}

--- a/test/retry-initial-async-rejection.js
+++ b/test/retry-initial-async-rejection.js
@@ -34,30 +34,84 @@ test('initial dispatch Promise rejection reaches onError without becoming unhand
   t.same(unhandled, [], 'the rejected dispatch Promise was observed')
 })
 
-test('a rejected result does not duplicate an error already reported by the dispatcher', async (t) => {
-  const reason = new Error('duplicate async dispatch failure')
-  const errors = []
+test('a rejected result does not duplicate a retry already started by onError', async (t) => {
+  const reason = Object.assign(new Error('duplicate async dispatch failure'), {
+    code: 'ECONNRESET',
+  })
   const unhandled = []
   const onUnhandledRejection = (err) => unhandled.push(err)
   process.on('unhandledRejection', onUnhandledRejection)
   t.teardown(() => process.removeListener('unhandledRejection', onUnhandledRejection))
 
+  const completed = Promise.withResolvers()
+  let attempts = 0
+  let statusCode
   const dispatch = responseRetry()((dispatchOpts, handler) => {
-    handler.onError(reason)
-    return Promise.reject(reason)
+    attempts++
+    handler.onConnect(() => {})
+    if (attempts === 1) {
+      handler.onError(reason)
+      return Promise.reject(reason)
+    }
+
+    handler.onHeaders(200, { 'content-length': '2' }, () => {})
+    handler.onData(Buffer.from('ok'))
+    handler.onComplete({})
   })
   dispatch(
-    { ...opts, retry: 0 },
+    { ...opts, retry: { count: 1, maxDelay: 0 } },
     {
-      onError(err) {
-        errors.push(err)
+      onConnect() {},
+      onHeaders(value) {
+        statusCode = value
+        return true
       },
+      onData() {
+        return true
+      },
+      onComplete() {
+        completed.resolve()
+      },
+      onError: completed.reject,
     },
   )
 
+  await completed.promise
   await tick()
   await tick()
 
-  t.same(errors, [reason], 'downstream receives one terminal error')
+  t.equal(attempts, 2, 'one initial attempt and one retry')
+  t.equal(statusCode, 200)
   t.same(unhandled, [], 'the redundant rejected Promise was still observed')
+})
+
+test('a throwing then getter is observed without changing the return value', async (t) => {
+  const reason = new Error('then getter failed')
+  const unhandled = []
+  const errors = []
+  let thenReads = 0
+  const onUnhandledRejection = (err) => unhandled.push(err)
+  process.on('unhandledRejection', onUnhandledRejection)
+  t.teardown(() => process.removeListener('unhandledRejection', onUnhandledRejection))
+
+  const thenable = Object.defineProperty({}, 'then', {
+    get() {
+      thenReads++
+      throw reason
+    },
+  })
+  const dispatch = responseRetry()(() => thenable)
+  const result = dispatch(opts, {
+    onError(err) {
+      errors.push(err)
+    },
+  })
+
+  t.equal(result, thenable)
+  await tick()
+  await tick()
+
+  t.equal(thenReads, 1)
+  t.same(errors, [reason])
+  t.same(unhandled, [])
 })

--- a/test/retry-initial-async-rejection.js
+++ b/test/retry-initial-async-rejection.js
@@ -34,6 +34,48 @@ test('initial dispatch Promise rejection reaches onError without becoming unhand
   t.same(unhandled, [], 'the rejected dispatch Promise was observed')
 })
 
+test('Promise rejections from later attempts consume the remaining retry budget', async (t) => {
+  const reason = Object.assign(new Error('async dispatch failed'), { code: 'ECONNRESET' })
+  const completed = Promise.withResolvers()
+  const errors = []
+  let attempts = 0
+
+  const dispatch = responseRetry()((dispatchOpts, handler) => {
+    attempts++
+    if (attempts < 3) {
+      return Promise.reject(reason)
+    }
+
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'content-length': '2' }, () => {})
+    handler.onData(Buffer.from('ok'))
+    handler.onComplete({})
+  })
+  dispatch(
+    { ...opts, retry: { count: 2, maxDelay: 0 } },
+    {
+      onConnect() {},
+      onHeaders() {
+        return true
+      },
+      onData() {
+        return true
+      },
+      onComplete: completed.resolve,
+      onError(err) {
+        errors.push(err)
+        completed.resolve()
+      },
+    },
+  )
+
+  await completed.promise
+  await tick()
+
+  t.equal(attempts, 3, 'both rejected attempts were retried')
+  t.same(errors, [], 'the successful final attempt completed normally')
+})
+
 test('a rejected result does not duplicate a retry already started by onError', async (t) => {
   const reason = Object.assign(new Error('duplicate async dispatch failure'), {
     code: 'ECONNRESET',
@@ -50,6 +92,9 @@ test('a rejected result does not duplicate a retry already started by onError', 
     attempts++
     handler.onConnect(() => {})
     if (attempts === 1) {
+      return Promise.reject(reason)
+    }
+    if (attempts === 2) {
       handler.onError(reason)
       return Promise.reject(reason)
     }
@@ -59,7 +104,7 @@ test('a rejected result does not duplicate a retry already started by onError', 
     handler.onComplete({})
   })
   dispatch(
-    { ...opts, retry: { count: 1, maxDelay: 0 } },
+    { ...opts, retry: { count: 2, maxDelay: 0 } },
     {
       onConnect() {},
       onHeaders(value) {
@@ -80,7 +125,7 @@ test('a rejected result does not duplicate a retry already started by onError', 
   await tick()
   await tick()
 
-  t.equal(attempts, 2, 'one initial attempt and one retry')
+  t.equal(attempts, 3, 'the dual terminal signal started only one additional retry')
   t.equal(statusCode, 200)
   t.same(unhandled, [], 'the redundant rejected Promise was still observed')
 })

--- a/test/retry-initial-async-rejection.js
+++ b/test/retry-initial-async-rejection.js
@@ -1,0 +1,63 @@
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import responseRetry from '../lib/interceptor/response-retry.js'
+
+const opts = {
+  origin: 'http://example.test',
+  path: '/',
+  method: 'GET',
+  headers: {},
+  retry: true,
+}
+
+test('initial dispatch Promise rejection reaches onError without becoming unhandled', async (t) => {
+  const reason = new Error('initial async dispatch failed')
+  const unhandled = []
+  const errors = []
+  const onUnhandledRejection = (err) => unhandled.push(err)
+  process.on('unhandledRejection', onUnhandledRejection)
+  t.teardown(() => process.removeListener('unhandledRejection', onUnhandledRejection))
+
+  const dispatchResult = Promise.reject(reason)
+  const dispatch = responseRetry()(() => dispatchResult)
+  const result = dispatch(opts, {
+    onError(err) {
+      errors.push(err)
+    },
+  })
+
+  t.equal(result, dispatchResult, 'preserves the original dispatch return value')
+  await tick()
+  await tick()
+
+  t.same(errors, [reason], 'delivers the rejection through the handler exactly once')
+  t.same(unhandled, [], 'the rejected dispatch Promise was observed')
+})
+
+test('a rejected result does not duplicate an error already reported by the dispatcher', async (t) => {
+  const reason = new Error('duplicate async dispatch failure')
+  const errors = []
+  const unhandled = []
+  const onUnhandledRejection = (err) => unhandled.push(err)
+  process.on('unhandledRejection', onUnhandledRejection)
+  t.teardown(() => process.removeListener('unhandledRejection', onUnhandledRejection))
+
+  const dispatch = responseRetry()((dispatchOpts, handler) => {
+    handler.onError(reason)
+    return Promise.reject(reason)
+  })
+  dispatch(
+    { ...opts, retry: 0 },
+    {
+      onError(err) {
+        errors.push(err)
+      },
+    },
+  )
+
+  await tick()
+  await tick()
+
+  t.same(errors, [reason], 'downstream receives one terminal error')
+  t.same(unhandled, [], 'the redundant rejected Promise was still observed')
+})


### PR DESCRIPTION
## Summary

- observe Promise and generic thenable rejections from every response-retry dispatch attempt
- route async rejection through the retry handler normal `onError` path so retryable failures consume the configured budget
- preserve the original initial-dispatch return value and synchronous-throw behavior
- make terminal callbacks idempotent per attempt, preventing duplicate retries when a dispatcher both calls `onError` and rejects
- safely assimilate throwing `then` getters without reading `.then` directly
- add once-only and multi-attempt regressions

## Root cause

The first dispatch result was returned without an observer, so a directly composed async dispatcher could produce an unhandled rejection. Later retry dispatches were adopted by the interceptor internal Promise chain, but their rejection went to the generic terminal-error catch instead of the normal retry path. A dispatcher that both emitted a terminal callback and rejected could also signal the same attempt twice.

## Validation

- retry-related suite: 333 assertions passed; 1 existing skip
- focused async-rejection suite: 12 assertions passed
- ESLint
- Prettier
- `git diff --check`
