### PR TITLE
fix(redirect): preserve trace provenance

### DIFF
--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -112,17 +112,12 @@ class Handler extends DecoratorHandler {
     this.#history.push(this.#location)
     this.#count += 1
 
-    // Capture the response's source before the user follow callback receives
-    // and may mutate the live opts object. The writer and logical request id
-    // are captured once on the first redirect so every doc remains correlated
-    // with the undici:request start/end pair, without moving trace work onto
-    // followed requests that complete without redirecting.
-    if (this.#trace === undefined) {
-      const write = traceWrite(this.#opts.trace)
-      this.#trace = write === null ? null : { write, id: this.#opts.id ?? null }
-    }
-    const trace = this.#trace
-    const from = trace !== null ? traceUrl(this.#opts) : null
+    // Snapshot provenance before the user follow callback receives and may
+    // mutate the live opts object. Resolve the writer only after the policy
+    // accepts the redirect so a veto does not read an otherwise-unused trace
+    // getter or cache trace state.
+    const traceId = this.#trace?.id ?? this.#opts.id ?? null
+    const traceSource = { origin: this.#opts.origin, path: this.#opts.path }
 
     if (typeof this.#opts.follow === 'function') {
       // follow() receives the live opts object and may mutate headers. Remove
@@ -156,6 +151,17 @@ class Handler extends DecoratorHandler {
     ) {
       throw new Error(`Disturbed request cannot be redirected.`)
     }
+
+    // Capture the writer and logical request id once on the first followed
+    // redirect so every doc remains correlated with the undici:request
+    // start/end pair. Keep this after both policy and replayability checks:
+    // rejected redirects must not resolve trace state.
+    if (this.#trace === undefined) {
+      const write = traceWrite(this.#opts.trace)
+      this.#trace = write === null ? null : { write, id: traceId }
+    }
+    const trace = this.#trace
+    const from = trace !== null ? traceUrl(traceSource) : null
 
     // Build the base URL by concatenating origin + path via buildURL rather
     // than `new URL(path, origin)`: the latter is unsafe when `path` is

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -51,8 +51,6 @@ class Handler extends DecoratorHandler {
 
     this.#dispatch = dispatch
     this.#opts = opts
-    const write = traceWrite(opts.trace)
-    this.#trace = write === null ? null : { write, id: opts.id ?? null }
     // `follow: true` means "follow redirects" — map it to the project default
     // cap rather than letting `true.count ?? 0` collapse to 0, which would
     // reject the very first redirect with "Max redirections reached: 0".
@@ -116,8 +114,13 @@ class Handler extends DecoratorHandler {
 
     // Capture the response's source before the user follow callback receives
     // and may mutate the live opts object. The writer and logical request id
-    // were captured once in the constructor so every redirect doc remains
-    // correlated with the undici:request start/end pair.
+    // are captured once on the first redirect so every doc remains correlated
+    // with the undici:request start/end pair, without moving trace work onto
+    // followed requests that complete without redirecting.
+    if (this.#trace === undefined) {
+      const write = traceWrite(this.#opts.trace)
+      this.#trace = write === null ? null : { write, id: this.#opts.id ?? null }
+    }
     const trace = this.#trace
     const from = trace !== null ? traceUrl(this.#opts) : null
 

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -35,6 +35,7 @@ function isOneShotIterable(body) {
 class Handler extends DecoratorHandler {
   #dispatch
   #opts
+  #trace
   #maxCount
 
   #abort
@@ -50,6 +51,8 @@ class Handler extends DecoratorHandler {
 
     this.#dispatch = dispatch
     this.#opts = opts
+    const write = traceWrite(opts.trace)
+    this.#trace = write === null ? null : { write, id: opts.id ?? null }
     // `follow: true` means "follow redirects" — map it to the project default
     // cap rather than letting `true.count ?? 0` collapse to 0, which would
     // reject the very first redirect with "Max redirections reached: 0".
@@ -111,6 +114,13 @@ class Handler extends DecoratorHandler {
     this.#history.push(this.#location)
     this.#count += 1
 
+    // Capture the response's source before the user follow callback receives
+    // and may mutate the live opts object. The writer and logical request id
+    // were captured once in the constructor so every redirect doc remains
+    // correlated with the undici:request start/end pair.
+    const trace = this.#trace
+    const from = trace !== null ? traceUrl(this.#opts) : null
+
     if (typeof this.#opts.follow === 'function') {
       // follow() receives the live opts object and may mutate headers. Remove
       // trust before invoking it so the next parseHeaders() call validates any
@@ -143,13 +153,6 @@ class Handler extends DecoratorHandler {
     ) {
       throw new Error(`Disturbed request cannot be redirected.`)
     }
-
-    // The redirect decision is final past this point, so trace work stays off
-    // the non-redirect path entirely. Resolve the writer per emission (trace
-    // survives the opts spread across hops) and capture `from` before #opts
-    // is rebuilt below.
-    const write = traceWrite(this.#opts.trace)
-    const from = write !== null ? traceUrl(this.#opts) : null
 
     // Build the base URL by concatenating origin + path via buildURL rather
     // than `new URL(path, origin)`: the latter is unsafe when `path` is
@@ -187,11 +190,11 @@ class Handler extends DecoratorHandler {
       }
     }
 
-    if (write !== null) {
+    if (trace !== null) {
       traceSafe(
-        write,
+        trace.write,
         {
-          id: this.#opts.id ?? null,
+          id: trace.id,
           // Post-rewrite method for the next hop (303 may have swapped it above).
           method: this.#opts.method ?? null,
           statusCode,

--- a/test/trace-redirect-metadata-snapshot.js
+++ b/test/trace-redirect-metadata-snapshot.js
@@ -103,3 +103,49 @@ test('non-redirect responses do not resolve redirect trace state', (t) => {
   t.equal(traceReads, 0)
   t.end()
 })
+
+test('follow veto does not resolve redirect trace state', (t) => {
+  let traceReads = 0
+  let followCalls = 0
+  let receivedStatus
+  let completed = false
+  const dispatch = interceptors.redirect()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(302, { location: '/next' }, () => {})
+    handler.onComplete({})
+  })
+
+  dispatch(
+    {
+      id: 'req-vetoed',
+      origin: 'http://original.test',
+      path: '/resource',
+      follow() {
+        followCalls++
+        return false
+      },
+      get trace() {
+        traceReads++
+        return null
+      },
+    },
+    {
+      onConnect() {},
+      onHeaders(statusCode) {
+        receivedStatus = statusCode
+      },
+      onComplete() {
+        completed = true
+      },
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  t.equal(followCalls, 1)
+  t.equal(receivedStatus, 302)
+  t.equal(completed, true)
+  t.equal(traceReads, 0)
+  t.end()
+})

--- a/test/trace-redirect-metadata-snapshot.js
+++ b/test/trace-redirect-metadata-snapshot.js
@@ -1,0 +1,75 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+import { request } from '../lib/request.js'
+
+test('follow callback mutations do not rewrite redirect trace provenance', async (t) => {
+  const docs = []
+  const trace = {
+    write(doc, op) {
+      docs.push({ ...doc, op })
+    },
+  }
+  const attempts = []
+
+  const dispatch = compose(
+    (opts, handler) => {
+      attempts.push({ ...opts })
+      handler.onConnect(() => {})
+
+      if (attempts.length === 1) {
+        handler.onHeaders(302, { location: '/next' }, () => {})
+      } else {
+        handler.onHeaders(200, { 'content-length': '0' }, () => {})
+      }
+      handler.onComplete({})
+    },
+    interceptors.redirect(),
+    interceptors.log(),
+  )
+
+  const { body } = await request(dispatch, {
+    id: 'req-original',
+    method: 'GET',
+    origin: 'http://original.test',
+    path: '/resource',
+    trace,
+    follow(_location, _count, opts) {
+      opts.id = 'req-mutated'
+      opts.method = 'PATCH'
+      opts.origin = 'http://mutated.test'
+      opts.path = '/different'
+      return true
+    },
+  })
+  await body.dump()
+
+  t.equal(attempts.length, 2)
+  t.match(attempts[1], {
+    id: 'req-mutated',
+    method: 'PATCH',
+    origin: 'http://mutated.test',
+    path: '/next',
+  })
+
+  const requestDocs = docs.filter((doc) => doc.op === 'undici:request')
+  const start = requestDocs.find((doc) => doc.phase === 'start')
+  const end = requestDocs.find((doc) => doc.phase === 'end')
+  const redirect = docs.find((doc) => doc.op === 'undici:redirect')
+
+  t.equal(requestDocs.length, 2, 'the logical request emits one trace pair')
+  t.ok(start, 'the request start trace exists')
+  t.ok(end, 'the request end trace exists')
+  t.ok(redirect, 'the redirect trace exists')
+  if (!start || !end || !redirect) {
+    return
+  }
+
+  t.match(end, { id: start.id, method: start.method, url: start.url })
+  t.match(redirect, {
+    id: start.id,
+    method: 'PATCH',
+    from: start.url,
+    to: 'http://mutated.test/next',
+    count: 1,
+  })
+})

--- a/test/trace-redirect-metadata-snapshot.js
+++ b/test/trace-redirect-metadata-snapshot.js
@@ -73,3 +73,33 @@ test('follow callback mutations do not rewrite redirect trace provenance', async
     count: 1,
   })
 })
+
+test('non-redirect responses do not resolve redirect trace state', (t) => {
+  let traceReads = 0
+  const dispatch = interceptors.redirect()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(200, { 'content-length': '0' }, () => {})
+    handler.onComplete({})
+  })
+
+  dispatch(
+    {
+      follow: true,
+      get trace() {
+        traceReads++
+        return null
+      },
+    },
+    {
+      onConnect() {},
+      onHeaders() {},
+      onComplete() {},
+      onError(err) {
+        throw err
+      },
+    },
+  )
+
+  t.equal(traceReads, 0)
+  t.end()
+})


### PR DESCRIPTION
## Summary

- lazily capture the redirect trace writer and logical request id on the first redirect that is actually followed
- snapshot each redirect's provenance before invoking a mutable user `follow()` callback
- defer `opts.trace` resolution until follow policy and body replayability checks accept the redirect
- keep redirect provenance correlated with the request trace while still reporting the actual post-callback method and destination used for the next hop
- retain zero redirect-trace work for non-redirect responses and callback-vetoed redirects

## Tests

- adds a regression that mutates `id`, `method`, `origin`, and `path` in `follow()`
- verifies the second hop uses those permitted mutations while the redirect doc retains the original response source and request id
- verifies non-redirect and callback-vetoed responses do not read `opts.trace`
- focused redirect/trace matrix: 164 assertions passing
- ESLint, Prettier, and `git diff --check` pass