### PR TITLE
fix(cache): version sqlite filename

### DIFF
--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -5,6 +5,12 @@ import { parseHttpDate, parseRangeHeader, getFastNow } from './utils.js'
 const VERSION = 14
 const CACHE_TABLE = `cacheInterceptorV${VERSION}`
 
+// Isolate schema versions at the file level so rolling deployments never
+// contend on or inspect another version's database.
+function versionedLocation(location) {
+  return location === ':memory:' ? location : `${location}.v${VERSION}`
+}
+
 class SqliteCacheSchemaError extends Error {
   code = 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH'
 
@@ -178,7 +184,7 @@ export class SqliteCacheStore {
     this.#dbTimeout = opts?.db?.timeout ?? this.#dbTimeout
     this.#maxEntrySize = opts?.maxEntrySize
     this.#maxEntryTTL = opts?.maxEntryTTL
-    this.#db = new DatabaseSync(opts?.location ?? ':memory:', {
+    this.#db = new DatabaseSync(versionedLocation(opts?.location ?? ':memory:'), {
       ...opts?.db,
       timeout: this.#dbTimeout,
     })

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -1,4 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
+import fs from 'node:fs'
+import path from 'node:path'
 import { parseHttpDate, parseRangeHeader, getFastNow } from './utils.js'
 
 // Bump version when the URL key format or schema changes to invalidate old caches.
@@ -8,7 +10,11 @@ const CACHE_TABLE = `cacheInterceptorV${VERSION}`
 // Isolate schema versions at the file level so rolling deployments never
 // contend on or inspect another version's database.
 function versionedLocation(location) {
-  return location === ':memory:' ? location : `${location}.v${VERSION}`
+  if (location === ':memory:') {
+    return location
+  }
+  fs.mkdirSync(location, { recursive: true })
+  return path.join(location, `v${VERSION}`)
 }
 
 class SqliteCacheSchemaError extends Error {

--- a/test/cache-coverage-sqlite-store.js
+++ b/test/cache-coverage-sqlite-store.js
@@ -40,6 +40,7 @@ function makeValue(overrides = {}) {
 
 // set() is async (batched via setImmediate); one tick lets a flush run.
 const flush = () => new Promise((resolve) => setImmediate(resolve))
+const versionedDb = (location) => `${location}.v14`
 
 // Poll until fn() is truthy, bounded by a deadline (never wait forever).
 async function waitFor(fn, timeout = 5000) {
@@ -57,10 +58,12 @@ function tmpDb(t, prefix) {
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
-      try {
-        fs.unlinkSync(dbPath + ext)
-      } catch {}
+    for (const location of [dbPath, versionedDb(dbPath)]) {
+      for (const ext of ['', '-wal', '-shm']) {
+        try {
+          fs.unlinkSync(location + ext)
+        } catch {}
+      }
     }
   })
   return dbPath
@@ -68,7 +71,7 @@ function tmpDb(t, prefix) {
 
 // Count rows in the current-version cache table of a CLOSED file-backed store.
 function countRows(dbPath) {
-  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const db = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   try {
     const table = db
       .prepare(
@@ -120,7 +123,7 @@ test('constructor honors opts.db.timeout and maxSize with a file-backed db', asy
 test('old-version tables fail hard, prefix-sharing user tables are kept', (t) => {
   const dbPath = tmpDb(t, 'schema-mismatch')
 
-  const seed = new DatabaseSync(dbPath)
+  const seed = new DatabaseSync(versionedDb(dbPath))
   seed.exec(`
     CREATE TABLE cacheInterceptorV1 (id INTEGER PRIMARY KEY, url TEXT);
     INSERT INTO cacheInterceptorV1 (url) VALUES ('https://old.example.com/');
@@ -137,7 +140,7 @@ test('old-version tables fail hard, prefix-sharing user tables are kept', (t) =>
   }
   t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
 
-  const check = new DatabaseSync(dbPath, { readOnly: true })
+  const check = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   t.teardown(() => check.close())
   const tables = check
     .prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`)
@@ -1101,7 +1104,7 @@ test('makeResult fails closed for an unexpected persisted Authorization marker',
   await flush()
   store.close()
 
-  const db = new DatabaseSync(dbPath)
+  const db = new DatabaseSync(versionedDb(dbPath))
   db.prepare('UPDATE cacheInterceptorV14 SET authorizationRequest = ?').run(2)
   db.close()
 

--- a/test/cache-coverage-sqlite-store.js
+++ b/test/cache-coverage-sqlite-store.js
@@ -40,7 +40,7 @@ function makeValue(overrides = {}) {
 
 // set() is async (batched via setImmediate); one tick lets a flush run.
 const flush = () => new Promise((resolve) => setImmediate(resolve))
-const versionedDb = (location) => `${location}.v14`
+const versionedDb = (location) => path.join(location, 'v14')
 
 // Poll until fn() is truthy, bounded by a deadline (never wait forever).
 async function waitFor(fn, timeout = 5000) {
@@ -57,14 +57,9 @@ function tmpDb(t, prefix) {
     os.tmpdir(),
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
+  fs.mkdirSync(dbPath, { recursive: true })
   t.teardown(() => {
-    for (const location of [dbPath, versionedDb(dbPath)]) {
-      for (const ext of ['', '-wal', '-shm']) {
-        try {
-          fs.unlinkSync(location + ext)
-        } catch {}
-      }
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
   return dbPath
 }

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -16,6 +16,7 @@ import { makeKey } from '../lib/interceptor/cache/store.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
+const versionedDb = (location) => `${location}.v14`
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -795,9 +796,9 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
   const store = new SqliteCacheStore({ location: dbPath })
   t.teardown(() => {
     store.close()
-    fs.rmSync(dbPath, { force: true })
-    fs.rmSync(`${dbPath}-wal`, { force: true })
-    fs.rmSync(`${dbPath}-shm`, { force: true })
+    for (const ext of ['', '-wal', '-shm']) {
+      fs.rmSync(versionedDb(dbPath) + ext, { force: true })
+    }
   })
 
   const key = { origin: 'https://example.com', method: 'GET', path: '/hot' }
@@ -822,7 +823,7 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
 
   t.equal(store.get(key).body.toString(), 'three', 'newest entry served')
 
-  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const db = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   const { c } = db
     .prepare(`SELECT COUNT(*) c FROM cacheInterceptorV14 WHERE url = ?`)
     .get('https://example.com/hot')

--- a/test/cache-storability.js
+++ b/test/cache-storability.js
@@ -16,7 +16,7 @@ import { makeKey } from '../lib/interceptor/cache/store.js'
 import undici from '@nxtedition/undici'
 
 const { SqliteCacheStore } = cacheModule
-const versionedDb = (location) => `${location}.v14`
+const versionedDb = (location) => path.join(location, 'v14')
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -796,9 +796,7 @@ test('store: re-caching a key supersedes the old row instead of accumulating', a
   const store = new SqliteCacheStore({ location: dbPath })
   t.teardown(() => {
     store.close()
-    for (const ext of ['', '-wal', '-shm']) {
-      fs.rmSync(versionedDb(dbPath) + ext, { force: true })
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
 
   const key = { origin: 'https://example.com', method: 'GET', path: '/hot' }

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -12,19 +12,14 @@ function tmpDb(t, prefix) {
     os.tmpdir(),
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
+  fs.mkdirSync(dbPath, { recursive: true })
   t.teardown(() => {
-    for (const location of [dbPath, versionedDb(dbPath)]) {
-      for (const ext of ['', '-wal', '-shm', '-journal']) {
-        try {
-          fs.unlinkSync(location + ext)
-        } catch {}
-      }
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
   return dbPath
 }
 
-const versionedDb = (location) => `${location}.v14`
+const versionedDb = (location, version = 14) => path.join(location, `v${version}`)
 
 function tableNames(db) {
   return db
@@ -33,9 +28,21 @@ function tableNames(db) {
     .map(({ name }) => name)
 }
 
-test('v14 uses a separate filename and leaves the legacy database untouched', (t) => {
+test('constructor creates a nested cache location', (t) => {
+  const root = tmpDb(t, 'nested-location')
+  const location = path.join(root, 'nested', 'cache')
+
+  const store = new SqliteCacheStore({ location })
+  store.close()
+
+  t.ok(fs.existsSync(versionedDb(location)), 'the v14 database was created below location')
+  t.end()
+})
+
+test('v14 uses a separate file and leaves the v13 database untouched', (t) => {
   const dbPath = tmpDb(t, 'schema-v13-to-v14')
-  const seed = new DatabaseSync(dbPath)
+  const oldPath = versionedDb(dbPath, 13)
+  const seed = new DatabaseSync(oldPath)
   seed.exec(`
     CREATE TABLE cacheInterceptorV13 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -46,15 +53,15 @@ test('v14 uses a separate filename and leaves the legacy database untouched', (t
       VALUES ('https://old.example.com/secret', x'deadbeef');
   `)
   seed.close()
-  const before = fs.readFileSync(dbPath)
+  const before = fs.readFileSync(oldPath)
 
   const store = new SqliteCacheStore({ location: dbPath })
   store.close()
 
-  t.strictSame(fs.readFileSync(dbPath), before, 'the v13 database is byte-for-byte unchanged')
-  t.ok(fs.existsSync(versionedDb(dbPath)), 'the v14 database uses a versioned filename')
+  t.strictSame(fs.readFileSync(oldPath), before, 'the v13 database is byte-for-byte unchanged')
+  t.ok(fs.existsSync(versionedDb(dbPath)), 'the v14 database uses a versioned path')
 
-  const check = new DatabaseSync(dbPath, { readOnly: true })
+  const check = new DatabaseSync(oldPath, { readOnly: true })
   t.teardown(() => check.close())
   t.strictSame(
     tableNames(check).filter((name) => /^cacheInterceptorV\d+$/.test(name)),

--- a/test/review-bugfixes-4-sqlite-stale-tables.js
+++ b/test/review-bugfixes-4-sqlite-stale-tables.js
@@ -1,6 +1,5 @@
-// SQLite cache files are intentionally never migrated or destructively
-// repaired. A different cache schema version or corrupt database is an
-// operator-visible startup failure, and the file must remain untouched.
+// SQLite cache files are versioned by schema so rolling deployments never
+// open, migrate, or destructively repair another package version's data.
 import { test } from 'tap'
 import os from 'node:os'
 import path from 'node:path'
@@ -14,14 +13,18 @@ function tmpDb(t, prefix) {
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm', '-journal']) {
-      try {
-        fs.unlinkSync(dbPath + ext)
-      } catch {}
+    for (const location of [dbPath, versionedDb(dbPath)]) {
+      for (const ext of ['', '-wal', '-shm', '-journal']) {
+        try {
+          fs.unlinkSync(location + ext)
+        } catch {}
+      }
     }
   })
   return dbPath
 }
+
+const versionedDb = (location) => `${location}.v14`
 
 function tableNames(db) {
   return db
@@ -30,7 +33,7 @@ function tableNames(db) {
     .map(({ name }) => name)
 }
 
-test('v13 is rejected byte-for-byte before the v14 table is created', (t) => {
+test('v14 uses a separate filename and leaves the legacy database untouched', (t) => {
   const dbPath = tmpDb(t, 'schema-v13-to-v14')
   const seed = new DatabaseSync(dbPath)
   seed.exec(`
@@ -45,30 +48,27 @@ test('v13 is rejected byte-for-byte before the v14 table is created', (t) => {
   seed.close()
   const before = fs.readFileSync(dbPath)
 
-  let error
-  try {
-    new SqliteCacheStore({ location: dbPath })
-    t.fail('construction should reject schema v13')
-  } catch (err) {
-    error = err
-  }
+  const store = new SqliteCacheStore({ location: dbPath })
+  store.close()
 
-  t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
-  t.match(error?.message, /expected cacheInterceptorV14, found cacheInterceptorV13/)
   t.strictSame(fs.readFileSync(dbPath), before, 'the v13 database is byte-for-byte unchanged')
+  t.ok(fs.existsSync(versionedDb(dbPath)), 'the v14 database uses a versioned filename')
 
   const check = new DatabaseSync(dbPath, { readOnly: true })
   t.teardown(() => check.close())
   t.strictSame(
     tableNames(check).filter((name) => /^cacheInterceptorV\d+$/.test(name)),
     ['cacheInterceptorV13'],
-    'v14 was not created and v13 was not dropped',
+    'v13 was not dropped or modified',
   )
   t.equal(
     check.prepare('SELECT hex(body) AS body FROM cacheInterceptorV13').get().body,
     'DEADBEEF',
     'v13 data remains readable to an operator-selected older package',
   )
+  const current = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
+  t.teardown(() => current.close())
+  t.ok(tableNames(current).includes('cacheInterceptorV14'), 'v14 was created separately')
   t.end()
 })
 
@@ -101,7 +101,7 @@ test('v14 operates and persists Authorization provenance with response Date', (t
   t.equal(value?.authorizationRequest, true)
   reopened.close()
 
-  const check = new DatabaseSync(dbPath, { readOnly: true })
+  const check = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   t.teardown(() => check.close())
   t.ok(tableNames(check).includes('cacheInterceptorV14'), 'the current v14 table exists')
   const columns = check.prepare('PRAGMA table_info(cacheInterceptorV14)').all()
@@ -118,7 +118,8 @@ test('v14 operates and persists Authorization provenance with response Date', (t
 
 test('incompatible cache schema versions fail without modifying the database', (t) => {
   const dbPath = tmpDb(t, 'schema-mismatch')
-  const seed = new DatabaseSync(dbPath)
+  const currentPath = versionedDb(dbPath)
+  const seed = new DatabaseSync(currentPath)
   seed.exec(`
     CREATE TABLE cacheInterceptorV99998 (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -150,7 +151,7 @@ test('incompatible cache schema versions fail without modifying the database', (
   t.equal(error?.code, 'ERR_SQLITE_CACHE_SCHEMA_MISMATCH')
   t.match(error?.message, /cacheInterceptorV99998, cacheInterceptorV99999/)
 
-  const check = new DatabaseSync(dbPath, { readOnly: true })
+  const check = new DatabaseSync(currentPath, { readOnly: true })
   t.teardown(() => check.close())
   const numericCacheTables = tableNames(check).filter((name) => /^cacheInterceptorV\d+$/.test(name))
   t.strictSame(
@@ -173,7 +174,8 @@ test('incompatible cache schema versions fail without modifying the database', (
 
 test('non-version tables sharing the cache prefix remain compatible', (t) => {
   const dbPath = tmpDb(t, 'prefix-table')
-  const seed = new DatabaseSync(dbPath)
+  const currentPath = versionedDb(dbPath)
+  const seed = new DatabaseSync(currentPath)
   seed.exec(`
     CREATE TABLE cacheInterceptorVBackup (k TEXT PRIMARY KEY, v TEXT);
     INSERT INTO cacheInterceptorVBackup (k, v) VALUES ('keep', 'me');
@@ -183,7 +185,7 @@ test('non-version tables sharing the cache prefix remain compatible', (t) => {
   const store = new SqliteCacheStore({ location: dbPath })
   store.close()
 
-  const check = new DatabaseSync(dbPath, { readOnly: true })
+  const check = new DatabaseSync(currentPath, { readOnly: true })
   t.teardown(() => check.close())
   t.equal(
     check.prepare('SELECT v FROM cacheInterceptorVBackup WHERE k = ?').get('keep').v,
@@ -199,8 +201,9 @@ test('non-version tables sharing the cache prefix remain compatible', (t) => {
 
 test('corrupt database fails hard and is not replaced', (t) => {
   const dbPath = tmpDb(t, 'corrupt-db')
+  const currentPath = versionedDb(dbPath)
   const original = Buffer.from('this is not a sqlite database')
-  fs.writeFileSync(dbPath, original)
+  fs.writeFileSync(currentPath, original)
 
   let error
   try {
@@ -210,13 +213,13 @@ test('corrupt database fails hard and is not replaced', (t) => {
     error = err
   }
   t.equal(error?.errcode, 26, 'original SQLITE_NOTADB error propagates')
-  t.strictSame(fs.readFileSync(dbPath), original, 'corrupt file is preserved byte-for-byte')
+  t.strictSame(fs.readFileSync(currentPath), original, 'corrupt file is preserved byte-for-byte')
   t.end()
 })
 
 test('a close() failure during schema-error cleanup does not mask the original error', (t) => {
   const dbPath = tmpDb(t, 'schema-close-fail')
-  const seed = new DatabaseSync(dbPath)
+  const seed = new DatabaseSync(versionedDb(dbPath))
   seed.exec('CREATE TABLE cacheInterceptorV99999 (id INTEGER PRIMARY KEY);')
   seed.close()
 

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -44,21 +44,16 @@ function makeValue(overrides = {}) {
 
 const flush = () => new Promise((resolve) => setImmediate(resolve))
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-const versionedDb = (location) => `${location}.v14`
+const versionedDb = (location) => path.join(location, 'v14')
 
 function tmpDb(t, prefix) {
   const dbPath = path.join(
     os.tmpdir(),
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
+  fs.mkdirSync(dbPath, { recursive: true })
   t.teardown(() => {
-    for (const location of [dbPath, versionedDb(dbPath)]) {
-      for (const ext of ['', '-wal', '-shm']) {
-        try {
-          fs.unlinkSync(location + ext)
-        } catch {}
-      }
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
   return dbPath
 }

--- a/test/review-bugfixes-5-sqlite.js
+++ b/test/review-bugfixes-5-sqlite.js
@@ -44,6 +44,7 @@ function makeValue(overrides = {}) {
 
 const flush = () => new Promise((resolve) => setImmediate(resolve))
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const versionedDb = (location) => `${location}.v14`
 
 function tmpDb(t, prefix) {
   const dbPath = path.join(
@@ -51,10 +52,12 @@ function tmpDb(t, prefix) {
     `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}.sqlite`,
   )
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
-      try {
-        fs.unlinkSync(dbPath + ext)
-      } catch {}
+    for (const location of [dbPath, versionedDb(dbPath)]) {
+      for (const ext of ['', '-wal', '-shm']) {
+        try {
+          fs.unlinkSync(location + ext)
+        } catch {}
+      }
     }
   })
   return dbPath
@@ -114,7 +117,7 @@ test('schema v14: Date-ordered lookup needs no temp B-tree; body is last', async
   t.ok(store.get(makeKey()), 'sanity: entry readable')
   store.close()
 
-  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const db = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   t.teardown(() => db.close())
   const table = db
     .prepare(
@@ -165,7 +168,7 @@ test('constructor retries SQLITE_BUSY while another process holds the write lock
         db.close()
       }, 500)
       `,
-      dbPath,
+      versionedDb(dbPath),
     ],
     { stdio: ['ignore', 'pipe', 'inherit'] },
   )
@@ -198,7 +201,7 @@ test('max_page_count uses the actual page size of a pre-existing DB file', async
   // Pin a 1024-byte page size before the store ever sees the file. With the
   // hard-coded 4096 the byte cap becomes maxSize/4 and eviction churns at a
   // quarter of the configured budget.
-  const seed = new DatabaseSync(dbPath)
+  const seed = new DatabaseSync(versionedDb(dbPath))
   seed.exec(`
     PRAGMA page_size = 1024;
     CREATE TABLE seed (x INTEGER);
@@ -263,7 +266,7 @@ test('equivalent vary maps serialize canonically so supersede replaces instead o
   store.set(makeKey(), makeValue({ vary: { 'accept-encoding': 'gzip', b: 'y' } }))
   await flush()
 
-  const db = new DatabaseSync(dbPath, { readOnly: true })
+  const db = new DatabaseSync(versionedDb(dbPath), { readOnly: true })
   t.teardown(() => db.close())
   const table = db
     .prepare(

--- a/test/review-bugfixes-store.js
+++ b/test/review-bugfixes-store.js
@@ -6,6 +6,8 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
+const versionedDb = (location) => `${location}.v14`
+
 function makeKey(overrides = {}) {
   return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
 }
@@ -105,7 +107,7 @@ test('close() persists a large batch that exceeds one flush time slice', (t) => 
   t.teardown(() => {
     for (const ext of ['', '-wal', '-shm']) {
       try {
-        fs.unlinkSync(dbPath + ext)
+        fs.unlinkSync(versionedDb(dbPath) + ext)
       } catch {}
     }
   })

--- a/test/review-bugfixes-store.js
+++ b/test/review-bugfixes-store.js
@@ -6,8 +6,6 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
-const versionedDb = (location) => `${location}.v14`
-
 function makeKey(overrides = {}) {
   return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
 }
@@ -105,11 +103,7 @@ test('vary: header absent at store time must miss when a later request supplies 
 test('close() persists a large batch that exceeds one flush time slice', (t) => {
   const dbPath = tmpDb('cache-close-large')
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
-      try {
-        fs.unlinkSync(versionedDb(dbPath) + ext)
-      } catch {}
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
 
   const N = 20000

--- a/test/sqlite-cache-store.js
+++ b/test/sqlite-cache-store.js
@@ -5,6 +5,8 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
+const versionedDb = (location) => `${location}.v14`
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1026,7 +1028,7 @@ test('file-based store persists data across instances', (t) => {
   t.teardown(() => {
     for (const ext of ['', '-wal', '-shm']) {
       try {
-        fs.unlinkSync(dbPath + ext)
+        fs.unlinkSync(versionedDb(dbPath) + ext)
       } catch {}
     }
   })
@@ -1052,7 +1054,7 @@ test('close() flushes pending items before closing the DB', (t) => {
   t.teardown(() => {
     for (const ext of ['', '-wal', '-shm']) {
       try {
-        fs.unlinkSync(dbPath + ext)
+        fs.unlinkSync(versionedDb(dbPath) + ext)
       } catch {}
     }
   })

--- a/test/sqlite-cache-store.js
+++ b/test/sqlite-cache-store.js
@@ -5,8 +5,6 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
-const versionedDb = (location) => `${location}.v14`
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1026,11 +1024,7 @@ test('file-based store persists data across instances', (t) => {
   // so data written with set() is always readable by the next instance.
   const dbPath = path.join(os.tmpdir(), `cache-test-${Date.now()}.sqlite`)
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
-      try {
-        fs.unlinkSync(versionedDb(dbPath) + ext)
-      } catch {}
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
 
   const store1 = new SqliteCacheStore({ location: dbPath })
@@ -1052,11 +1046,7 @@ test('file-based store persists data across instances', (t) => {
 test('close() flushes pending items before closing the DB', (t) => {
   const dbPath = path.join(os.tmpdir(), `cache-close-${Date.now()}.sqlite`)
   t.teardown(() => {
-    for (const ext of ['', '-wal', '-shm']) {
-      try {
-        fs.unlinkSync(versionedDb(dbPath) + ext)
-      } catch {}
-    }
+    fs.rmSync(dbPath, { recursive: true, force: true })
   })
 
   const store = new SqliteCacheStore({ location: dbPath })

--- a/test/sqlite-store-error-contract.js
+++ b/test/sqlite-store-error-contract.js
@@ -18,7 +18,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { DatabaseSync, StatementSync } from 'node:sqlite'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
-const versionedDb = (location) => `${location}.v14`
+const versionedDb = (location) => path.join(location, 'v14')
 
 function makeKey(overrides = {}) {
   return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }

--- a/test/sqlite-store-error-contract.js
+++ b/test/sqlite-store-error-contract.js
@@ -18,6 +18,8 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { DatabaseSync, StatementSync } from 'node:sqlite'
 import { SqliteCacheStore } from '../lib/sqlite-cache-store.js'
 
+const versionedDb = (location) => `${location}.v14`
+
 function makeKey(overrides = {}) {
   return { origin: 'https://example.com', method: 'GET', path: '/test', ...overrides }
 }
@@ -85,7 +87,7 @@ test('delete() warns instead of throwing when the database is locked', async (t)
 
   // A second connection holding the write lock makes the store's DELETE hit
   // SQLITE_BUSY once its 5ms busy timeout expires.
-  const locker = new DatabaseSync(dbPath)
+  const locker = new DatabaseSync(versionedDb(dbPath))
   locker.exec('PRAGMA busy_timeout = 5')
   locker.exec('BEGIN IMMEDIATE')
   t.teardown(() => {


### PR DESCRIPTION
## Summary

- treat each file-backed cache `location` as a directory and create it recursively
- store the SQLite schema below it at `<location>/v14`
- keep `:memory:` behavior unchanged
- update direct database and lock-contention tests to use the physical versioned path
- cover rolling-deployment isolation by proving a sibling v13 database remains byte-for-byte untouched

## Why

Like nxtedition/lib#528, schema versions should not open the same physical SQLite file. Keeping versioned databases beneath the configured location isolates rolling deployments and gives each cache location a predictable directory layout.

## Validation

- Node v26.5.0
- 7 focused SQLite/cache suites run directly: 470 assertions passing
- `yarn test:types`
- ESLint on all changed files
- Prettier check on all changed files

The repository's committed lockfile is currently out of sync with `package.json` for `@nxtedition/trace`, and the refreshed Tap wrapper loads its TypeScript plugin despite the checked-in exclusion, so the full `yarn test` wrapper could not be used locally.