### PR TITLE
refactor(pressure): rely on Node timer API

### DIFF
--- a/lib/interceptor/pressure.js
+++ b/lib/interceptor/pressure.js
@@ -280,7 +280,7 @@ class PressureMonitor {
       this.#timer = setInterval(() => this.#tick(), this.#sampleInterval)
       // Never keep the event loop alive just to sample — the producer's own
       // activity is what matters.
-      this.#timer.unref?.()
+      this.#timer.unref()
     }
   }
 


### PR DESCRIPTION
## Summary

- call Timeout.unref directly for the pressure sampling interval
- remove the obsolete optional feature check now that the package targets Node 26

## Validation

- 7 pressure/trace suites: 151 assertions passed
- ESLint and Prettier checks pass
- git diff --check passes