### PR TITLE
fix(request): require paired abort subscriptions

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -25,6 +25,21 @@ function tryAddAbortListener(signal, listener) {
   }
 }
 
+function getEmitterRemoval(signal) {
+  return typeof signal.removeListener === 'function' ? signal.removeListener : signal.off
+}
+
+function isAbortEventTarget(signal) {
+  return (
+    typeof signal.addEventListener === 'function' &&
+    typeof signal.removeEventListener === 'function'
+  )
+}
+
+function isAbortEventEmitter(signal) {
+  return typeof signal.on === 'function' && typeof getEmitterRemoval(signal) === 'function'
+}
+
 export class RequestHandler {
   constructor({ signal, method, body, highWaterMark }, resolve) {
     if (isStream(body) && body.closed) {
@@ -42,11 +57,7 @@ export class RequestHandler {
         throw new InvalidArgumentError('invalid highWaterMark')
       }
 
-      if (
-        signal &&
-        typeof signal.on !== 'function' &&
-        typeof signal.addEventListener !== 'function'
-      ) {
+      if (signal && !isAbortEventTarget(signal) && !isAbortEventEmitter(signal)) {
         throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
       }
 
@@ -94,7 +105,7 @@ export class RequestHandler {
       // Let Node recognize native AbortSignals so cross-realm instances get a
       // propagation-resistant listener. Generic EventTargets and EventEmitters
       // retain their compatibility paths.
-      if (typeof signal.addEventListener === 'function') {
+      if (isAbortEventTarget(signal)) {
         const disposable = tryAddAbortListener(signal, onAbort)
         if (disposable) {
           this.removeAbortListener = () => disposable[Symbol.dispose]()
@@ -103,8 +114,9 @@ export class RequestHandler {
           this.removeAbortListener = () => signal.removeEventListener('abort', onAbort)
         }
       } else {
+        const removeEmitterListener = getEmitterRemoval(signal)
         signal.on('abort', onAbort)
-        this.removeAbortListener = () => signal.removeListener('abort', onAbort)
+        this.removeAbortListener = () => removeEmitterListener.call(signal, 'abort', onAbort)
       }
     }
   }

--- a/test/request-signal-subscription.js
+++ b/test/request-signal-subscription.js
@@ -1,0 +1,73 @@
+import { test } from 'tap'
+import { RequestHandler } from '../lib/request.js'
+
+test('RequestHandler rejects abort signals without a matching removal method', (t) => {
+  t.plan(2)
+
+  const signals = [{ addEventListener() {} }, { on() {} }]
+
+  for (const signal of signals) {
+    t.throws(
+      () => new RequestHandler({ method: 'GET', body: null, signal }, () => {}),
+      /signal must be an EventEmitter or EventTarget/,
+    )
+  }
+})
+
+test('RequestHandler supports and cleans up on/off-only abort signals', async (t) => {
+  const reason = new Error('stop request')
+  const { promise, resolve } = Promise.withResolvers()
+  let listener
+  let removals = 0
+
+  const signal = {
+    aborted: false,
+    reason,
+    on(event, value) {
+      t.equal(event, 'abort')
+      listener = value
+    },
+    off(event, value) {
+      t.equal(event, 'abort')
+      t.equal(value, listener)
+      removals++
+    },
+  }
+
+  new RequestHandler({ method: 'GET', body: null, signal }, resolve)
+
+  t.type(listener, 'function')
+  listener()
+
+  t.equal(await promise.catch((err) => err), reason)
+  t.equal(removals, 1)
+})
+
+test('RequestHandler cleans up generic EventTarget abort signals', async (t) => {
+  const reason = new Error('stop request')
+  const { promise, resolve } = Promise.withResolvers()
+  let listener
+  let removals = 0
+
+  const signal = {
+    aborted: false,
+    reason,
+    addEventListener(event, value) {
+      t.equal(event, 'abort')
+      listener = value
+    },
+    removeEventListener(event, value) {
+      t.equal(event, 'abort')
+      t.equal(value, listener)
+      removals++
+    },
+  }
+
+  new RequestHandler({ method: 'GET', body: null, signal }, resolve)
+
+  t.type(listener, 'function')
+  listener()
+
+  t.equal(await promise.catch((err) => err), reason)
+  t.equal(removals, 1)
+})


### PR DESCRIPTION
## Summary

- validate that EventTarget-like request signals provide both `addEventListener()` and `removeEventListener()`
- validate that EventEmitter-like signals provide `on()` plus either `removeListener()` or `off()`
- support `on()`/`off()`-only signals during RequestHandler cleanup instead of later calling a missing `removeListener()`
- reject half-shaped signals before installing an abort listener that cannot be removed

## Validation

- 5 request/signal/retry test files: 52 assertions passed
- ESLint and Prettier pass
- `git diff --check` passes