### PR TITLE
fix(verify): snapshot trace metadata

### DIFF
--- a/lib/interceptor/response-verify.js
+++ b/lib/interceptor/response-verify.js
@@ -6,20 +6,19 @@ import { traceWrite, traceSafe, traceUrl } from '../trace.js'
 // detail of a verification failure, immediately before the error is delivered.
 // The undici:request end doc already tags THAT the request failed; this doc is
 // for fingerprinting truncation vs corruption. Cold path only — every call
-// site is an already-failing branch — so the writer is resolved per emission
-// (explicit opts.trace wins, absent falls back to the global) at zero cost on
-// the per-chunk hot path. Hash values are origin-influenced strings (a
-// duplicated Content-MD5 header keeps `expected` as an array of conflicting
-// values, which String() flattens), so bound them.
-function traceVerify(opts, kind, expectedSize, actualSize, expectedHash, actualHash) {
-  const write = traceWrite(opts.trace)
-  if (write !== null) {
+// site is an already-failing branch. The handler captures writer and request
+// identity once so a retry callback mutating the live opts object cannot break
+// correlation with the undici:request start/end pair. Hash values are
+// origin-influenced strings (a duplicated Content-MD5 header keeps `expected`
+// as an array of conflicting values, which String() flattens), so bound them.
+function traceVerify(trace, kind, expectedSize, actualSize, expectedHash, actualHash) {
+  if (trace !== null) {
     traceSafe(
-      write,
+      trace.write,
       {
-        id: opts.id ?? null,
-        method: opts.method ?? null,
-        url: traceUrl(opts),
+        id: trace.id,
+        method: trace.method,
+        url: trace.url,
         kind,
         expectedSize,
         actualSize,
@@ -32,7 +31,7 @@ function traceVerify(opts, kind, expectedSize, actualSize, expectedHash, actualH
 }
 
 class Handler extends DecoratorHandler {
-  #opts
+  #trace
   #verifyOpts
   #contentMD5
   #expectedSize
@@ -43,8 +42,16 @@ class Handler extends DecoratorHandler {
   constructor(opts, { handler }) {
     super(handler)
 
-    // Retained only for failure-time trace tagging (id/method/url).
-    this.#opts = opts
+    const write = traceWrite(opts.trace)
+    this.#trace =
+      write === null
+        ? null
+        : {
+            write,
+            id: opts.id ?? null,
+            method: opts.method ?? null,
+            url: traceUrl(opts),
+          }
     this.#verifyOpts = opts.verify === true ? { hash: true, size: true } : opts.verify
   }
 
@@ -103,7 +110,7 @@ class Handler extends DecoratorHandler {
         expected: this.#expectedSize,
         actual: this.#pos,
       })
-      traceVerify(this.#opts, 'overrun', this.#expectedSize, this.#pos, null, null)
+      traceVerify(this.#trace, 'overrun', this.#expectedSize, this.#pos, null, null)
       super.onError(err)
       // Returning false only applies backpressure; the socket would stay
       // paused until bodyTimeout. Abort to release the connection now.
@@ -118,7 +125,7 @@ class Handler extends DecoratorHandler {
     const contentMD5 = this.#hasher?.digest('base64')
 
     if (this.#expectedSize != null && this.#pos !== this.#expectedSize) {
-      traceVerify(this.#opts, 'size', this.#expectedSize, this.#pos, null, null)
+      traceVerify(this.#trace, 'size', this.#expectedSize, this.#pos, null, null)
       super.onError(
         Object.assign(new Error('Response body size mismatch'), {
           expected: this.#expectedSize,
@@ -126,7 +133,7 @@ class Handler extends DecoratorHandler {
         }),
       )
     } else if (this.#contentMD5 != null && contentMD5 !== this.#contentMD5) {
-      traceVerify(this.#opts, 'hash', null, null, this.#contentMD5, contentMD5)
+      traceVerify(this.#trace, 'hash', null, null, this.#contentMD5, contentMD5)
       super.onError(
         Object.assign(new Error('Response Content-MD5 mismatch'), {
           expected: this.#contentMD5,

--- a/test/trace-verify.js
+++ b/test/trace-verify.js
@@ -2,7 +2,8 @@ import { test } from 'tap'
 import crypto from 'node:crypto'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
-import { request, Agent, interceptors } from '../lib/index.js'
+import { request, Agent, compose, interceptors } from '../lib/index.js'
+import { request as rawRequest } from '../lib/request.js'
 
 async function startServer(handler) {
   const server = createServer(handler)
@@ -183,4 +184,67 @@ test('trace-verify: overrun emits undici:verify doc with kind overrun', (t) => {
   })
 
   t.end()
+})
+
+test('trace-verify: retry callback mutations do not break request correlation', async (t) => {
+  const writer = makeWriter()
+  let attempts = 0
+
+  const dispatch = compose(
+    (_opts, handler) => {
+      handler.onConnect(() => {})
+
+      if (attempts++ === 0) {
+        handler.onError(Object.assign(new Error('retry me'), { code: 'ECONNRESET' }))
+        return
+      }
+
+      handler.onHeaders(206, { 'content-range': 'bytes 0-9/10', 'content-length': '5' }, () => {})
+      handler.onData(Buffer.from('short'))
+      handler.onComplete({})
+    },
+    interceptors.responseRetry(),
+    interceptors.responseVerify(),
+    interceptors.log(),
+  )
+
+  const { body } = await rawRequest(dispatch, {
+    id: 'req-original',
+    method: 'GET',
+    origin: 'http://original.test',
+    path: '/resource',
+    verify: { size: true },
+    trace: writer,
+    retry(_err, _count, opts) {
+      opts.id = 'req-mutated'
+      opts.method = 'PATCH'
+      opts.origin = 'http://mutated.test'
+      opts.path = '/different'
+      return true
+    },
+  })
+
+  await t.rejects(body.text(), /size mismatch/)
+  t.equal(attempts, 2)
+
+  const requestDocs = writer.docs.filter((doc) => doc.op === 'undici:request')
+  const start = requestDocs.find((doc) => doc.phase === 'start')
+  const end = requestDocs.find((doc) => doc.phase === 'end')
+  const verify = writer.docs.find((doc) => doc.op === 'undici:verify')
+
+  t.equal(requestDocs.length, 2, 'the logical request emits one trace pair')
+  t.ok(start, 'the request start trace exists')
+  t.ok(end, 'the request end trace exists')
+  t.ok(verify, 'the verification failure trace exists')
+  if (!start || !end || !verify) {
+    return
+  }
+
+  t.match(end, { id: start.id, method: start.method, url: start.url })
+  t.match(verify, {
+    id: start.id,
+    method: start.method,
+    url: start.url,
+    kind: 'size',
+  })
 })


### PR DESCRIPTION
## Summary

- stop retaining the live request options object in the response-verification handler
- capture the trace writer and `id`/`method`/bounded `url` once when the logical request starts
- keep `undici:verify` failures correlated with the immutable `undici:request` start/end pair even when a retry strategy mutates live options

## Tests

- adds a regression that mutates `id`, `method`, `origin`, and `path` in a retry callback before a later size-verification failure
- verifies request start/end and verification docs retain one correlation identity
- focused verify/retry/trace matrix: 202 assertions passing
- ESLint, Prettier, and `git diff --check` pass