### PR TITLE
fix(proxy): centralize target and redirect policy

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,9 +114,9 @@ export interface DispatchOptions {
    *  dispatch handler must implement onUpgrade — only meaningful with raw
    *  dispatch()/compose(); request() has no upgrade support (see RequestOptions). */
   upgrade?: string | null
-  follow?: number | FollowFn | boolean | null
+  follow?: FollowPolicy | null
   /** Alias for `follow`; ignored when `follow` is also set. */
-  redirect?: number | FollowFn | boolean | null
+  redirect?: FollowPolicy | null
   error?: boolean | null
   /** Alias for `error`; ignored when `error` is also set. */
   throwOnError?: boolean | null
@@ -153,7 +153,18 @@ export type RetryFn = (
   defaultRetryFn: () => Promise<boolean>,
 ) => boolean | Promise<boolean>
 
-export type FollowFn = (location: string, count: number, opts: DispatchOptions) => boolean
+export type FollowFn = (
+  this: DispatchOptions,
+  location: string,
+  count: number,
+  opts: DispatchOptions,
+) => boolean
+
+export interface FollowOptions {
+  readonly count: number
+}
+
+export type FollowPolicy = number | boolean | FollowOptions | FollowFn
 
 export type LookupFn = (
   origin: OriginLike,
@@ -166,6 +177,16 @@ export interface ProxyOptions {
   socket?: import('node:net').Socket
   name?: string
   req?: import('node:http').IncomingMessage
+  /** Parsed inbound target consumed by the public dispatch/request boundary.
+   *  Only pathname and search are used when reducing an absolute-form request
+   *  target to origin-form. */
+  requestTarget?: ProxyRequestTarget | null
+  /** Additional case-insensitive headers removed on cross-origin redirects. */
+  originBoundHeaders?: readonly string[] | null
+}
+
+export interface ProxyRequestTarget extends URLObject {
+  readonly pathname: string
 }
 
 export interface CacheOptions {

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,6 +143,10 @@ function wrapDispatch(dispatcher) {
       interceptors.requestId(),
       interceptors.responseError(),
       interceptors.query(),
+      // Consume the parsed inbound request target once at the public boundary.
+      // Every inner policy (log, redirect, cache, retry and DNS) must observe
+      // the same origin-form path that will reach the transport.
+      proxyInterceptors.proxyTarget(),
       (dispatch) => (opts, handler) => {
         if (!opts.origin) {
           throw new TypeError('opts.origin is required')

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -5,7 +5,6 @@ import { DecoratorHandler, parseHeaders } from '../utils.js'
 
 const ORIGIN_FORM_PATH = /^\/(?![/\\\t\r\n])/
 const ABSOLUTE_FORM_TARGET = /^https?:\/\//i
-const kRequestTarget = Symbol('proxy request target')
 
 function noop() {}
 
@@ -15,12 +14,6 @@ function unsupportedRequestTarget() {
 
 function isOriginFormPath(path) {
   return typeof path === 'string' && ORIGIN_FORM_PATH.test(path)
-}
-
-function assertOriginFormPath(path) {
-  if (!isOriginFormPath(path)) {
-    throw unsupportedRequestTarget()
-  }
 }
 
 /**
@@ -817,7 +810,6 @@ export const proxyTarget = () => (dispatch) => (opts, handler) => {
     {
       ...opts,
       ...normalizeProxyTarget(opts.path, opts.proxy),
-      [kRequestTarget]: true,
     },
     handler,
   )
@@ -826,13 +818,6 @@ export const proxyTarget = () => (dispatch) => (opts, handler) => {
 export const proxyRequest = () => (dispatch) => (opts, handler) => {
   if (!opts.proxy) {
     return dispatch(opts, handler)
-  }
-
-  // Redirects and retries can mutate opts after the one-shot target
-  // normalization. Reassert origin-form at every transport attempt so an
-  // absolute or ambiguous path cannot be reintroduced below cache/log policy.
-  if (opts[kRequestTarget]) {
-    assertOriginFormPath(opts.path)
   }
 
   const expectsPayload =
@@ -874,9 +859,7 @@ export const proxyRequest = () => (dispatch) => (opts, handler) => {
     {},
   )
 
-  const dispatchOpts = { ...opts, headers }
-  delete dispatchOpts[kRequestTarget]
-  return dispatch(dispatchOpts, handler)
+  return dispatch({ ...opts, headers }, handler)
 }
 
 export const proxyResponse = () => (dispatch) => (opts, handler) => {

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -3,7 +3,64 @@ import { domainToASCII } from 'node:url'
 import createError from 'http-errors'
 import { DecoratorHandler, parseHeaders } from '../utils.js'
 
+const ORIGIN_FORM_PATH = /^\/(?![/\\\t\r\n])/
+const ABSOLUTE_FORM_TARGET = /^https?:\/\//i
+const kRequestTarget = Symbol('proxy request target')
+
 function noop() {}
+
+function unsupportedRequestTarget() {
+  return new createError.BadRequest('Unsupported request target')
+}
+
+function isOriginFormPath(path) {
+  return typeof path === 'string' && ORIGIN_FORM_PATH.test(path)
+}
+
+function assertOriginFormPath(path) {
+  if (!isOriginFormPath(path)) {
+    throw unsupportedRequestTarget()
+  }
+}
+
+/**
+ * Normalize an inbound proxy request target once, before cache, redirect and
+ * logging observe the request. The configured origin remains authoritative:
+ * absolute-form targets contribute only their already-parsed path and query.
+ *
+ * @param {unknown} path
+ * @param {boolean | Record<string, unknown>} proxy
+ * @returns {{ path: string, proxy: boolean | Record<string, unknown> }}
+ */
+export function normalizeProxyTarget(path, proxy) {
+  if (!proxy || typeof proxy !== 'object' || !Object.hasOwn(proxy, 'requestTarget')) {
+    return { path, proxy }
+  }
+
+  let normalizedPath = path
+
+  if (!isOriginFormPath(normalizedPath)) {
+    const requestTarget = proxy.requestTarget
+    const pathname = requestTarget?.pathname
+    const search = requestTarget?.search
+
+    if (
+      typeof path !== 'string' ||
+      !ABSOLUTE_FORM_TARGET.test(path) ||
+      !isOriginFormPath(pathname) ||
+      (search != null && typeof search !== 'string')
+    ) {
+      throw unsupportedRequestTarget()
+    }
+
+    normalizedPath = `${pathname}${search ?? ''}`
+  }
+
+  proxy = { ...proxy }
+  delete proxy.requestTarget
+
+  return { path: normalizedPath, proxy }
+}
 
 function setOwnHeader(headers, key, value) {
   if (key === '__proto__') {
@@ -747,9 +804,35 @@ function printIp(address, port) {
   return str
 }
 
+export const proxyTarget = () => (dispatch) => (opts, handler) => {
+  if (
+    !opts.proxy ||
+    typeof opts.proxy !== 'object' ||
+    !Object.hasOwn(opts.proxy, 'requestTarget')
+  ) {
+    return dispatch(opts, handler)
+  }
+
+  return dispatch(
+    {
+      ...opts,
+      ...normalizeProxyTarget(opts.path, opts.proxy),
+      [kRequestTarget]: true,
+    },
+    handler,
+  )
+}
+
 export const proxyRequest = () => (dispatch) => (opts, handler) => {
   if (!opts.proxy) {
     return dispatch(opts, handler)
+  }
+
+  // Redirects and retries can mutate opts after the one-shot target
+  // normalization. Reassert origin-form at every transport attempt so an
+  // absolute or ambiguous path cannot be reintroduced below cache/log policy.
+  if (opts[kRequestTarget]) {
+    assertOriginFormPath(opts.path)
   }
 
   const expectsPayload =
@@ -791,7 +874,9 @@ export const proxyRequest = () => (dispatch) => (opts, handler) => {
     {},
   )
 
-  return dispatch({ ...opts, headers }, handler)
+  const dispatchOpts = { ...opts, headers }
+  delete dispatchOpts[kRequestTarget]
+  return dispatch(dispatchOpts, handler)
 }
 
 export const proxyResponse = () => (dispatch) => (opts, handler) => {

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -10,6 +10,43 @@ import {
 import { traceWrite, traceSafe, traceUrl } from '../trace.js'
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
+const defaultOriginBoundHeaders = ['authorization', 'proxy-authorization', 'cookie']
+
+function getRedirectLimit(follow) {
+  return follow === true ? 8 : Number.isFinite(follow) ? follow : (follow?.count ?? 0)
+}
+
+function getOriginBoundHeaders(proxy) {
+  const result = new Set(defaultOriginBoundHeaders)
+  const headers =
+    proxy && typeof proxy === 'object' && Object.hasOwn(proxy, 'originBoundHeaders')
+      ? proxy.originBoundHeaders
+      : null
+
+  if (headers == null) {
+    return result
+  }
+  if (!Array.isArray(headers)) {
+    throw new TypeError('proxy.originBoundHeaders must be an array')
+  }
+
+  for (const header of headers) {
+    if (typeof header !== 'string') {
+      throw new TypeError('proxy.originBoundHeaders entries must be strings')
+    }
+    result.add(header.toLowerCase())
+  }
+
+  return result
+}
+
+function canonicalOrigin(origin) {
+  try {
+    return parseURL(origin).origin
+  } catch {
+    return null
+  }
+}
 
 function isOneShotIterable(body) {
   if (body == null || typeof body !== 'object') {
@@ -36,7 +73,7 @@ class Handler extends DecoratorHandler {
   #dispatch
   #opts
   #trace
-  #maxCount
+  #originBoundHeaders
 
   #abort
   #aborted = false
@@ -51,15 +88,10 @@ class Handler extends DecoratorHandler {
 
     this.#dispatch = dispatch
     this.#opts = opts
-    // `follow: true` means "follow redirects" — map it to the project default
-    // cap rather than letting `true.count ?? 0` collapse to 0, which would
-    // reject the very first redirect with "Max redirections reached: 0".
-    this.#maxCount =
-      opts.follow === true
-        ? 8
-        : Number.isFinite(opts.follow)
-          ? opts.follow
-          : (opts.follow?.count ?? 0)
+    // Redirect policy is live and may replace opts.proxy. Snapshot the
+    // security boundary before the first callback so it cannot weaken which
+    // credentials are removed on a later cross-origin hop.
+    this.#originBoundHeaders = getOriginBoundHeaders(opts.proxy)
 
     super.onConnect((reason) => {
       this.#aborted = true
@@ -81,6 +113,13 @@ class Handler extends DecoratorHandler {
 
   onUpgrade(statusCode, headers, socket) {
     super.onUpgrade(statusCode, headers, socket)
+  }
+
+  #passThrough(statusCode, headers, resume) {
+    assert(!this.#headersSent)
+    this.#headersSent = true
+    this.#location = null
+    return super.onHeaders(statusCode, headers, resume)
   }
 
   onHeaders(statusCode, headers, resume) {
@@ -117,26 +156,43 @@ class Handler extends DecoratorHandler {
     // accepts the redirect so a veto does not read an otherwise-unused trace
     // getter or cache trace state.
     const traceId = this.#trace?.id ?? this.#opts.id ?? null
-    const traceSource = { origin: this.#opts.origin, path: this.#opts.path }
+    const sourceOrigin = canonicalOrigin(this.#opts.origin)
+    const traceSource = {
+      // Preserve the spelling used by the request trace while detaching it
+      // from mutable URL/URL-like objects handed to the follow callback.
+      origin:
+        this.#opts.origin instanceof URL
+          ? this.#opts.origin.origin
+          : typeof this.#opts.origin === 'string' || this.#opts.origin == null
+            ? this.#opts.origin
+            : String(this.#opts.origin),
+      path: this.#opts.path,
+    }
 
-    if (typeof this.#opts.follow === 'function') {
+    const follow = this.#opts.follow
+    if (typeof follow === 'function') {
       // follow() receives the live opts object and may mutate headers. Remove
       // trust before invoking it so the next parseHeaders() call validates any
       // changes instead of taking the identity fast path.
       invalidateNormalizedHeaders(this.#opts.headers)
-      if (!this.#opts.follow(this.#location, this.#count, this.#opts)) {
-        assert(!this.#headersSent)
-        this.#headersSent = true
-        this.#location = null
-        return super.onHeaders(statusCode, headers, resume)
+      if (!follow.call(this.#opts, this.#location, this.#count, this.#opts)) {
+        return this.#passThrough(statusCode, headers, resume)
       }
     } else {
+      // A custom policy can hand control to false/0/undefined for subsequent
+      // hops. The current hop was already accepted by that callback; deliver
+      // the next redirect response instead of turning the handoff into Max 0.
+      if (!follow) {
+        return this.#passThrough(statusCode, headers, resume)
+      }
+
       // `follow: N` follows up to N redirects and errors on the N+1th, matching
       // undici/fetch maxRedirections semantics. `>` (not `>=`): with `>=`,
       // `follow: 1` threw on the very first redirect with a self-contradictory
       // "Max redirections reached: 1." message.
-      if (this.#count > this.#maxCount) {
-        throw Object.assign(new Error(`Max redirections reached: ${this.#maxCount}.`), {
+      const maxCount = getRedirectLimit(follow)
+      if (this.#count > maxCount) {
+        throw Object.assign(new Error(`Max redirections reached: ${maxCount}.`), {
           history: this.#history,
         })
       }
@@ -182,7 +238,8 @@ class Handler extends DecoratorHandler {
       headers: cleanRequestHeaders(
         this.#opts.headers,
         statusCode === 303,
-        !isSameOrigin(this.#opts.origin, origin),
+        sourceOrigin !== origin,
+        this.#originBoundHeaders,
       ),
       path,
       origin,
@@ -283,38 +340,13 @@ class Handler extends DecoratorHandler {
   }
 }
 
-// `target` is always a WHATWG-normalized origin (it comes off a parsed URL:
-// lowercased host, default port elided, no path), while `optsOrigin` is
-// caller-provided and may not be (trailing slash, explicit `:80`/`:443`,
-// uppercase host — defaultLookup in index.js even produces `http://host:80`
-// for object-form origins). A raw string compare misclassifies such
-// same-origin redirects as cross-origin and strips authorization/cookie,
-// breaking authenticated redirect flows with a confusing 401. Normalize
-// through `URL.parse` before comparing; if optsOrigin is not parseable, the
-// optional chain produces false, which fails toward stripping — the safe
-// direction.
-function isSameOrigin(optsOrigin, target) {
-  if (optsOrigin === target) {
-    return true
-  }
-  if (optsOrigin instanceof URL) {
-    return optsOrigin.origin === target
-  }
-  return URL.parse(optsOrigin)?.origin === target
-}
-
 // https://tools.ietf.org/html/rfc7231#section-6.4.4
-function shouldRemoveHeader(header, removeContent, unknownOrigin) {
+function shouldRemoveHeader(header, removeContent, unknownOrigin, originBoundHeaders) {
+  const name = header.toString().toLowerCase()
   return (
-    (header.length === 4 && header.toString().toLowerCase() === 'host') ||
-    (removeContent && header.toString().toLowerCase().indexOf('content-') === 0) ||
-    (unknownOrigin &&
-      header.length === 13 &&
-      header.toString().toLowerCase() === 'authorization') ||
-    (unknownOrigin &&
-      header.length === 19 &&
-      header.toString().toLowerCase() === 'proxy-authorization') ||
-    (unknownOrigin && header.length === 6 && header.toString().toLowerCase() === 'cookie')
+    name === 'host' ||
+    (removeContent && name.startsWith('content-')) ||
+    (unknownOrigin && originBoundHeaders.has(name))
   )
 }
 
@@ -332,7 +364,7 @@ function setOwnHeader(headers, key, value) {
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4
-function cleanRequestHeaders(headers, removeContent, unknownOrigin) {
+function cleanRequestHeaders(headers, removeContent, unknownOrigin, originBoundHeaders) {
   const ret = {}
   if (Array.isArray(headers)) {
     // undici accepts request headers as a flat [name, value, ...] array.
@@ -343,7 +375,7 @@ function cleanRequestHeaders(headers, removeContent, unknownOrigin) {
   }
   if (headers && typeof headers === 'object') {
     for (const key of Object.keys(headers)) {
-      if (!shouldRemoveHeader(key, removeContent, unknownOrigin)) {
+      if (!shouldRemoveHeader(key, removeContent, unknownOrigin, originBoundHeaders)) {
         // `__proto__` is a valid header token. Assigning it onto `{}` invokes
         // Object.prototype's legacy setter, which either drops a scalar value
         // or replaces the accumulator prototype with an array value.

--- a/test/proxy-request-target.js
+++ b/test/proxy-request-target.js
@@ -235,61 +235,66 @@ test('proxy target: cache and log observe the canonical path', async (t) => {
   t.equal(loggedPath, '/canonical?value=1')
 })
 
-test('proxy target: marker rejects an unsafe path introduced by redirect', async (t) => {
+test('proxy target: parsed metadata is not reapplied to redirect paths', async (t) => {
   const attempts = []
   const dispatcher = (opts, handler) => {
     attempts.push(opts.path)
     handler.onConnect(() => {})
-    handler.onHeaders(
-      302,
-      { location: 'http://configured.invalid//reintroduced-by-redirect' },
-      () => {},
-    )
+    if (attempts.length === 1) {
+      handler.onHeaders(
+        302,
+        { location: 'http://configured.invalid//redirect-generated/path' },
+        () => {},
+      )
+    } else {
+      handler.onHeaders(204, {}, () => {})
+    }
     handler.onComplete({})
     return true
   }
 
-  await t.rejects(
-    run(dispatcher, {
-      path: 'http://untrusted.invalid/start',
-      follow: 2,
-      proxy: {
-        requestTarget: { pathname: '/start', search: null },
-      },
-    }),
-    BAD_REQUEST,
-  )
-  t.same(attempts, ['/start'], 'the unsafe follow-up never reaches the dispatcher')
+  await run(dispatcher, {
+    path: 'http://untrusted.invalid/start',
+    follow: 2,
+    proxy: {
+      requestTarget: { pathname: '/start', search: null },
+    },
+  })
+
+  t.same(attempts, ['/start', '//redirect-generated/path'])
 })
 
-test('proxy target: marker rejects an unsafe path introduced by retry', async (t) => {
+test('proxy target: parsed metadata is not reapplied to retry mutations', async (t) => {
   const attempts = []
   let retryCalls = 0
   const dispatcher = (opts, handler) => {
     attempts.push(opts.path)
     handler.onConnect(() => {})
-    handler.onError(Object.assign(new Error('retry me'), { code: 'ECONNRESET' }))
+    if (attempts.length === 1) {
+      handler.onError(Object.assign(new Error('retry me'), { code: 'ECONNRESET' }))
+    } else {
+      handler.onHeaders(204, {}, () => {})
+      handler.onComplete({})
+    }
     return true
   }
 
-  await t.rejects(
-    run(dispatcher, {
-      path: 'http://untrusted.invalid/start',
-      proxy: {
-        requestTarget: { pathname: '/start', search: null },
-      },
-      retry(err, retryCount, opts) {
-        retryCalls++
-        t.equal(err.code, 'ECONNRESET')
-        t.equal(retryCount, 0)
-        t.equal(opts.path, '/start')
-        t.notOk(Object.hasOwn(opts.proxy, 'requestTarget'))
-        opts.path = 'http://untrusted.invalid/reintroduced-by-retry'
-        return true
-      },
-    }),
-    BAD_REQUEST,
-  )
+  await run(dispatcher, {
+    path: 'http://untrusted.invalid/start',
+    proxy: {
+      requestTarget: { pathname: '/start', search: null },
+    },
+    retry(err, retryCount, opts) {
+      retryCalls++
+      t.equal(err.code, 'ECONNRESET')
+      t.equal(retryCount, 0)
+      t.equal(opts.path, '/start')
+      t.notOk(Object.hasOwn(opts.proxy, 'requestTarget'))
+      opts.path = '/retry-generated/path'
+      return true
+    },
+  })
+
   t.equal(retryCalls, 1)
-  t.same(attempts, ['/start'], 'the unsafe retry never reaches the dispatcher')
+  t.same(attempts, ['/start', '/retry-generated/path'])
 })

--- a/test/proxy-request-target.js
+++ b/test/proxy-request-target.js
@@ -1,0 +1,295 @@
+import { test } from 'tap'
+import { dispatch as dispatchRequest } from '../lib/index.js'
+
+const BAD_REQUEST = {
+  message: 'Unsupported request target',
+  statusCode: 400,
+  expose: true,
+}
+
+const BASE_OPTIONS = {
+  origin: 'http://configured.invalid',
+  path: '/',
+  method: 'GET',
+  headers: {},
+  cache: false,
+  dns: false,
+  error: false,
+  follow: false,
+  lookup: false,
+  retry: false,
+  verify: false,
+}
+
+function run(dispatcher, overrides) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+    let result
+
+    try {
+      result = dispatchRequest(
+        dispatcher,
+        { ...BASE_OPTIONS, ...overrides },
+        {
+          onConnect() {},
+          onHeaders(code, value) {
+            statusCode = code
+            headers = value
+            return true
+          },
+          onData() {},
+          onComplete() {
+            resolve({ statusCode, headers })
+          },
+          onError: reject,
+        },
+      )
+    } catch (err) {
+      reject(err)
+      return
+    }
+
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+      Promise.resolve(result).catch(reject)
+    }
+  })
+}
+
+async function capture(overrides) {
+  let captured
+  await run((opts, handler) => {
+    captured = opts
+    handler.onConnect(() => {})
+    handler.onHeaders(204, {}, () => {})
+    handler.onComplete({})
+    return true
+  }, overrides)
+  return captured
+}
+
+test('proxy target: own parsed target reduces absolute-form to path and query', async (t) => {
+  const captured = await capture({
+    path: 'HTTP://untrusted.invalid/absolute/path?foo=bar',
+    proxy: {
+      requestTarget: { pathname: '/absolute/path', search: '?foo=bar' },
+    },
+  })
+
+  t.equal(captured.origin, 'http://configured.invalid')
+  t.equal(captured.path, '/absolute/path?foo=bar')
+})
+
+test('proxy target: safe origin-form wins without inspecting parsed target fields', async (t) => {
+  const captured = await capture({
+    path: '/safe/path?foo=bar',
+    proxy: {
+      requestTarget: { pathname: '//ignored.invalid', search: 42 },
+    },
+  })
+
+  t.equal(captured.path, '/safe/path?foo=bar')
+  t.notOk(Object.hasOwn(captured.proxy, 'requestTarget'), 'one-shot metadata is consumed')
+})
+
+test('proxy target: consumption does not mutate the caller proxy object', async (t) => {
+  const requestTarget = { pathname: '/resource', search: null }
+  const proxy = {
+    name: 'edge',
+    originBoundHeaders: ['nxt-user-id'],
+    requestTarget,
+  }
+
+  const captured = await capture({
+    path: 'http://untrusted.invalid/resource',
+    proxy,
+  })
+
+  t.equal(proxy.requestTarget, requestTarget)
+  t.ok(Object.hasOwn(proxy, 'requestTarget'), 'caller metadata remains present')
+  t.not(captured.proxy, proxy, 'the internal proxy options are isolated')
+  t.notOk(Object.hasOwn(captured.proxy, 'requestTarget'), 'internal metadata is consumed')
+  t.same(captured.proxy.originBoundHeaders, ['nxt-user-id'])
+  t.equal(captured.proxy.name, 'edge')
+})
+
+test('proxy target: an inherited requestTarget is ignored', async (t) => {
+  const inherited = { pathname: '/forged', search: '?forged=1' }
+  const proxy = Object.assign(Object.create({ requestTarget: inherited }), { name: 'edge' })
+  const path = 'http://untrusted.invalid/original?value=1'
+
+  const captured = await capture({ path, proxy })
+
+  t.equal(captured.path, path)
+  t.equal(captured.proxy, proxy)
+  t.notOk(Object.hasOwn(captured.proxy, 'requestTarget'))
+  t.equal(captured.proxy.requestTarget, inherited, 'prototype metadata was not consumed or trusted')
+})
+
+test('proxy target: proxy requests without own metadata retain legacy path behavior', async (t) => {
+  const paths = [
+    'http://untrusted.invalid/absolute?value=1',
+    '//untrusted.invalid/network?value=1',
+    '/\\untrusted.invalid/backslash?value=1',
+    '*',
+  ]
+
+  for (const path of paths) {
+    const captured = await capture({ path, proxy: { name: 'edge' } })
+    t.equal(captured.path, path, path)
+  }
+})
+
+test('proxy target: invalid own-target combinations fail as exposed client errors', async (t) => {
+  const cases = [
+    {
+      name: 'network-path request target',
+      path: '//untrusted.invalid/network',
+      requestTarget: { pathname: '/network', search: '' },
+    },
+    {
+      name: 'slash-backslash request target',
+      path: '/\\untrusted.invalid/backslash',
+      requestTarget: { pathname: '/backslash', search: '' },
+    },
+    {
+      name: 'asterisk-form request target',
+      path: '*',
+      requestTarget: { pathname: '/', search: '' },
+    },
+    {
+      name: 'unsupported absolute scheme',
+      path: 'ftp://untrusted.invalid/resource',
+      requestTarget: { pathname: '/resource', search: '' },
+    },
+    {
+      name: 'missing parsed target',
+      path: 'http://untrusted.invalid/resource',
+      requestTarget: null,
+    },
+    {
+      name: 'ambiguous parsed pathname',
+      path: 'http://untrusted.invalid//network',
+      requestTarget: { pathname: '//network', search: '' },
+    },
+    {
+      name: 'non-string parsed search',
+      path: 'http://untrusted.invalid/resource',
+      requestTarget: { pathname: '/resource', search: 42 },
+    },
+    {
+      name: 'non-string raw path',
+      path: Symbol('request target'),
+      requestTarget: { pathname: '/resource', search: '' },
+    },
+  ]
+
+  for (const { name, path, requestTarget } of cases) {
+    await t.rejects(capture({ path, proxy: { requestTarget } }), BAD_REQUEST, name)
+  }
+})
+
+test('proxy target: query serialization runs after absolute-form canonicalization', async (t) => {
+  const captured = await capture({
+    path: 'http://untrusted.invalid/search',
+    query: { q: 'test', page: 2 },
+    proxy: {
+      requestTarget: { pathname: '/search', search: null },
+    },
+  })
+
+  t.equal(captured.path, '/search?q=test&page=2')
+})
+
+test('proxy target: cache and log observe the canonical path', async (t) => {
+  const cachePaths = []
+  let loggedPath
+  const logger = {
+    child(bindings) {
+      loggedPath = bindings.ureq.path
+      return this
+    },
+    debug() {},
+    error() {},
+    info() {},
+    warn() {},
+  }
+
+  await capture({
+    path: 'http://untrusted.invalid/canonical?value=1',
+    proxy: {
+      requestTarget: { pathname: '/canonical', search: '?value=1' },
+    },
+    cache: {
+      store: {
+        get(key) {
+          cachePaths.push(key.path)
+        },
+        set() {},
+      },
+    },
+    logger,
+  })
+
+  t.same(cachePaths, ['/canonical?value=1'])
+  t.equal(loggedPath, '/canonical?value=1')
+})
+
+test('proxy target: marker rejects an unsafe path introduced by redirect', async (t) => {
+  const attempts = []
+  const dispatcher = (opts, handler) => {
+    attempts.push(opts.path)
+    handler.onConnect(() => {})
+    handler.onHeaders(
+      302,
+      { location: 'http://configured.invalid//reintroduced-by-redirect' },
+      () => {},
+    )
+    handler.onComplete({})
+    return true
+  }
+
+  await t.rejects(
+    run(dispatcher, {
+      path: 'http://untrusted.invalid/start',
+      follow: 2,
+      proxy: {
+        requestTarget: { pathname: '/start', search: null },
+      },
+    }),
+    BAD_REQUEST,
+  )
+  t.same(attempts, ['/start'], 'the unsafe follow-up never reaches the dispatcher')
+})
+
+test('proxy target: marker rejects an unsafe path introduced by retry', async (t) => {
+  const attempts = []
+  let retryCalls = 0
+  const dispatcher = (opts, handler) => {
+    attempts.push(opts.path)
+    handler.onConnect(() => {})
+    handler.onError(Object.assign(new Error('retry me'), { code: 'ECONNRESET' }))
+    return true
+  }
+
+  await t.rejects(
+    run(dispatcher, {
+      path: 'http://untrusted.invalid/start',
+      proxy: {
+        requestTarget: { pathname: '/start', search: null },
+      },
+      retry(err, retryCount, opts) {
+        retryCalls++
+        t.equal(err.code, 'ECONNRESET')
+        t.equal(retryCount, 0)
+        t.equal(opts.path, '/start')
+        t.notOk(Object.hasOwn(opts.proxy, 'requestTarget'))
+        opts.path = 'http://untrusted.invalid/reintroduced-by-retry'
+        return true
+      },
+    }),
+    BAD_REQUEST,
+  )
+  t.equal(retryCalls, 1)
+  t.same(attempts, ['/start'], 'the unsafe retry never reaches the dispatcher')
+})

--- a/test/redirect-origin-bound-headers.js
+++ b/test/redirect-origin-bound-headers.js
@@ -1,0 +1,157 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function cloneHeaders(headers) {
+  if (Array.isArray(headers)) {
+    return [...headers]
+  }
+
+  return headers && typeof headers === 'object' ? { ...headers } : headers
+}
+
+function lowerCaseHeaders(headers) {
+  return Object.fromEntries(
+    Object.entries(headers ?? {}).map(([name, value]) => [name.toLowerCase(), value]),
+  )
+}
+
+function runRedirect(responses, opts) {
+  const attempts = []
+  let responseIndex = 0
+
+  const base = (currentOpts, handler) => {
+    const response = responses[responseIndex++]
+    if (response == null) {
+      throw new Error(`Unexpected redirect attempt ${responseIndex}`)
+    }
+
+    attempts.push({ ...currentOpts, headers: cloneHeaders(currentOpts.headers) })
+    handler.onConnect?.(() => {})
+    handler.onHeaders?.(response.statusCode, response.headers ?? {}, () => {})
+    handler.onComplete?.({})
+    return true
+  }
+
+  const dispatch = compose(base, interceptors.redirect())
+  return new Promise((resolve, reject) => {
+    let statusCode
+
+    try {
+      dispatch(opts, {
+        onConnect() {},
+        onHeaders(nextStatusCode) {
+          statusCode = nextStatusCode
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve({ attempts, statusCode })
+        },
+        onError: reject,
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+const sensitiveHeaders = {
+  Authorization: 'Bearer client-token',
+  Cookie: 'session=client-cookie',
+  'Nxt-User-Id': 'trusted-user',
+  'Proxy-Authorization': 'Basic proxy-token',
+  'X-Preserved': 'yes',
+}
+
+const sensitiveHeaderArray = Object.entries(sensitiveHeaders).flat()
+
+for (const { createHeaders, label } of [
+  { createHeaders: () => ({ ...sensitiveHeaders }), label: 'object replacement' },
+  { createHeaders: () => [...sensitiveHeaderArray], label: 'flat-array replacement' },
+]) {
+  test(`cross-origin redirect strips mandatory and custom headers after ${label}`, async (t) => {
+    const result = await runRedirect(
+      [
+        { statusCode: 302, headers: { location: '/final' } },
+        { statusCode: 200, headers: {} },
+      ],
+      {
+        origin: 'http://source.test',
+        path: '/first',
+        method: 'GET',
+        headers: {},
+        proxy: { originBoundHeaders: ['NXT-USER-ID'] },
+        follow(location, count, opts) {
+          t.equal(location, '/final')
+          t.equal(count, 1)
+          t.equal(this, opts)
+          opts.origin = 'http://destination.test'
+          opts.headers = createHeaders()
+          return true
+        },
+      },
+    )
+
+    const redirectedHeaders = lowerCaseHeaders(result.attempts[1].headers)
+    t.equal(result.statusCode, 200)
+    t.notOk(redirectedHeaders.authorization)
+    t.notOk(redirectedHeaders['proxy-authorization'])
+    t.notOk(redirectedHeaders.cookie)
+    t.notOk(redirectedHeaders['nxt-user-id'])
+    t.equal(redirectedHeaders['x-preserved'], 'yes')
+  })
+}
+
+test('same-origin redirect preserves a configured origin-bound header', async (t) => {
+  const result = await runRedirect(
+    [
+      { statusCode: 302, headers: { location: '/final' } },
+      { statusCode: 200, headers: {} },
+    ],
+    {
+      origin: 'http://source.test',
+      path: '/first',
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer client-token',
+        'nxt-user-id': 'trusted-user',
+      },
+      proxy: { originBoundHeaders: ['nxt-user-id'] },
+      follow: 1,
+    },
+  )
+
+  const redirectedHeaders = lowerCaseHeaders(result.attempts[1].headers)
+  t.equal(result.statusCode, 200)
+  t.equal(redirectedHeaders.authorization, 'Bearer client-token')
+  t.equal(redirectedHeaders['nxt-user-id'], 'trusted-user')
+})
+
+test('cross-origin redirect leaves an unconfigured custom header intact', async (t) => {
+  const result = await runRedirect(
+    [
+      { statusCode: 302, headers: { location: 'http://destination.test/final' } },
+      { statusCode: 200, headers: {} },
+    ],
+    {
+      origin: 'http://source.test',
+      path: '/first',
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer client-token',
+        cookie: 'session=client-cookie',
+        'nxt-user-id': 'trusted-user',
+        'proxy-authorization': 'Basic proxy-token',
+      },
+      proxy: {},
+      follow: 1,
+    },
+  )
+
+  const redirectedHeaders = lowerCaseHeaders(result.attempts[1].headers)
+  t.equal(result.statusCode, 200)
+  t.notOk(redirectedHeaders.authorization)
+  t.notOk(redirectedHeaders['proxy-authorization'])
+  t.notOk(redirectedHeaders.cookie)
+  t.equal(redirectedHeaders['nxt-user-id'], 'trusted-user')
+})

--- a/test/redirect-policy-handoff.js
+++ b/test/redirect-policy-handoff.js
@@ -1,0 +1,143 @@
+import { test } from 'tap'
+import { compose, interceptors } from '../lib/index.js'
+
+function cloneHeaders(headers) {
+  if (Array.isArray(headers)) {
+    return [...headers]
+  }
+
+  return headers && typeof headers === 'object' ? { ...headers } : headers
+}
+
+function runRedirect(responses, opts) {
+  const attempts = []
+  let responseIndex = 0
+
+  const base = (currentOpts, handler) => {
+    const response = responses[responseIndex++]
+    if (response == null) {
+      throw new Error(`Unexpected redirect attempt ${responseIndex}`)
+    }
+
+    attempts.push({ ...currentOpts, headers: cloneHeaders(currentOpts.headers) })
+    handler.onConnect?.(() => {})
+    handler.onHeaders?.(response.statusCode, response.headers ?? {}, () => {})
+    handler.onComplete?.({})
+    return true
+  }
+
+  const dispatch = compose(base, interceptors.redirect())
+  return new Promise((resolve, reject) => {
+    let statusCode
+    let headers
+
+    try {
+      dispatch(opts, {
+        onConnect() {},
+        onHeaders(nextStatusCode, nextHeaders) {
+          statusCode = nextStatusCode
+          headers = nextHeaders
+          return true
+        },
+        onData() {},
+        onComplete() {
+          resolve({ attempts, headers, statusCode })
+        },
+        onError: reject,
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+const redirectChain = [
+  { statusCode: 302, headers: { location: '/second' } },
+  { statusCode: 302, headers: { location: '/final' } },
+]
+
+test('redirect policy replacement keeps live this binding and count', async (t) => {
+  const calls = []
+  const result = await runRedirect(redirectChain, {
+    origin: 'http://source.test',
+    path: '/first',
+    method: 'GET',
+    headers: {},
+    follow(location, count, opts) {
+      calls.push({ count, location, thisMatchesOpts: this === opts })
+      opts.follow = function replacement(nextLocation, nextCount, nextOpts) {
+        calls.push({
+          count: nextCount,
+          location: nextLocation,
+          thisMatchesOpts: this === nextOpts,
+        })
+        return false
+      }
+      return true
+    },
+  })
+
+  t.equal(result.statusCode, 302)
+  t.equal(result.headers.location, '/final')
+  t.equal(result.attempts.length, 2)
+  t.same(calls, [
+    { count: 1, location: '/second', thisMatchesOpts: true },
+    { count: 2, location: '/final', thisMatchesOpts: true },
+  ])
+})
+
+for (const { label, policy } of [
+  { label: 'a number', policy: 1 },
+  { label: 'a counted policy', policy: { count: 1 } },
+]) {
+  test(`redirect policy handoff to ${label} preserves history`, async (t) => {
+    const promise = runRedirect(redirectChain, {
+      origin: 'http://source.test',
+      path: '/first',
+      method: 'GET',
+      headers: {},
+      follow(location, count, opts) {
+        t.equal(location, '/second')
+        t.equal(count, 1)
+        t.equal(this, opts)
+        opts.follow = policy
+        return true
+      },
+    })
+
+    const err = await promise.then(
+      () => null,
+      (reason) => reason,
+    )
+    t.type(err, Error)
+    t.equal(err.message, 'Max redirections reached: 1.')
+    t.same(err.history, ['/second', '/final'])
+  })
+}
+
+for (const { label, policy } of [
+  { label: 'false', policy: false },
+  { label: '0', policy: 0 },
+  { label: 'undefined', policy: undefined },
+]) {
+  test(`redirect policy handoff to ${label} passes through the next redirect`, async (t) => {
+    const result = await runRedirect(redirectChain, {
+      origin: 'http://source.test',
+      path: '/first',
+      method: 'GET',
+      headers: {},
+      follow(location, count, opts) {
+        t.equal(location, '/second')
+        t.equal(count, 1)
+        t.equal(this, opts)
+        opts.follow = policy
+        return true
+      },
+    })
+
+    t.equal(result.statusCode, 302)
+    t.equal(result.headers.location, '/final')
+    t.equal(result.attempts.length, 2)
+    t.equal(result.attempts[1].follow, policy)
+  })
+}

--- a/test/trace-redirect.js
+++ b/test/trace-redirect.js
@@ -1,7 +1,7 @@
 import { test } from 'tap'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
-import { request, Agent } from '../lib/index.js'
+import { request, dispatch, Agent } from '../lib/index.js'
 
 async function startServer(handler) {
   const server = createServer(handler)
@@ -103,4 +103,47 @@ test('trace: 303 doc carries the post-rewrite GET method', async (t) => {
   t.equal(redirects[0].method, 'GET')
   t.ok(redirects[0].from.endsWith('/a'))
   t.ok(redirects[0].to.endsWith('/b'))
+})
+
+test('trace: redirect source keeps the request origin spelling', async (t) => {
+  const writer = makeWriter()
+  let attempt = 0
+  const dispatcher = {
+    dispatch(opts, handler) {
+      attempt++
+      handler.onConnect(() => {})
+      if (attempt === 1) {
+        handler.onHeaders(302, { location: '/b' }, () => {})
+      } else {
+        handler.onHeaders(200, {}, () => {})
+      }
+      handler.onComplete({})
+    },
+  }
+
+  await new Promise((resolve, reject) => {
+    Promise.resolve(
+      dispatch(
+        dispatcher,
+        {
+          origin: 'http://LOCALHOST:80',
+          path: '/a',
+          follow: 1,
+          dns: false,
+          trace: writer,
+        },
+        {
+          onConnect() {},
+          onHeaders() {},
+          onComplete: resolve,
+          onError: reject,
+        },
+      ),
+    ).catch(reject)
+  })
+
+  const start = writer.docs.find((doc) => doc.op === 'undici:request' && doc.phase === 'start')
+  const redirect = writer.docs.find((doc) => doc.op === 'undici:redirect')
+  t.equal(start.url, 'http://LOCALHOST:80/a')
+  t.equal(redirect.from, start.url)
 })

--- a/type-tests/proxy-options.ts
+++ b/type-tests/proxy-options.ts
@@ -1,0 +1,40 @@
+import type { DispatchOptions, FollowFn, ProxyOptions, ProxyRequestTarget } from '../lib/index.js'
+
+const parsedTarget = {
+  origin: 'http://client-selected.example',
+  pathname: '/canonical/path',
+  search: '?value=1',
+} as const satisfies ProxyRequestTarget
+
+const originBoundHeaders = ['nxt-user-id', 'x-tenant-id'] as const
+const proxy = {
+  requestTarget: parsedTarget,
+  originBoundHeaders,
+} satisfies ProxyOptions
+
+const follow: FollowFn = function (location, count, opts) {
+  void [location, count, this]
+  opts.follow = { count: 1 }
+  return true
+}
+
+const options: DispatchOptions = {
+  origin: 'http://configured-upstream.example',
+  path: 'http://client-selected.example/canonical/path?value=1',
+  proxy,
+  follow,
+}
+
+const counted: DispatchOptions = { follow: { count: 2 } }
+const urlTarget: ProxyRequestTarget = new URL('http://client-selected.example/path')
+
+// @ts-expect-error A parsed request target must include a pathname.
+const missingPathname: ProxyRequestTarget = { search: '?value=1' }
+
+// @ts-expect-error Origin-bound header names must be strings.
+const invalidHeaders: ProxyOptions = { originBoundHeaders: ['valid', 1] }
+
+// @ts-expect-error A counted follow policy requires a numeric count.
+const invalidFollow: DispatchOptions = { follow: { count: '2' } }
+
+void [options, counted, urlTarget, missingPathname, invalidHeaders, invalidFollow]


### PR DESCRIPTION
## Summary

- consume an opt-in parsed `proxy.requestTarget` at the public dispatch boundary, reduce valid absolute-form targets to origin-form, and reject ambiguous targets as exposed 400 errors
- preserve legacy proxy path behavior when `requestTarget` is absent and consume parsed target metadata once, without overwriting later redirect/retry paths
- evaluate redirect follow policies live on every hop, including callback replacements and counted/disabled handoffs
- snapshot additional `proxy.originBoundHeaders` and strip them together with credentials after policy mutation when a redirect crosses origins
- add public types and focused coverage for target confinement, policy handoffs, header sanitation, pipeline ordering, and trace provenance

Consumer integration: nxtedition/nxt#12984

## Validation

- focused target/redirect/type/trace suite: 117 passing
- Nxt upstream integration suite against this branch: 54 passing
- full TAP run: 3,884 passing assertions; two unrelated workers were SIGKILLed/time-limited under parallel load and both passed when rerun independently (13 assertions)
- ESLint, Prettier, and `git diff --check`
