### PR TITLE
fix(url): validate URL object authorities

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import {
   buildAuthority,
   createNormalizedHeaders,
   invalidateNormalizedHeaders,
+  isHttpProtocol,
   parseHeaders,
 } from './utils.js'
 import { request as _request } from './request.js'
@@ -47,7 +48,10 @@ function defaultLookup(origin, opts, callback) {
     // Note: not `else if` — an array element may itself be an object that
     // still needs normalizing to an origin string.
     if (origin != null && typeof origin === 'object') {
-      const protocol = origin.protocol || 'http:'
+      const protocol = origin.protocol ?? 'http:'
+      if (!isHttpProtocol(protocol)) {
+        throw new Error('invalid url')
+      }
 
       let host = origin.host
       if (!host && origin.hostname) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import {
   invalidateNormalizedHeaders,
   isHttpProtocol,
   parseHeaders,
+  validateAuthority,
 } from './utils.js'
 import { request as _request } from './request.js'
 import { SqliteCacheStore } from './sqlite-cache-store.js'
@@ -54,6 +55,9 @@ function defaultLookup(origin, opts, callback) {
       }
 
       let host = origin.host
+      if (host) {
+        host = validateAuthority(protocol, host)
+      }
       if (!host && origin.hostname) {
         host = buildAuthority(protocol, origin.hostname, origin.port)
       }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { addAbortListener } from 'node:events'
 import { errors, Readable } from '@nxtedition/undici'
-import { buildAuthority, isStream } from './utils.js'
+import { buildAuthority, isHttpProtocol, isStream } from './utils.js'
 
 const { InvalidArgumentError, RequestAbortedError } = errors
 
@@ -209,6 +209,9 @@ export function request(dispatch, urlOrOpts, optsOrNully) {
   let origin = url.origin
   if (!origin) {
     const protocol = url.protocol ?? 'http:'
+    if (!isHttpProtocol(protocol)) {
+      throw new InvalidArgumentError('invalid url')
+    }
     const host =
       url.host || (url.hostname ? buildAuthority(protocol, url.hostname, url.port) : null)
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { addAbortListener } from 'node:events'
 import { errors, Readable } from '@nxtedition/undici'
-import { buildAuthority, isHttpProtocol, isStream } from './utils.js'
+import { buildAuthority, isHttpProtocol, isStream, validateAuthority } from './utils.js'
 
 const { InvalidArgumentError, RequestAbortedError } = errors
 
@@ -212,8 +212,16 @@ export function request(dispatch, urlOrOpts, optsOrNully) {
     if (!isHttpProtocol(protocol)) {
       throw new InvalidArgumentError('invalid url')
     }
-    const host =
-      url.host || (url.hostname ? buildAuthority(protocol, url.hostname, url.port) : null)
+    let host
+    try {
+      host = url.host
+        ? validateAuthority(protocol, url.host)
+        : url.hostname
+          ? buildAuthority(protocol, url.hostname, url.port)
+          : null
+    } catch {
+      throw new InvalidArgumentError('invalid url')
+    }
 
     if (!host || !protocol) {
       throw new InvalidArgumentError('invalid url')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -566,6 +566,10 @@ export function parseURL(url) {
     throw new Error('Invalid URL hostname: the hostname must be a string or null/undefined.')
   }
 
+  if (url.host != null && typeof url.host !== 'string') {
+    throw new Error('Invalid URL host: the host must be a string or null/undefined.')
+  }
+
   if (url.origin != null && typeof url.origin !== 'string') {
     throw new Error('Invalid URL origin: the origin must be a string or null/undefined.')
   }
@@ -579,7 +583,11 @@ export function parseURL(url) {
     const origin =
       url.origin != null
         ? url.origin
-        : `${url.protocol}//${buildAuthority(url.protocol, url.hostname, url.port)}`
+        : `${url.protocol}//${
+            url.host
+              ? validateAuthority(url.protocol, url.host)
+              : buildAuthority(url.protocol, url.hostname, url.port)
+          }`
     const path = url.path != null ? url.path : `${url.pathname || ''}${url.search || ''}`
 
     url = buildURL(origin, path)
@@ -592,10 +600,38 @@ export function isHttpProtocol(protocol) {
   return protocol === 'http:' || protocol === 'https:'
 }
 
+export function validateAuthority(protocol, authority) {
+  if (
+    !isHttpProtocol(protocol) ||
+    typeof authority !== 'string' ||
+    authority.length === 0 ||
+    /[\s@/?#\\]/u.test(authority)
+  ) {
+    throw new Error('Invalid URL authority')
+  }
+
+  let url
+  try {
+    url = new URL(`${protocol}//${authority}`)
+  } catch {
+    throw new Error('Invalid URL authority')
+  }
+
+  if (!url.host || url.username || url.password || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('Invalid URL authority')
+  }
+
+  return authority
+}
+
 export function buildAuthority(protocol, hostname, port) {
+  if (typeof hostname !== 'string' || hostname.length === 0) {
+    throw new Error('Invalid URL authority')
+  }
+
   const normalizedHostname = net.isIPv6(hostname) ? `[${hostname}]` : hostname
   const normalizedPort = port == null || port === '' ? (protocol === 'https:' ? 443 : 80) : port
-  return `${normalizedHostname}:${normalizedPort}`
+  return validateAuthority(protocol, `${normalizedHostname}:${normalizedPort}`)
 }
 
 // Build an absolute URL from an origin and a path by concatenation.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -537,7 +537,7 @@ export function parseURL(url) {
   if (typeof url === 'string') {
     url = new URL(url)
 
-    if (!/^https?:/.test(url.origin || url.protocol)) {
+    if (!isHttpProtocol(url.protocol)) {
       throw new Error('Invalid URL protocol: the URL must start with `http:` or `https:`.')
     }
 
@@ -570,7 +570,8 @@ export function parseURL(url) {
     throw new Error('Invalid URL origin: the origin must be a string or null/undefined.')
   }
 
-  if (!/^https?:/.test(url.origin || url.protocol)) {
+  const protocol = url.origin != null ? URL.parse(url.origin)?.protocol : url.protocol
+  if (!isHttpProtocol(protocol)) {
     throw new Error('Invalid URL protocol: the URL must start with `http:` or `https:`.')
   }
 
@@ -585,6 +586,10 @@ export function parseURL(url) {
   }
 
   return url
+}
+
+export function isHttpProtocol(protocol) {
+  return protocol === 'http:' || protocol === 'https:'
 }
 
 export function buildAuthority(protocol, hostname, port) {

--- a/test/url-object-protocol-validation.js
+++ b/test/url-object-protocol-validation.js
@@ -15,6 +15,22 @@ test('parseURL rejects protocol-like URL object values', (t) => {
   t.end()
 })
 
+test('parseURL validates host and hostname as authorities', (t) => {
+  t.equal(
+    parseURL({ protocol: 'http:', host: 'example.test:8080', path: '/' }).origin,
+    'http://example.test:8080',
+  )
+  t.throws(
+    () => parseURL({ protocol: 'http:', hostname: 'victim.test@attacker.test', path: '/' }),
+    /Invalid URL authority/,
+  )
+  t.throws(
+    () => parseURL({ protocol: 'http:', host: 'victim.test/path', path: '/' }),
+    /Invalid URL authority/,
+  )
+  t.end()
+})
+
 test('request rejects a malformed object protocol before dispatch', (t) => {
   let dispatches = 0
 
@@ -32,6 +48,22 @@ test('request rejects a malformed object protocol before dispatch', (t) => {
       ),
     { code: 'UND_ERR_INVALID_ARG', message: 'invalid url' },
   )
+  t.equal(dispatches, 0)
+  t.end()
+})
+
+test('request rejects authority delimiters before dispatch', (t) => {
+  let dispatches = 0
+  const inner = () => {
+    dispatches++
+  }
+
+  for (const url of [
+    { protocol: 'http:', hostname: 'victim.test@attacker.test', path: '/' },
+    { protocol: 'http:', host: 'victim.test/path', path: '/' },
+  ]) {
+    t.throws(() => request(inner, url), { code: 'UND_ERR_INVALID_ARG', message: 'invalid url' })
+  }
   t.equal(dispatches, 0)
   t.end()
 })
@@ -62,5 +94,31 @@ test('default lookup rejects a malformed object protocol before the dispatcher b
   )
 
   t.match(await error, { message: 'invalid url' })
+  t.equal(dispatches, 0)
+})
+
+test('default lookup rejects an injected object authority before dispatch', async (t) => {
+  let dispatches = 0
+  const { promise: error, resolve } = Promise.withResolvers()
+
+  await dispatch(
+    {
+      dispatch() {
+        dispatches++
+      },
+    },
+    {
+      origin: {
+        protocol: 'http:',
+        hostname: 'victim.test@attacker.test',
+      },
+      path: '/',
+      method: 'GET',
+      dns: false,
+    },
+    { onError: resolve },
+  )
+
+  t.match(await error, { message: 'Invalid URL authority' })
   t.equal(dispatches, 0)
 })

--- a/test/url-object-protocol-validation.js
+++ b/test/url-object-protocol-validation.js
@@ -1,0 +1,66 @@
+import { test } from 'tap'
+import { dispatch } from '../lib/index.js'
+import { request } from '../lib/request.js'
+import { parseURL } from '../lib/utils.js'
+
+test('parseURL rejects protocol-like URL object values', (t) => {
+  t.throws(
+    () => parseURL({ protocol: 'http:attacker.test', hostname: 'victim.test', path: '/' }),
+    /Invalid URL protocol/,
+  )
+  t.throws(
+    () => parseURL({ protocol: 'https:attacker.test', hostname: 'victim.test', path: '/' }),
+    /Invalid URL protocol/,
+  )
+  t.end()
+})
+
+test('request rejects a malformed object protocol before dispatch', (t) => {
+  let dispatches = 0
+
+  t.throws(
+    () =>
+      request(
+        () => {
+          dispatches++
+        },
+        {
+          protocol: 'http:attacker.test',
+          hostname: 'victim.test',
+          path: '/',
+        },
+      ),
+    { code: 'UND_ERR_INVALID_ARG', message: 'invalid url' },
+  )
+  t.equal(dispatches, 0)
+  t.end()
+})
+
+test('default lookup rejects a malformed object protocol before the dispatcher boundary', async (t) => {
+  let dispatches = 0
+  const dispatcher = {
+    dispatch() {
+      dispatches++
+    },
+  }
+  const { promise: error, resolve } = Promise.withResolvers()
+
+  await dispatch(
+    dispatcher,
+    {
+      origin: {
+        protocol: 'http:attacker.test',
+        hostname: 'victim.test',
+      },
+      path: '/',
+      method: 'GET',
+      dns: false,
+    },
+    {
+      onError: resolve,
+    },
+  )
+
+  t.match(await error, { message: 'invalid url' })
+  t.equal(dispatches, 0)
+})


### PR DESCRIPTION
## Summary

- require exact http: or https: protocols when normalizing URL-like objects
- validate host and hostname fields as authorities before concatenation, preventing user-info/path delimiters from changing the effective destination
- support host-only URL objects in parseURL while preserving IPv6 and explicit port-zero handling
- enforce the same boundary in request(), parseURL(), and default lookup object normalization

## Validation

- 4 request/URL utility suites: 136 assertions passed
- ESLint and Prettier checks pass
- git diff --check passes