### PR TITLE
fix(dns): snapshot refresh trace metadata

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -454,19 +454,25 @@ export default () => (dispatch) => {
         // attach-relative durations — the doc denotes the background lookup
         // itself, not a per-request wait (nothing awaits a refresh).
         const write = traceWrite(opts.trace)
-        const initiated = write !== null && !promises.has(key)
+        const trace =
+          write !== null && !promises.has(key)
+            ? { write, id: opts.id ?? null, url: traceUrl(opts) }
+            : null
         const promise = resolve(key, hostname, { ttl, negativeTTL, lookup, state })
-        if (initiated) {
+        if (trace !== null) {
           // Side-observe a copy of the chain: resolve() never rejects (it
           // settles with an [err, val] tuple) and .then returns a new promise,
           // so the shared in-flight promise's other consumers are unaffected.
+          // Request metadata is captured before dispatch: a slow refresh may
+          // otherwise outlive this attempt and observe retry-callback mutations
+          // to the live opts object when its trace doc finally settles.
           const started = performance.now()
           promise.then(([err, val]) => {
             traceSafe(
-              write,
+              trace.write,
               {
-                id: opts.id ?? null,
-                url: traceUrl(opts),
+                id: trace.id,
+                url: trace.url,
                 source: 'refresh',
                 durationMs: Math.round(performance.now() - started),
                 records: err ? null : val.length,

--- a/test/trace-dns-metadata-snapshot.js
+++ b/test/trace-dns-metadata-snapshot.js
@@ -1,0 +1,102 @@
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+import { request } from '../lib/request.js'
+
+test('background DNS refresh snapshots request trace metadata', async (t) => {
+  const originalNow = Date.now
+  let now = originalNow()
+  Date.now = () => now
+  t.teardown(() => {
+    Date.now = originalNow
+  })
+
+  const docs = []
+  const trace = {
+    write(doc, op) {
+      docs.push({ ...doc, op })
+    },
+  }
+  let lookupCount = 0
+  let releaseRefresh
+  const lookup = (_hostname, _opts, callback) => {
+    lookupCount++
+    if (lookupCount === 1) {
+      callback(null, [{ address: '127.0.0.1' }])
+    } else {
+      releaseRefresh = () => callback(null, [{ address: '127.0.0.1' }])
+    }
+  }
+  let dispatchCount = 0
+  const dispatch = compose(
+    (_opts, handler) => {
+      dispatchCount++
+      handler.onConnect(() => {})
+      if (dispatchCount === 1) {
+        handler.onHeaders(200, { 'content-length': '0' }, () => {})
+        handler.onComplete({})
+      } else {
+        handler.onError(new Error('stop after starting refresh'))
+      }
+    },
+    interceptors.dns(),
+    interceptors.responseRetry(),
+    interceptors.log(),
+  )
+  const dns = { ttl: 1000, lookup }
+
+  const first = await request(dispatch, {
+    id: 'req-prime',
+    method: 'GET',
+    origin: 'http://refresh.test',
+    path: '/prime',
+    dns,
+    retry: false,
+    trace,
+  })
+  await first.body.dump()
+
+  now += 600
+
+  await t.rejects(
+    request(dispatch, {
+      id: 'req-refresh',
+      method: 'GET',
+      origin: 'http://refresh.test',
+      path: '/resource',
+      dns,
+      trace,
+      retry(_err, _count, opts) {
+        opts.id = 'req-mutated'
+        opts.origin = 'http://mutated.test'
+        opts.path = '/different'
+        return false
+      },
+    }),
+    /stop after starting refresh/,
+  )
+
+  t.equal(lookupCount, 2, 'the second request started a background refresh')
+  t.type(releaseRefresh, 'function')
+  releaseRefresh?.()
+  await tick()
+
+  const start = docs.find(
+    (doc) => doc.op === 'undici:request' && doc.phase === 'start' && doc.id === 'req-refresh',
+  )
+  const refresh = docs.find((doc) => doc.op === 'undici:dns' && doc.source === 'refresh')
+
+  t.ok(start, 'the triggering request start trace exists')
+  t.ok(refresh, 'the refresh trace exists')
+  if (!start || !refresh) {
+    return
+  }
+
+  t.match(refresh, {
+    id: start.id,
+    url: start.url,
+    source: 'refresh',
+    records: 1,
+    err: null,
+  })
+})


### PR DESCRIPTION
## Summary

- snapshot `id` and bounded logical `url` when a request actually initiates a pre-emptive DNS refresh
- stop the asynchronous refresh observer from reading a live options object after the triggering attempt has settled
- prevent later retry-callback mutations from misattributing `undici:dns` refresh docs

## Tests

- adds a controlled slow-refresh regression whose triggering attempt mutates options before the resolver completes
- verifies the refresh doc remains attributed to the original triggering request
- focused DNS/trace matrix: 185 assertions passing
- ESLint, Prettier, and `git diff --check` pass