### PR TITLE
fix(trace): snapshot request metadata

### DIFF
--- a/lib/interceptor/log.js
+++ b/lib/interceptor/log.js
@@ -233,7 +233,9 @@ class Handler extends DecoratorHandler {
   // when tracing is off. Logging and tracing are independently optional; the
   // dispatch entry only constructs this handler when at least one is active.
   #write
-  #traceUrl
+  // Correlation fields must be identical in the start/end pair. Capture them
+  // before the inner pipeline can mutate the live dispatch options.
+  #traceRequest
   #upgraded = false
 
   #abort
@@ -248,24 +250,22 @@ class Handler extends DecoratorHandler {
     end: -1,
   }
 
-  #opts
   #statusCode
   #headers
 
   constructor(write, logOpts, opts, { handler }) {
     super(handler)
 
-    this.#opts = opts
     this.#write = write
 
     if (write !== null) {
-      this.#traceUrl = traceUrl(opts)
+      this.#traceRequest = {
+        id: opts.id ?? null,
+        method: opts.method ?? null,
+        url: traceUrl(opts),
+      }
 
-      traceSafe(
-        write,
-        { phase: 'start', id: opts.id ?? null, method: opts.method ?? null, url: this.#traceUrl },
-        'undici:request',
-      )
+      traceSafe(write, { phase: 'start', ...this.#traceRequest }, 'undici:request')
     }
 
     if (opts.logger) {
@@ -441,9 +441,7 @@ class Handler extends DecoratorHandler {
           this.#write,
           {
             phase: 'end',
-            id: this.#opts.id ?? null,
-            method: this.#opts.method ?? null,
-            url: this.#traceUrl,
+            ...this.#traceRequest,
             statusCode: this.#statusCode ?? null,
             durationMs: Math.round(performance.now() - this.#created),
             bytes: this.#upgraded ? null : this.#pos,

--- a/test/trace.js
+++ b/test/trace.js
@@ -77,6 +77,58 @@ test('trace: start/end pair with correct shape', async (t) => {
   t.equal(end.err, null)
 })
 
+test('trace: start/end metadata stays paired when dispatch options mutate', async (t) => {
+  const { interceptors } = await import('../lib/index.js')
+
+  const writer = makeWriter()
+  const opts = {
+    id: 'req-original',
+    method: 'GET',
+    origin: 'http://original.test',
+    path: '/before',
+    trace: writer,
+  }
+  const dispatch = interceptors.log()((innerOpts, handler) => {
+    handler.onConnect(() => {})
+
+    innerOpts.id = 'req-mutated'
+    innerOpts.method = 'POST'
+    innerOpts.origin = 'http://mutated.test'
+    innerOpts.path = '/after'
+
+    handler.onHeaders(204, {}, () => {})
+    handler.onComplete({})
+  })
+
+  dispatch(opts, {
+    onConnect() {},
+    onHeaders() {
+      return true
+    },
+    onComplete() {},
+  })
+
+  t.equal(opts.id, 'req-mutated', 'the inner dispatcher mutated the live options')
+  t.strictSame(
+    writer.docs.map(({ phase, id, method, url }) => ({ phase, id, method, url })),
+    [
+      {
+        phase: 'start',
+        id: 'req-original',
+        method: 'GET',
+        url: 'http://original.test/before',
+      },
+      {
+        phase: 'end',
+        id: 'req-original',
+        method: 'GET',
+        url: 'http://original.test/before',
+      },
+    ],
+    'the pair keeps one correlation identity',
+  )
+})
+
 // ---------------------------------------------------------------------------
 // url is bounded to 256 characters
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- capture request trace `id`, `method`, and bounded URL once before entering the mutable interceptor/dispatcher pipeline
- reuse that immutable correlation snapshot for both `undici:request` start and end documents
- stop retaining the full mutable dispatch options object solely for terminal trace emission
- add a regression proving an inner dispatcher can mutate live options without splitting the start/end pair

## Root cause and impact

The start document read `id` and `method` during handler construction, but the end document reread them from the live options object. A dispatcher, retry strategy, or follow callback could mutate that object in between, causing the end document to use a different request ID/method and become orphaned from its start document. This affects trace correlation and derived latency/error metrics; request behavior is unchanged.

## Validation

- 14 trace/log lifecycle suites: 551 assertions passed
- ESLint
- Prettier check
- `git diff --check`