### PR TITLE
fix(priority): cancel queued work before admission

### DIFF
--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -1,6 +1,47 @@
+import { addAbortListener } from 'node:events'
+import { errors } from '@nxtedition/undici'
 import { Scheduler } from '@nxtedition/scheduler'
 import { DecoratorHandler, parseURL } from '../utils.js'
 import { traceWrite, traceSafe, traceUrl } from '../trace.js'
+
+const { RequestAbortedError } = errors
+
+function abortReason(signal) {
+  return signal.reason === undefined ? new RequestAbortedError() : signal.reason
+}
+
+function subscribeAbort(signal, onAbort) {
+  try {
+    if (typeof signal.addEventListener === 'function') {
+      try {
+        const disposable = addAbortListener(signal, onAbort)
+        return () => disposable[Symbol.dispose]()
+      } catch (err) {
+        if (err?.code !== 'ERR_INVALID_ARG_TYPE') {
+          return null
+        }
+      }
+
+      if (typeof signal.removeEventListener === 'function') {
+        signal.addEventListener('abort', onAbort)
+        return () => signal.removeEventListener('abort', onAbort)
+      }
+      return null
+    }
+
+    const removeListener =
+      typeof signal.removeListener === 'function' ? signal.removeListener : signal.off
+    if (typeof signal.on === 'function' && typeof removeListener === 'function') {
+      signal.on('abort', onAbort)
+      return () => removeListener.call(signal, 'abort', onAbort)
+    }
+  } catch {
+    // A raw dispatch caller can supply a signal-like object with throwing
+    // subscription hooks. Leave it to the downstream dispatcher in that case.
+  }
+
+  return null
+}
 
 function canonicalOrigin(origin, host) {
   if (Array.isArray(origin)) {
@@ -25,12 +66,64 @@ class Handler extends DecoratorHandler {
   #scheduler
   #onIdle
   #trace
+  #admitted = false
+  #slotAcquired = false
+  #cancelled = false
+  #removeAbortListener = null
+  #traceEnded = false
 
   constructor(handler, scheduler, onIdle, trace) {
     super(handler)
     this.#scheduler = scheduler
     this.#onIdle = onIdle
     this.#trace = trace
+  }
+
+  onAcquired() {
+    this.#admitted = true
+    this.#slotAcquired = true
+    this.#stopWatchingAbort()
+
+    if (this.#cancelled) {
+      // Scheduler has no per-item removal API. A cancelled queued entry is a
+      // tombstone until it reaches admission; consume and immediately release
+      // that slot without invoking the downstream dispatcher.
+      this.#release()
+      return false
+    }
+
+    if (this.#trace !== null) {
+      this.#trace.dispatched = performance.now()
+    }
+    return true
+  }
+
+  watchAbort(signal) {
+    if (signal == null || this.#admitted || this.#cancelled) {
+      return
+    }
+
+    const onAbort = () => this.#cancelQueued(abortReason(signal))
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+
+    const removeAbortListener = subscribeAbort(signal, onAbort)
+    if (removeAbortListener === null) {
+      return
+    }
+    if (this.#admitted || this.#cancelled) {
+      removeAbortListener()
+      return
+    }
+    this.#removeAbortListener = removeAbortListener
+
+    // Covers signal-like implementations that can transition during their
+    // subscription hook without invoking the newly-added listener.
+    if (signal.aborted) {
+      onAbort()
+    }
   }
 
   onConnect(abort) {
@@ -49,9 +142,10 @@ class Handler extends DecoratorHandler {
   }
 
   #release() {
-    if (this.#scheduler) {
+    if (this.#scheduler && this.#slotAcquired) {
       const scheduler = this.#scheduler
       this.#scheduler = null
+      this.#slotAcquired = false
 
       // Slot-release timestamp is captured BEFORE release(): it synchronously
       // pumps queued dispatches, whose work must not inflate this request's
@@ -64,23 +158,62 @@ class Handler extends DecoratorHandler {
 
       scheduler.release()
       this.#onIdle?.()
-
-      if (trace !== null) {
-        traceSafe(
-          trace.write,
-          {
-            id: trace.id,
-            key: trace.key,
-            priority: trace.priority,
-            phase: 'end',
-            pending: null,
-            waitMs: Math.round(trace.dispatched - trace.acquired),
-            holdMs: Math.round(released - trace.dispatched),
-          },
-          'undici:priority',
-        )
-      }
+      this.#emitEnd(released)
     }
+  }
+
+  #cancelQueued(reason) {
+    if (this.#admitted || this.#cancelled || this.#scheduler === null) {
+      return
+    }
+
+    this.#cancelled = true
+    this.#stopWatchingAbort()
+
+    if (this.#trace !== null) {
+      const ended = performance.now()
+      this.#trace.dispatched = ended
+      this.#emitEnd(ended)
+    }
+
+    try {
+      super.onError(reason)
+    } catch {
+      // Abort listeners must not surface a downstream callback failure as an
+      // uncaught exception. The handler is already terminal at this point.
+    }
+  }
+
+  #stopWatchingAbort() {
+    const removeAbortListener = this.#removeAbortListener
+    this.#removeAbortListener = null
+    try {
+      removeAbortListener?.()
+    } catch {
+      // Detaching a hostile signal-like listener is best-effort.
+    }
+  }
+
+  #emitEnd(released) {
+    const trace = this.#trace
+    if (trace === null || this.#traceEnded) {
+      return
+    }
+
+    this.#traceEnded = true
+    traceSafe(
+      trace.write,
+      {
+        id: trace.id,
+        key: trace.key,
+        priority: trace.priority,
+        phase: 'end',
+        pending: null,
+        waitMs: Math.round(trace.dispatched - trace.acquired),
+        holdMs: Math.round(released - trace.dispatched),
+      },
+      'undici:priority',
+    )
   }
 }
 
@@ -140,8 +273,8 @@ export default () => (dispatch) => {
     let dispatchResult
     const acquired = scheduler.acquire(
       (priorityHandler) => {
-        if (trace !== null) {
-          trace.dispatched = performance.now()
+        if (!priorityHandler.onAcquired()) {
+          return
         }
         try {
           dispatchResult = dispatch(opts, priorityHandler)
@@ -184,6 +317,9 @@ export default () => (dispatch) => {
         },
         'undici:priority',
       )
+    }
+    if (!acquired) {
+      priorityHandler.watchAbort(opts.signal)
     }
 
     // acquire() invokes the callback synchronously when a slot is available,

--- a/test/body-factory-queued-abort.js
+++ b/test/body-factory-queued-abort.js
@@ -74,7 +74,7 @@ test('queued request abort promptly releases its body factory', async (t) => {
 
   t.equal(await firstResult, releaseReason, 'the occupying request is released')
   t.equal(await secondResult, abortReason, 'the queued request later settles with its abort reason')
-  t.equal(dispatched.length, 2, 'the queued attempt only reaches dispatch after release')
+  t.equal(dispatched.length, 1, 'the aborted queued attempt never reaches dispatch')
 })
 
 test('completed factory body removes its request abort listener', async (t) => {

--- a/test/priority-queued-abort.js
+++ b/test/priority-queued-abort.js
@@ -1,0 +1,124 @@
+import { EventEmitter } from 'node:events'
+import { setImmediate as tick } from 'node:timers/promises'
+import { test } from 'tap'
+import priority from '../lib/interceptor/priority.js'
+import { request } from '../lib/request.js'
+
+const base = {
+  origin: 'http://example.test',
+  method: 'GET',
+  headers: {},
+  priority: 'normal',
+}
+
+function handler(overrides = {}) {
+  return {
+    onConnect() {},
+    onHeaders() {},
+    onData() {},
+    onComplete() {},
+    onError() {},
+    ...overrides,
+  }
+}
+
+function writer() {
+  const docs = []
+  return {
+    docs,
+    write(doc, op) {
+      docs.push({ ...doc, op })
+    },
+  }
+}
+
+async function checkQueuedAbort(t, signal, abort) {
+  const seen = []
+  let releaseFirst
+  const dispatch = priority()((opts, wrapped) => {
+    seen.push(opts.path)
+
+    if (opts.path === '/hold') {
+      releaseFirst = () => wrapped.onConnect(() => {})
+      return true
+    }
+
+    wrapped.onConnect((reason) => wrapped.onError(reason))
+    if (!opts.signal?.aborted) {
+      wrapped.onComplete({})
+    }
+    return true
+  })
+
+  dispatch({ ...base, path: '/hold' }, handler())
+  const trace = writer()
+  const reason = new Error('queued request aborted')
+  const queued = request(dispatch, {
+    ...base,
+    id: 'queued-request',
+    path: '/queued',
+    signal,
+    trace,
+  })
+  let rejection
+  void queued.catch((err) => {
+    rejection = err
+  })
+
+  t.same(seen, ['/hold'], 'second request is waiting for scheduler admission')
+  t.same(
+    trace.docs.filter((doc) => doc.op === 'undici:priority').map((doc) => doc.phase),
+    ['queued'],
+  )
+
+  abort(reason)
+  await tick()
+  await tick()
+
+  t.equal(rejection, reason, 'queued request rejects before the active slot is released')
+  t.same(seen, ['/hold'], 'abort does not dispatch the queued request downstream')
+  const beforeRelease = trace.docs.filter((doc) => doc.op === 'undici:priority')
+  t.same(
+    beforeRelease.map((doc) => doc.phase),
+    ['queued', 'end'],
+    'queued trace is paired at cancellation time',
+  )
+  t.equal(beforeRelease[1]?.holdMs, 0, 'a request that never acquired a slot held it for 0ms')
+
+  releaseFirst()
+  t.equal(await queued.catch((err) => err), reason)
+  t.same(seen, ['/hold'], 'the admitted cancellation tombstone skips inner dispatch')
+
+  let thirdCompleted = false
+  dispatch(
+    { ...base, path: '/third' },
+    handler({
+      onComplete() {
+        thirdCompleted = true
+      },
+    }),
+  )
+
+  t.same(seen, ['/hold', '/third'], 'a later request can immediately reuse the drained slot')
+  t.equal(thirdCompleted, true)
+  t.equal(
+    trace.docs.filter((doc) => doc.op === 'undici:priority' && doc.id === 'queued-request').length,
+    2,
+    'tombstone admission does not emit a second end trace',
+  )
+}
+
+test('priority: native AbortSignal cancels queued work before admission', async (t) => {
+  const controller = new AbortController()
+  await checkQueuedAbort(t, controller.signal, (reason) => controller.abort(reason))
+})
+
+test('priority: EventEmitter signal cancels queued work before admission', async (t) => {
+  const signal = new EventEmitter()
+  signal.aborted = false
+  await checkQueuedAbort(t, signal, (reason) => {
+    signal.aborted = true
+    signal.reason = reason
+    signal.emit('abort')
+  })
+})

--- a/test/priority-queued-abort.js
+++ b/test/priority-queued-abort.js
@@ -122,3 +122,41 @@ test('priority: EventEmitter signal cancels queued work before admission', async
     signal.emit('abort')
   })
 })
+
+test('priority: reentrant queue tracing cannot install a stale abort listener', (t) => {
+  const signal = Object.assign(new EventEmitter(), { aborted: false, reason: undefined })
+  let releaseFirst
+  let calls = 0
+  let completed = false
+  const dispatch = priority()((opts, wrapped) => {
+    calls++
+    if (calls === 1) {
+      releaseFirst = () => wrapped.onConnect(() => {})
+      return
+    }
+    wrapped.onConnect(() => {})
+    wrapped.onComplete({})
+  })
+
+  dispatch({ ...base, path: '/hold' }, handler())
+  const trace = {
+    write(doc, op) {
+      if (op === 'undici:priority' && doc.phase === 'queued') {
+        releaseFirst()
+      }
+    },
+  }
+  dispatch(
+    { ...base, path: '/queued', signal, trace },
+    handler({
+      onComplete() {
+        completed = true
+      },
+    }),
+  )
+
+  t.equal(calls, 2, 'the queued request was admitted reentrantly by its trace writer')
+  t.equal(completed, true)
+  t.equal(signal.listenerCount('abort'), 0, 'no queued-only listener is installed after admission')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- observe native AbortSignal and supported EventEmitter-style signals while a priority request is queued
- terminate the queued handler and pair its priority trace at cancellation time
- turn the scheduler entry into a tombstone that skips downstream dispatch when eventually admitted
- immediately release that admitted tombstone so later work can reuse the slot
- avoid stale abort listeners when a reentrant trace writer admits work during queue tracing
- update the body-factory integration regression to require that cancelled queued work never reaches the dispatcher

## Root cause

The priority interceptor delegated cancellation entirely to the downstream dispatcher, but a queued request has not reached that dispatcher yet. The public request and body factory now terminate promptly, while the priority queue entry remained live and later invoked downstream transport work after its signal was already aborted. Its queued trace also remained unpaired until that later admission.

`@nxtedition/scheduler` exposes `acquire()` and `release()` but no per-item removal handle. The interceptor therefore cannot physically delete a queued entry. This change makes that limitation explicit: cancellation promptly settles the request and trace, and the retained entry is a side-effect-free tombstone that releases immediately at admission instead of leaking a slot or dispatching transport work.

## Validation

- all priority-related tests: 104 assertions passed
- queued-abort/request/body integration: 52 assertions passed
- focused queued-abort suite: 25 assertions passed
- ESLint
- Prettier
- `git diff --check`
