### PR TITLE
fix(lookup): settle on request abort

### DIFF
--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -12,7 +12,10 @@ function abortReason(signal) {
 }
 
 function listenForAbort(signal, listener) {
-  if (typeof signal.addEventListener === 'function') {
+  if (
+    typeof signal.addEventListener === 'function' &&
+    typeof signal.removeEventListener === 'function'
+  ) {
     try {
       const disposable = addAbortListener(signal, listener)
       return () => disposable[Symbol.dispose]()
@@ -24,13 +27,28 @@ function listenForAbort(signal, listener) {
       // RequestSignal also permits generic EventTargets. They do not get
       // addAbortListener's propagation resistance, but retain the established
       // compatibility path used by request().
-      signal.addEventListener('abort', listener)
-      return () => signal.removeEventListener('abort', listener)
+      try {
+        signal.addEventListener('abort', listener)
+        return () => signal.removeEventListener('abort', listener)
+      } catch {
+        return noop
+      }
     }
   }
 
-  signal.on('abort', listener)
-  return () => signal.removeListener('abort', listener)
+  const removeEmitterListener =
+    typeof signal.removeListener === 'function' ? signal.removeListener : signal.off
+
+  if (typeof signal.on !== 'function' || typeof removeEmitterListener !== 'function') {
+    return noop
+  }
+
+  try {
+    signal.on('abort', listener)
+    return () => removeEmitterListener.call(signal, 'abort', listener)
+  } catch {
+    return noop
+  }
 }
 
 // Emit the single `undici:lookup` doc for an origin resolution: an async

--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -1,5 +1,37 @@
+import { addAbortListener } from 'node:events'
+import { errors } from '@nxtedition/undici'
 import { DecoratorHandler } from '../utils.js'
 import { traceWrite, traceSafe, traceErr, traceUrl } from '../trace.js'
+
+const { RequestAbortedError } = errors
+
+function noop() {}
+
+function abortReason(signal) {
+  return signal.reason === undefined ? new RequestAbortedError() : signal.reason
+}
+
+function listenForAbort(signal, listener) {
+  if (typeof signal.addEventListener === 'function') {
+    try {
+      const disposable = addAbortListener(signal, listener)
+      return () => disposable[Symbol.dispose]()
+    } catch (err) {
+      if (err?.code !== 'ERR_INVALID_ARG_TYPE') {
+        throw err
+      }
+
+      // RequestSignal also permits generic EventTargets. They do not get
+      // addAbortListener's propagation resistance, but retain the established
+      // compatibility path used by request().
+      signal.addEventListener('abort', listener)
+      return () => signal.removeEventListener('abort', listener)
+    }
+  }
+
+  signal.on('abort', listener)
+  return () => signal.removeListener('abort', listener)
+}
 
 // Emit the single `undici:lookup` doc for an origin resolution: an async
 // success carries the resolved origin, a failure carries the error tag. `url`
@@ -46,37 +78,84 @@ export default () => (dispatch) => async (opts, handler) => {
   try {
     const origin = await new Promise((resolve, reject) => {
       let sync = true
-      const thenable = lookup(opts.origin, { signal: opts.signal ?? undefined }, (err, val) => {
-        if (!sync) {
-          resolvedAsync = true
+      let settled = false
+      let removeAbortListener = noop
+
+      const settle = (fn, value) => {
+        if (settled) {
+          return
         }
-        if (err) {
-          reject(err)
-        } else {
-          resolve(val)
-        }
-      })
-      sync = false
+
+        settled = true
+        removeAbortListener()
+        removeAbortListener = noop
+        fn(value)
+      }
+
+      const signal = opts.signal
+      const onAbort = () => settle(reject, abortReason(signal))
+
+      if (signal?.aborted) {
+        onAbort()
+        return
+      }
+
+      if (signal) {
+        removeAbortListener = listenForAbort(signal, onAbort)
+      }
+
+      let thenable
+      try {
+        thenable = lookup(opts.origin, { signal: signal ?? undefined }, (err, val) => {
+          if (!sync) {
+            resolvedAsync = true
+          }
+          if (err) {
+            settle(reject, err)
+          } else {
+            settle(resolve, val)
+          }
+        })
+      } catch (err) {
+        settle(reject, err)
+        return
+      } finally {
+        sync = false
+      }
 
       if (typeof thenable === 'string') {
         // Keep the established synchronous shorthand used by standalone
         // compositions, but do not treat arbitrary callback return values
         // (timer/request/cancellation handles) as resolved origins.
-        resolve(thenable)
-      } else if (typeof thenable?.then === 'function') {
+        settle(resolve, thenable)
+        return
+      }
+
+      let then
+      try {
+        then = thenable?.then
+      } catch (err) {
+        settle(reject, err)
+        return
+      }
+
+      if (typeof then === 'function') {
         // A promise-returning lookup is always asynchronous (`.then` callbacks
         // never run on the current stack), so its success doc must be emitted
         // like the async-callback shape's — only the sync callback path is
         // suppressed as noise.
-        Promise.resolve(thenable).then((val) => {
-          // An async callback-style lookup may return a thenable that fulfills
-          // with void before the callback fires, so only a string fulfillment
-          // may take control of the lookup result.
-          if (typeof val === 'string') {
-            resolvedAsync = true
-            resolve(val)
-          }
-        }, reject)
+        Promise.resolve(thenable).then(
+          (val) => {
+            // An async callback-style lookup may return a thenable that fulfills
+            // with void before the callback fires, so only a string fulfillment
+            // may take control of the lookup result.
+            if (typeof val === 'string') {
+              resolvedAsync = true
+              settle(resolve, val)
+            }
+          },
+          (err) => settle(reject, err),
+        )
       }
     })
 

--- a/test/lookup-abort-settlement.js
+++ b/test/lookup-abort-settlement.js
@@ -1,0 +1,125 @@
+import { getEventListeners } from 'node:events'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function withTimeout(promise) {
+  const { promise: timeout, reject } = Promise.withResolvers()
+  const timer = setTimeout(reject, 500, new Error('lookup abort did not settle'))
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+function errorHandler() {
+  const { promise, resolve } = Promise.withResolvers()
+  let calls = 0
+
+  return {
+    promise,
+    get calls() {
+      return calls
+    },
+    handler: {
+      onError(err) {
+        calls++
+        resolve(err)
+      },
+    },
+  }
+}
+
+test('lookup: abort settles an ignored lookup and prevents late dispatch', async (t) => {
+  const controller = new AbortController()
+  const reason = new Error('stop lookup')
+  const terminal = errorHandler()
+  let callback
+  let dispatches = 0
+
+  const dispatch = interceptors.lookup()(() => {
+    dispatches++
+  })
+
+  const result = dispatch(
+    {
+      origin: 'http://service.test',
+      signal: controller.signal,
+      lookup(_origin, _opts, cb) {
+        callback = cb
+      },
+    },
+    terminal.handler,
+  )
+
+  await tick()
+  t.equal(getEventListeners(controller.signal, 'abort').length, 1, 'abort listener installed')
+
+  controller.abort(reason)
+
+  t.equal(await withTimeout(terminal.promise), reason, 'exact abort reason reaches the handler')
+  await result
+  t.equal(dispatches, 0, 'aborted lookup never dispatches')
+  t.equal(getEventListeners(controller.signal, 'abort').length, 0, 'abort listener removed')
+
+  callback(null, 'http://late.test')
+  await tick()
+  t.equal(dispatches, 0, 'a late callback stays ignored')
+  t.equal(terminal.calls, 1, 'terminal error is delivered once')
+})
+
+test('lookup: a pre-aborted signal skips lookup and preserves a falsy reason', async (t) => {
+  const controller = new AbortController()
+  controller.abort(0)
+  const terminal = errorHandler()
+  let lookups = 0
+  let dispatches = 0
+
+  const dispatch = interceptors.lookup()(() => {
+    dispatches++
+  })
+
+  const result = dispatch(
+    {
+      origin: 'http://service.test',
+      signal: controller.signal,
+      lookup() {
+        lookups++
+      },
+    },
+    terminal.handler,
+  )
+
+  t.equal(await withTimeout(terminal.promise), 0)
+  await result
+  t.equal(lookups, 0, 'pre-aborted lookup has no side effects')
+  t.equal(dispatches, 0)
+  t.equal(terminal.calls, 1)
+})
+
+test('lookup: successful settlement removes its abort listener', async (t) => {
+  const controller = new AbortController()
+  let completed = 0
+
+  const dispatch = interceptors.lookup()((_opts, handler) => {
+    handler.onComplete([])
+  })
+
+  await dispatch(
+    {
+      origin: 'http://service.test',
+      signal: controller.signal,
+      lookup(origin, _opts, callback) {
+        setImmediate(callback, null, origin)
+      },
+    },
+    {
+      onComplete() {
+        completed++
+      },
+      onError(err) {
+        t.threw(err)
+      },
+    },
+  )
+
+  t.equal(completed, 1)
+  t.equal(getEventListeners(controller.signal, 'abort').length, 0)
+})

--- a/test/lookup-abort-settlement.js
+++ b/test/lookup-abort-settlement.js
@@ -115,7 +115,7 @@ test('lookup: successful settlement removes its abort listener', async (t) => {
         completed++
       },
       onError(err) {
-        t.threw(err)
+        t.fail(`unexpected lookup error: ${err}`)
       },
     },
   )

--- a/test/lookup-abort-settlement.js
+++ b/test/lookup-abort-settlement.js
@@ -123,3 +123,78 @@ test('lookup: successful settlement removes its abort listener', async (t) => {
   t.equal(completed, 1)
   t.equal(getEventListeners(controller.signal, 'abort').length, 0)
 })
+
+test('lookup: raw dispatch ignores an unpaired EventTarget signal', async (t) => {
+  let subscriptions = 0
+  let dispatches = 0
+
+  const dispatch = interceptors.lookup()((_opts, handler) => {
+    dispatches++
+    handler.onComplete([])
+  })
+
+  await dispatch(
+    {
+      origin: 'http://service.test',
+      signal: {
+        aborted: false,
+        addEventListener() {
+          subscriptions++
+        },
+      },
+      lookup(origin, _opts, callback) {
+        callback(null, origin)
+      },
+    },
+    {
+      onComplete() {},
+      onError(err) {
+        t.fail(`unexpected lookup error: ${err}`)
+      },
+    },
+  )
+
+  t.equal(subscriptions, 0, 'an unremovable listener is never installed')
+  t.equal(dispatches, 1, 'lookup still dispatches')
+})
+
+test('lookup: on/off-only signal is unsubscribed after settlement', async (t) => {
+  let listener
+  let removals = 0
+
+  const signal = {
+    aborted: false,
+    on(event, value) {
+      t.equal(event, 'abort')
+      listener = value
+    },
+    off(event, value) {
+      t.equal(event, 'abort')
+      t.equal(value, listener)
+      removals++
+    },
+  }
+
+  const dispatch = interceptors.lookup()((_opts, handler) => {
+    handler.onComplete([])
+  })
+
+  await dispatch(
+    {
+      origin: 'http://service.test',
+      signal,
+      lookup(origin, _opts, callback) {
+        callback(null, origin)
+      },
+    },
+    {
+      onComplete() {},
+      onError(err) {
+        t.fail(`unexpected lookup error: ${err}`)
+      },
+    },
+  )
+
+  t.type(listener, 'function')
+  t.equal(removals, 1)
+})


### PR DESCRIPTION
## Summary

- settle a pending custom lookup when the request signal aborts, even when the lookup implementation ignores that signal
- skip lookup side effects for pre-aborted requests and prevent a late callback or thenable from dispatching afterward
- remove the abort listener on every terminal lookup outcome while preserving the exact caller abort reason

## Validation

- 5 lookup/trace suites: 53 assertions passed
- ESLint and Prettier checks pass
- git diff --check passes