### PR TITLE
fix(deps): align scheduler and trace majors

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,8 +100,8 @@ export interface LoggerLike {
  *  is enabled and null while disabled (it flips between the two at runtime).
  *  The per-thread fallback writer lives in the Symbol.for('@nxtedition/app/trace')
  *  slot and must be installed via the package's installTrace(). */
-export type { TraceWriter } from '@nxtedition/trace'
-import type { TraceWriter } from '@nxtedition/trace'
+export type { TraceWriter } from '@nxtedition/trace/core'
+import type { TraceWriter } from '@nxtedition/trace/core'
 
 export type BodyFactoryResult =
   Readable | ArrayBuffer | ArrayBufferView | string | Iterable<unknown> | AsyncIterable<unknown>
@@ -148,7 +148,7 @@ export interface DispatchOptions {
   logger?: LoggerLike | null
   userAgent?: string | null
   /** Per-request trace writer: undefined falls back to the per-thread writer
-   *  installed via @nxtedition/trace's installTrace(), null disables tracing
+   *  installed via @nxtedition/trace/core's installTrace(), null disables tracing
    *  for this request. */
   trace?: TraceWriter | null
   dns?: DnsOptions | boolean | null

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -246,7 +246,11 @@ export default () => (dispatch) => {
     // guard avoids deleting a freshly-created replacement; release() drains
     // pending synchronously, so running===0 && pending===0 here means idle.
     const onIdle = () => {
-      if (schedulers.get(key) === scheduler && scheduler.running === 0 && scheduler.pending === 0) {
+      if (schedulers.get(key) !== scheduler) {
+        return
+      }
+      const { running, pending } = scheduler.stats
+      if (running === 0 && pending === 0) {
         schedulers.delete(key)
       }
     }
@@ -311,7 +315,7 @@ export default () => (dispatch) => {
           key: trace.key,
           priority: trace.priority,
           phase: 'queued',
-          pending: scheduler.pending,
+          pending: scheduler.stats.pending,
           waitMs: null,
           holdMs: null,
         },

--- a/lib/trace.d.ts
+++ b/lib/trace.d.ts
@@ -1,6 +1,6 @@
-import type { TraceWriter } from '@nxtedition/trace'
+import type { TraceWriter } from '@nxtedition/trace/core'
 
-export { installTrace, traceErr, traceSafe, traceWrite } from '@nxtedition/trace'
+export { installTrace, traceErr, traceSafe, traceWrite } from '@nxtedition/trace/core'
 
 export function validateTrace(trace: unknown): TraceWriter | null | undefined
 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,13 +1,10 @@
 // Trace plumbing shared by the interceptors. The writer contract and the
-// generic helpers live in @nxtedition/trace; only the nxt-undici-specific
+// generic helpers live in @nxtedition/trace/core; only the nxt-undici-specific
 // pieces (dispatch-opts url tagging, undici-flavored option validation) are
 // implemented here.
 //
-// Importing @nxtedition/trace statically is safe despite the package cycle
-// (@nxtedition/trace flushes through nxt-undici): the trace package imports
-// nxt-undici lazily at first flush precisely so consumers can depend on it
-// statically. The only constraint is publish order — @nxtedition/trace must
-// be published before a nxt-undici release that depends on it.
+// Use the dependency-free core entry so this hot path does not load the trace
+// transport facade, which flushes through nxt-undici.
 //
 // The contract in short: a writer is `{ write }` where `write` is the trace
 // function while tracing is enabled and null while disabled (it flips between
@@ -17,19 +14,19 @@
 // unsupported.
 
 import { errors } from '@nxtedition/undici'
-import { validateTrace as validateTraceWriter } from '@nxtedition/trace'
+import { validateTrace as validateTraceWriter } from '@nxtedition/trace/core'
 
 const { InvalidArgumentError } = errors
 
 // installTrace is part of the surface: the per-thread default writer lives in
 // the Symbol.for('@nxtedition/app/trace') slot and is mirrored
-// module-locally inside @nxtedition/trace, so a
+// module-locally inside @nxtedition/trace/core, so a
 // writer must be installed through installTrace — a bare slot assignment only
 // propagates on the next mirror refresh.
-export { traceWrite, traceSafe, traceErr, installTrace } from '@nxtedition/trace'
+export { traceWrite, traceSafe, traceErr, installTrace } from '@nxtedition/trace/core'
 
 /**
- * @typedef {import('@nxtedition/trace').TraceWriter} TraceWriter
+ * @typedef {import('@nxtedition/trace/core').TraceWriter} TraceWriter
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lib/*"
   ],
   "dependencies": {
-    "@nxtedition/scheduler": "^4.2.6",
-    "@nxtedition/trace": "^1.1.4",
+    "@nxtedition/scheduler": "^5.0.0",
+    "@nxtedition/trace": "^2.0.0",
     "@nxtedition/undici": "^12.0.0",
     "fast-querystring": "^1.1.2",
     "http-errors": "^2.0.1",

--- a/type-tests/trace-deep-import.ts
+++ b/type-tests/trace-deep-import.ts
@@ -1,4 +1,4 @@
-import type { TraceWriter } from '@nxtedition/trace'
+import type { TraceWriter } from '@nxtedition/trace/core'
 import {
   installTrace,
   traceErr,


### PR DESCRIPTION
## Summary

- require `@nxtedition/scheduler@^5.0.0`
- require `@nxtedition/trace@^2.0.0`
- use Trace 2's dependency-free `@nxtedition/trace/core` entry for runtime imports and public types
- use Scheduler 5's public `stats` API instead of reading private `running` and `pending` fields

## Why

The published `@nxtedition/nxt-undici@8.0.4` still declares the previous Scheduler and Trace majors. This aligns nxt-undici with the published lib major train, updates its runtime and type contracts, and avoids loading Trace's transport facade back through nxt-undici's hot path.

## Release

**Semver major:** publish this as `@nxtedition/nxt-undici@9.0.0` after merge. The major classification is for dependency-contract, runtime, and public-type risk; it is not caused by the Node 26 requirement.

The manifest remains at `8.0.4` in this PR, following the repository's normal separate post-merge version/tag release commit.

## Cross-package release order

`@nxtedition/trace@2.0.0` currently depends on `@nxtedition/nxt-undici@^8.0.4`. Before publishing nxt-undici 9, publish a Trace 2 patch that also accepts nxt-undici 9 (for example `^8.0.4 || ^9.0.0`). The `^2.0.0` range in this PR will accept that patch and avoid retaining the legacy Scheduler 4 / Trace 1 subtree in fresh installs.

## Validation

- `npm test` — 3,996 assertions: 3,992 passed, 4 skipped; TypeScript API tests passed
- `npm ls @nxtedition/scheduler @nxtedition/trace --depth=0` — resolves Scheduler 5.0.0 and Trace 2.0.0
- `npm pack --dry-run --json` — passed
- pre-commit ESLint and Prettier checks — passed