### PR TITLE
fix(body-factory): abort while queued

### DIFF
--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -16,7 +16,10 @@ function subscribeAbort(signal, listener) {
     listener()
     return noop
   }
-  if (typeof signal.addEventListener === 'function') {
+  if (
+    typeof signal.addEventListener === 'function' &&
+    typeof signal.removeEventListener === 'function'
+  ) {
     try {
       const disposable = addAbortListener(signal, listener)
       return () => disposable[Symbol.dispose]()
@@ -29,8 +32,14 @@ function subscribeAbort(signal, listener) {
     }
   }
 
-  signal.once('abort', listener)
-  return () => signal.removeListener('abort', listener)
+  const removeEmitterListener =
+    typeof signal.removeListener === 'function' ? signal.removeListener : signal.off
+  if (typeof signal.on !== 'function' || typeof removeEmitterListener !== 'function') {
+    return noop
+  }
+
+  signal.on('abort', listener)
+  return () => removeEmitterListener.call(signal, 'abort', listener)
 }
 
 function getAbortReason(signal) {

--- a/lib/interceptor/request-body-factory.js
+++ b/lib/interceptor/request-body-factory.js
@@ -1,8 +1,41 @@
+import { addAbortListener } from 'node:events'
 import { Readable, finished } from 'node:stream'
 import { types } from 'node:util'
+import { errors } from '@nxtedition/undici'
 import { DecoratorHandler, isStream } from '../utils.js'
 
+const { RequestAbortedError } = errors
+
 function noop() {}
+
+function subscribeAbort(signal, listener) {
+  if (signal == null) {
+    return noop
+  }
+  if (signal.aborted) {
+    listener()
+    return noop
+  }
+  if (typeof signal.addEventListener === 'function') {
+    try {
+      const disposable = addAbortListener(signal, listener)
+      return () => disposable[Symbol.dispose]()
+    } catch (err) {
+      if (err?.code !== 'ERR_INVALID_ARG_TYPE') {
+        throw err
+      }
+      signal.addEventListener('abort', listener, { once: true })
+      return () => signal.removeEventListener('abort', listener)
+    }
+  }
+
+  signal.once('abort', listener)
+  return () => signal.removeListener('abort', listener)
+}
+
+function getAbortReason(signal) {
+  return signal.reason === undefined ? new RequestAbortedError() : signal.reason
+}
 
 function normalizeFactoryError(reason) {
   // Node's stream construction callback treats every falsy value as success.
@@ -17,10 +50,15 @@ class FactoryStream extends Readable {
   #body
   #removeBodyListeners = noop
   #cleanupFinished = noop
+  #removeRequestAbortListener = noop
 
-  constructor(factory) {
+  constructor(factory, requestSignal) {
     super()
     this.#factory = factory
+    this.once('end', () => this.#stopWatchingRequest())
+    this.#removeRequestAbortListener = subscribeAbort(requestSignal, () => {
+      this.destroy(getAbortReason(requestSignal))
+    })
   }
 
   _construct(callback) {
@@ -121,8 +159,14 @@ class FactoryStream extends Readable {
     // A factory waiting for its signal would therefore deadlock teardown:
     // _destroy waits for the factory while the factory waits for _destroy to
     // abort it. Abort synchronously when destroy() is requested instead.
+    this.#stopWatchingRequest()
     this.#abortFactory(err)
     return super.destroy(err)
+  }
+
+  #stopWatchingRequest() {
+    this.#removeRequestAbortListener()
+    this.#removeRequestAbortListener = noop
   }
 
   #abortFactory(err) {
@@ -192,7 +236,7 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  const body = new FactoryStream(opts.body).on('error', noop)
+  const body = new FactoryStream(opts.body, opts.signal).on('error', noop)
   try {
     const result = dispatch({ ...opts, body }, new Handler(handler, body))
     if (result != null) {

--- a/test/body-factory-queued-abort.js
+++ b/test/body-factory-queued-abort.js
@@ -96,3 +96,30 @@ test('completed factory body removes its request abort listener', async (t) => {
   t.equal(Buffer.concat(chunks).toString(), 'complete')
   t.equal(signal.listenerCount('abort'), 0, 'removes the listener when the body ends')
 })
+
+test('body factory supports EventEmitter-like signals with on/off', async (t) => {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    on(event, listener) {
+      t.equal(event, 'abort')
+      listeners.add(listener)
+    },
+    off(event, listener) {
+      t.equal(event, 'abort')
+      listeners.delete(listener)
+    },
+  }
+  let body
+  const dispatch = interceptors.requestBodyFactory()((opts) => {
+    body = opts.body
+  })
+
+  t.doesNotThrow(() => dispatch({ body: () => 'complete', signal }, {}))
+  t.equal(listeners.size, 1, 'subscribes through on()')
+
+  await body.toArray()
+
+  t.equal(listeners.size, 0, 'unsubscribes through off()')
+})

--- a/test/body-factory-queued-abort.js
+++ b/test/body-factory-queued-abort.js
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+import { request } from '../lib/request.js'
+
+test('queued request abort promptly releases its body factory', async (t) => {
+  const dispatched = []
+  let firstDispatchedResolve
+  const firstDispatched = new Promise((resolve) => {
+    firstDispatchedResolve = resolve
+  })
+  const innerDispatch = (opts, handler) => {
+    dispatched.push({ opts, handler })
+
+    if (dispatched.length === 1) {
+      firstDispatchedResolve()
+      return
+    }
+
+    handler.onConnect((reason) => {
+      queueMicrotask(() => handler.onError(reason))
+    })
+  }
+  const dispatch = compose(
+    innerDispatch,
+    interceptors.priority(),
+    interceptors.requestBodyFactory(),
+  )
+  const common = {
+    origin: 'http://queued.test',
+    path: '/',
+    priority: 'high',
+  }
+
+  const releaseReason = new Error('release occupied priority slot')
+  const firstResult = request(dispatch, { ...common, method: 'GET' }).catch((err) => err)
+  await firstDispatched
+
+  const controller = new AbortController()
+  const abortReason = new Error('abort while queued')
+  const factoryBody = new PassThrough().on('error', () => {})
+  let factorySignal
+  let factoryStartedResolve
+  const factoryStarted = new Promise((resolve) => {
+    factoryStartedResolve = resolve
+  })
+  const secondResult = request(dispatch, {
+    ...common,
+    method: 'PUT',
+    signal: controller.signal,
+    body({ signal }) {
+      factorySignal = signal
+      factoryStartedResolve()
+      return factoryBody
+    },
+  }).catch((err) => err)
+
+  await factoryStarted
+  await tick()
+  t.equal(dispatched.length, 1, 'the body factory starts while its attempt remains queued')
+
+  controller.abort(abortReason)
+  await tick()
+
+  t.equal(dispatched.length, 1, 'the queue has not drained')
+  t.equal(factorySignal.aborted, true, 'the factory signal aborts before dispatch')
+  t.equal(factorySignal.reason, abortReason, 'the exact request abort reason is preserved')
+  t.equal(factoryBody.destroyed, true, 'the factory result is released before dispatch')
+  t.equal(factoryBody.errored, abortReason, 'the result is destroyed with the abort reason')
+
+  dispatched[0].handler.onError(releaseReason)
+
+  t.equal(await firstResult, releaseReason, 'the occupying request is released')
+  t.equal(await secondResult, abortReason, 'the queued request later settles with its abort reason')
+  t.equal(dispatched.length, 2, 'the queued attempt only reaches dispatch after release')
+})
+
+test('completed factory body removes its request abort listener', async (t) => {
+  const signal = Object.assign(new EventEmitter(), { aborted: false, reason: undefined })
+  let body
+  const dispatch = interceptors.requestBodyFactory()((opts) => {
+    body = opts.body
+  })
+
+  dispatch({ body: () => 'complete', signal }, {})
+
+  t.equal(signal.listenerCount('abort'), 1, 'watches the request while the body is active')
+
+  const chunks = []
+  for await (const chunk of body) {
+    chunks.push(chunk)
+  }
+
+  t.equal(Buffer.concat(chunks).toString(), 'complete')
+  t.equal(signal.listenerCount('abort'), 0, 'removes the listener when the body ends')
+})


### PR DESCRIPTION
## Summary

- subscribe each factory-backed request body to the outer request signal
- abort pending factory work immediately even when an inner priority/dispatcher queue has not called `onConnect`
- preserve the exact caller abort reason and release factory-returned streams promptly
- remove the request-signal listener after either teardown or normal body completion

## Tests

- adds an integration regression with a blocked priority slot proving cancellation occurs before the queue drains
- adds listener-lifetime coverage for successful completion
- focused body-factory/priority matrix: 151 assertions passing
- full suite: 3,425 assertions passed; `proxy-advanced.js` timed out only in the highly parallel run and passed 49/49 when rerun alone
- ESLint, Prettier, and `git diff --check` pass