### PR TITLE
fix(cache-tests): harden test ID maps and require pass baselines

### DIFF
--- a/cache-tests/README.md
+++ b/cache-tests/README.md
@@ -18,15 +18,17 @@ node cache-tests/run.js --emit-pass-baseline              # regenerate pass-base
 node cache-tests/run.js --heuristic --emit-pass-baseline  # ...and [heuristic]
 ```
 
-A full `--ci` run exits 1 on any of: an unexpected required-kind failure, a
-harness failure, a zero-pass run, a `retried` verdict outside the baseline (a
-duplicate dispatch — this runner composes no retry interceptor, so a retry is a
-double-dispatch bug that also silently drops the test from verification), a
-setup failure outside the baseline, or a **pass-ratchet regression** (a
-previously passing `optimal`/`check` test that stopped passing). The last two
-gates need the full suite, so they are disabled on `--suite`/`--id` subset runs
-— only a full run is equivalent to CI. `test:cache-tests` runs the full gate in
-the default environment and then, if it passes, the `--heuristic` environment.
+A full `--ci` run exits 1 on any of: a missing or empty pass baseline for the
+current environment, an unexpected required-kind failure, a harness failure, a
+zero-pass run, a `retried` verdict outside the baseline (a duplicate dispatch —
+this runner composes no retry interceptor, so a retry is a double-dispatch bug
+that also silently drops the test from verification), a setup failure outside
+the baseline, or a **pass-ratchet regression** (a previously passing
+`optimal`/`check` test that stopped passing). The baseline-presence check happens
+before the suite starts. The setup-failure and pass-ratchet gates need the full
+suite, so they are disabled on `--suite`/`--id` subset runs — only a full run is
+equivalent to CI. `test:cache-tests` runs the full gate in the default
+environment and then, if it passes, the `--heuristic` environment.
 
 ## Layout
 
@@ -55,8 +57,9 @@ the default environment and then, if it passes, the `--heuristic` environment.
   entries that now pass.
 - `pass-baseline.json` — the pass-ratchet: the `optimal`/`check` tests that
   currently pass, keyed per environment (`default` / `heuristic`). CI fails if
-  any baselined test stops passing (a silent regression, e.g. RFC 5861 SWR
-  going non-conformant) and warns about new passes to add. Regenerate with
+  the current environment's baseline is missing or empty, or if any baselined
+  test stops passing (a silent regression, e.g. RFC 5861 SWR going
+  non-conformant), and warns about new passes to add. Regenerate with
   `--emit-pass-baseline` (once per environment).
 
 Vendored from upstream commit `b555b8d8d13950aaffa396689d38177b3de66bcf`

--- a/cache-tests/run.js
+++ b/cache-tests/run.js
@@ -35,6 +35,7 @@ import { compose, interceptors, cache as cacheExports } from '../lib/index.js'
 import { createTestServer } from './engine/server.js'
 import { makeTest, rawRequest } from './engine/client.js'
 import { determineTestResult, resultTypes, testLookup } from './engine/lib/results.mjs'
+import { createTestIdRecord, getPassBaselineError, hasOwnTestId } from './runner-state.js'
 import suites from './tests/index.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -106,7 +107,8 @@ async function main() {
   // Pass-ratchet baseline: the optimal/check tests that currently pass, keyed
   // per environment (heuristic freshness unlocks a superset). A regression —
   // a baselined test no longer passing — gates CI; new passes only warn (add
-  // them via `--emit-pass-baseline`). Absent/empty baseline disables the gate.
+  // them via `--emit-pass-baseline`). Full CI rejects an absent or empty
+  // environment baseline before starting the suite.
   const envKey = args.heuristic ? 'heuristic' : 'default'
   let passBaselineAll = {}
   try {
@@ -115,6 +117,18 @@ async function main() {
     if (err.code !== 'ENOENT') throw err // malformed baseline must not pass silently
   }
   const passBaseline = passBaselineAll[envKey] ?? []
+  const isFullRun = !args.suite && args.id == null
+  const passBaselineError = getPassBaselineError({
+    ci: args.ci,
+    isFullRun,
+    passBaseline,
+    envKey,
+  })
+  if (passBaselineError !== null) {
+    console.error(`\n${passBaselineError}`)
+    process.exitCode = 1
+    return
+  }
 
   const serverHandle = createTestServer()
   const baseUrl = await serverHandle.listen()
@@ -128,7 +142,7 @@ async function main() {
   // Flatten, filter, run in chunks of CHUNK_SIZE concurrently (upstream
   // runSome). Each test is fully isolated by its uuid'd URL.
   const testArray = []
-  const skipped = {}
+  const skipped = createTestIdRecord()
   for (const suite of suitesToRun) {
     for (const test of suite.tests) {
       if (test.id === undefined) throw new Error('Missing test id')
@@ -152,13 +166,13 @@ async function main() {
     process.exit(2)
   }
 
-  const results = {}
+  const results = createTestIdRecord()
   for (let index = 0; index < testArray.length; index += CHUNK_SIZE) {
     const chunk = testArray.slice(index, index + CHUNK_SIZE)
     await Promise.all(
       chunk.map(async (test) => {
         const result = await makeTest(test, ctx)
-        if (test.id in results) throw new Error(`Duplicate test ${test.id}`)
+        if (hasOwnTestId(results, test.id)) throw new Error(`Duplicate test ${test.id}`)
         results[test.id] = result
       }),
     )
@@ -241,13 +255,13 @@ async function main() {
     }
   }
 
-  const unexpectedFailures = stats.failed.filter(([id]) => !(id in knownFailures))
-  const expectedFailures = stats.failed.filter(([id]) => id in knownFailures)
-  const unexpectedSetup = stats.setup.filter(([id]) => !(id in knownSetupFailures))
+  const unexpectedFailures = stats.failed.filter(([id]) => !hasOwnTestId(knownFailures, id))
+  const expectedFailures = stats.failed.filter(([id]) => hasOwnTestId(knownFailures, id))
+  const unexpectedSetup = stats.setup.filter(([id]) => !hasOwnTestId(knownSetupFailures, id))
   // Only a genuine pass makes a known-failure entry stale — a setup/harness
   // failure or retry is not "now passing".
   const passedSet = new Set(stats.passed)
-  const unexpectedRetries = stats.retried.filter(([id]) => !(id in knownRetries))
+  const unexpectedRetries = stats.retried.filter(([id]) => !hasOwnTestId(knownRetries, id))
   const staleKnown = [
     ...Object.keys(knownFailures),
     ...Object.keys(knownSetupFailures),
@@ -269,7 +283,6 @@ async function main() {
   }
   // The ratchet only makes sense against the full suite: a --suite/--id run
   // sees a subset, so every un-run baseline entry would read as a regression.
-  const isFullRun = !args.suite && args.id == null
   const ratchetSet = new Set(ratchetPasses)
   const regressedPasses = isFullRun ? passBaseline.filter((id) => !ratchetSet.has(id)) : []
   const newlyPassing = isFullRun ? ratchetPasses.filter((id) => !passBaseline.includes(id)) : []

--- a/cache-tests/run.js
+++ b/cache-tests/run.js
@@ -35,7 +35,12 @@ import { compose, interceptors, cache as cacheExports } from '../lib/index.js'
 import { createTestServer } from './engine/server.js'
 import { makeTest, rawRequest } from './engine/client.js'
 import { determineTestResult, resultTypes, testLookup } from './engine/lib/results.mjs'
-import { createTestIdRecord, getPassBaselineError, hasOwnTestId } from './runner-state.js'
+import {
+  createTestIdRecord,
+  getPassBaselineError,
+  hasOwnTestId,
+  selectPassBaseline,
+} from './runner-state.js'
 import suites from './tests/index.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -116,7 +121,7 @@ async function main() {
   } catch (err) {
     if (err.code !== 'ENOENT') throw err // malformed baseline must not pass silently
   }
-  const passBaseline = passBaselineAll[envKey] ?? []
+  const passBaseline = selectPassBaseline(passBaselineAll, envKey)
   const isFullRun = !args.suite && args.id == null
   const passBaselineError = getPassBaselineError({
     ci: args.ci,

--- a/cache-tests/runner-state.js
+++ b/cache-tests/runner-state.js
@@ -1,0 +1,16 @@
+export function createTestIdRecord() {
+  return Object.create(null)
+}
+
+export function hasOwnTestId(record, id) {
+  return Object.hasOwn(record, id)
+}
+
+export function getPassBaselineError({ ci, isFullRun, passBaseline, envKey }) {
+  if (!Array.isArray(passBaseline)) {
+    return `pass-baseline.json["${envKey}"] must be an array.`
+  }
+  if (!ci || !isFullRun || passBaseline.length !== 0) return null
+
+  return `pass-baseline.json is missing or has no "${envKey}" entries — the pass-ratchet is disabled. Regenerate it with --emit-pass-baseline.`
+}

--- a/cache-tests/runner-state.js
+++ b/cache-tests/runner-state.js
@@ -6,6 +6,18 @@ export function hasOwnTestId(record, id) {
   return Object.hasOwn(record, id)
 }
 
+export function selectPassBaseline(passBaselineAll, envKey) {
+  if (
+    typeof passBaselineAll !== 'object' ||
+    passBaselineAll === null ||
+    Array.isArray(passBaselineAll)
+  ) {
+    throw new TypeError('pass-baseline.json must contain an object.')
+  }
+
+  return Object.hasOwn(passBaselineAll, envKey) ? passBaselineAll[envKey] : []
+}
+
 export function getPassBaselineError({ ci, isFullRun, passBaseline, envKey }) {
   if (!Array.isArray(passBaseline)) {
     return `pass-baseline.json["${envKey}"] must be an array.`

--- a/test/cache-tests-runner-state.js
+++ b/test/cache-tests-runner-state.js
@@ -3,6 +3,7 @@ import {
   createTestIdRecord,
   getPassBaselineError,
   hasOwnTestId,
+  selectPassBaseline,
 } from '../cache-tests/runner-state.js'
 
 const prototypeIds = ['__proto__', 'constructor', 'hasOwnProperty', 'toString', 'valueOf']
@@ -65,5 +66,33 @@ test('full CI requires a populated pass baseline', (t) => {
     getPassBaselineError({ ...fullCi, passBaseline: {} }),
     'pass-baseline.json["default"] must be an array.',
   )
+  t.equal(
+    getPassBaselineError({ ...fullCi, passBaseline: null }),
+    'pass-baseline.json["default"] must be an array.',
+  )
+  t.end()
+})
+
+test('pass baseline selection distinguishes missing and malformed shapes', (t) => {
+  const baseline = ['passing-test']
+
+  t.strictSame(selectPassBaseline({}, 'default'), [], 'a missing environment is empty')
+  t.equal(selectPassBaseline({ default: baseline }, 'default'), baseline)
+  t.equal(
+    selectPassBaseline({ default: null }, 'default'),
+    null,
+    'an explicit null remains malformed instead of becoming empty',
+  )
+
+  for (const malformed of [null, [], 'baseline', 1, true]) {
+    t.throws(
+      () => selectPassBaseline(malformed, 'default'),
+      {
+        name: 'TypeError',
+        message: 'pass-baseline.json must contain an object.',
+      },
+      `${JSON.stringify(malformed)} is not a top-level baseline object`,
+    )
+  }
   t.end()
 })

--- a/test/cache-tests-runner-state.js
+++ b/test/cache-tests-runner-state.js
@@ -1,0 +1,69 @@
+import { test } from 'tap'
+import {
+  createTestIdRecord,
+  getPassBaselineError,
+  hasOwnTestId,
+} from '../cache-tests/runner-state.js'
+
+const prototypeIds = ['__proto__', 'constructor', 'hasOwnProperty', 'toString', 'valueOf']
+
+test('cache-test ID records accept Object.prototype names', (t) => {
+  const results = createTestIdRecord()
+
+  t.equal(Object.getPrototypeOf(results), null)
+  for (const id of prototypeIds) {
+    t.notOk(hasOwnTestId(results, id), `${id} starts absent`)
+    results[id] = true
+    t.ok(hasOwnTestId(results, id), `${id} is stored as an own property`)
+    t.equal(results[id], true, `${id} remains readable by property lookup`)
+  }
+  t.strictSame(Object.keys(results), prototypeIds)
+  t.equal(
+    JSON.stringify(results),
+    '{"__proto__":true,"constructor":true,"hasOwnProperty":true,"toString":true,"valueOf":true}',
+  )
+
+  t.end()
+})
+
+test('cache-test baseline lookups ignore inherited properties', (t) => {
+  const emptyBaseline = JSON.parse('{}')
+  for (const id of prototypeIds) {
+    t.notOk(hasOwnTestId(emptyBaseline, id), `${id} is not inherited into the baseline`)
+  }
+
+  const ownBaseline = JSON.parse('{"__proto__":"known","constructor":"known","toString":"known"}')
+  for (const id of ['__proto__', 'constructor', 'toString']) {
+    t.ok(hasOwnTestId(ownBaseline, id), `${id} is recognized when explicitly baselined`)
+  }
+  t.end()
+})
+
+test('full CI requires a populated pass baseline', (t) => {
+  const fullCi = { ci: true, isFullRun: true, envKey: 'default' }
+
+  t.equal(
+    getPassBaselineError({ ...fullCi, passBaseline: [] }),
+    'pass-baseline.json is missing or has no "default" entries — the pass-ratchet is disabled. Regenerate it with --emit-pass-baseline.',
+  )
+  t.equal(getPassBaselineError({ ...fullCi, passBaseline: ['passing-test'] }), null)
+  t.equal(
+    getPassBaselineError({ ...fullCi, ci: false, passBaseline: [] }),
+    null,
+    'non-CI runs may regenerate a missing baseline',
+  )
+  t.equal(
+    getPassBaselineError({ ...fullCi, isFullRun: false, passBaseline: [] }),
+    null,
+    'subset CI runs do not require a full-suite baseline',
+  )
+  t.equal(
+    getPassBaselineError({ ...fullCi, envKey: 'heuristic', passBaseline: [] }),
+    'pass-baseline.json is missing or has no "heuristic" entries — the pass-ratchet is disabled. Regenerate it with --emit-pass-baseline.',
+  )
+  t.equal(
+    getPassBaselineError({ ...fullCi, passBaseline: {} }),
+    'pass-baseline.json["default"] must be an array.',
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary
- store cache-test results and skipped IDs in null-prototype records, with own-property checks for duplicate and known-baseline membership
- validate the top-level and selected pass-baseline shapes, then reject missing or empty full-CI baselines before starting the test server
- add focused regression coverage and document the full-CI baseline requirement

## Why
The harness accepts upstream test IDs as object keys. IDs such as `toString`, `constructor`, or `__proto__` can otherwise collide with inherited properties or mutate an Object-prototype-backed result map.

A missing per-environment pass baseline also silently disables the optimal/check regression ratchet. The previous implementation proposal detected that only after running the entire suite.

Supersedes #244.

## Validation
- `node test/cache-tests-runner-state.js` — 41 assertions passed
- `npm run test:cache-tests` — default and heuristic full suites passed
- `node --check` on the runner, helper, and regression test
- focused ESLint and Prettier checks
- integration probes confirmed malformed top-level/selected baseline shapes fail before indexing, missing and empty baselines fail full CI before suite startup, and subset CI remains allowed
