### PR TITLE
feat(cache): expose cache and dispatcher statistics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -322,6 +322,53 @@ export interface PressureInterceptor {
   [Symbol.dispose](): void
 }
 
+export interface SqliteCacheStoreStats {
+  gets: number
+  hits: number
+  sets: number
+  writes: number
+  deletes: number
+  flushes: number
+  gcs: number
+  clears: number
+  evictions: number
+  errors: number
+  pending: number
+  hitRate: number
+  /** Allocated SQLite pages in bytes, including freelist pages. */
+  size: number
+  /** Allocated non-freelist SQLite pages in bytes. */
+  usedSize: number
+  maxSize: number
+  closed: boolean
+}
+
+export interface CacheStats {
+  hits: number
+  misses: number
+  /** Background plus foreground validation attempts. */
+  revalidations: number
+  /** Cache-configured requests that cannot use the lookup path. */
+  bypasses: number
+  /** `hits / (hits + misses)`; zero before the first lookup. */
+  hitRate: number
+  store?: Omit<SqliteCacheStoreStats, 'closed'> & { stores: number }
+}
+
+export interface CacheInterceptorOptions {
+  origins?: Array<string | RegExp>
+}
+
+export interface CacheInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  stats(): CacheStats
+}
+
+export interface GlobalDispatcherStats {
+  cache: CacheStats
+  pressure: Array<PressureStats & { origin: string }>
+}
+
 export interface CacheKey {
   origin: string
   method: string
@@ -374,6 +421,7 @@ export interface CacheStore {
   gc(): void
   clear(): void
   close(): void
+  readonly stats?: Partial<SqliteCacheStoreStats>
 }
 
 /** `upgrade` is omitted: request()'s internal handler has no onUpgrade, so any
@@ -408,6 +456,11 @@ export function compose(
   ...interceptors: (Interceptor | null | undefined)[]
 ): DispatchFn
 
+/** Aggregate cache and pressure snapshots for every live dispatcher wrapped
+ * by this module in the current thread. Also exposed through the global
+ * `Symbol.for('@nxtedition/nxt-undici/dispatcher-stats')` provider. */
+export function getGlobalDispatcherStats(): GlobalDispatcherStats
+
 export function parseHeaders(headers?: HeaderInput | null): Record<string, string | string[]>
 
 export const interceptors: {
@@ -419,7 +472,7 @@ export const interceptors: {
   log: (opts?: LogInterceptorOptions) => Interceptor
   redirect: () => Interceptor
   proxy: () => Interceptor
-  cache: () => Interceptor
+  cache: (opts?: CacheInterceptorOptions) => CacheInterceptor
   requestId: () => Interceptor
   dns: () => Interceptor
   lookup: () => Interceptor
@@ -456,6 +509,7 @@ export class SqliteCacheStore implements CacheStore {
   close(): void
   readonly maxEntrySize: number | undefined
   readonly maxEntryTTL: number | undefined
+  readonly stats: SqliteCacheStoreStats
 }
 
 export { Client, Pool, Agent, getGlobalDispatcher, setGlobalDispatcher } from '@nxtedition/undici'

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,14 @@ import { SqliteCacheStore } from './sqlite-cache-store.js'
 import { validateTrace } from './trace.js'
 
 const dispatcherCache = new WeakMap()
+const dispatcherStatsRegistrySymbol = Symbol.for('@nxtedition/nxt-undici/dispatcher-stats/registry')
+const dispatcherStatsProviderSymbol = Symbol.for('@nxtedition/nxt-undici/dispatcher-stats')
+const dispatcherStatsRegistry =
+  globalThis[dispatcherStatsRegistrySymbol] ??
+  (globalThis[dispatcherStatsRegistrySymbol] = new Set())
+const dispatcherStatsFinalizer = new FinalizationRegistry((ref) => {
+  dispatcherStatsRegistry.delete(ref)
+})
 const proxyInterceptors = await import('./interceptor/proxy.js')
 
 export const interceptors = {
@@ -101,10 +109,74 @@ export function compose(...interceptors) {
 }
 
 const PRIORITY_TOS = [0x04, 0x04, 0x04, 0x00, 0x68, 0x88, 0xb8]
+const CACHE_STORE_COUNTERS = [
+  'gets',
+  'hits',
+  'sets',
+  'writes',
+  'deletes',
+  'flushes',
+  'gcs',
+  'clears',
+  'evictions',
+  'errors',
+  'pending',
+  'size',
+  'usedSize',
+  'maxSize',
+]
+
+export function getGlobalDispatcherStats() {
+  const cacheStats = {
+    hits: 0,
+    misses: 0,
+    revalidations: 0,
+    bypasses: 0,
+    hitRate: 0,
+  }
+  const storeStats = { stores: 0 }
+  for (const counter of CACHE_STORE_COUNTERS) {
+    storeStats[counter] = 0
+  }
+  const pressure = []
+
+  for (const ref of dispatcherStatsRegistry) {
+    const dispatcher = ref.deref()
+    if (dispatcher === undefined) {
+      dispatcherStatsRegistry.delete(ref)
+      continue
+    }
+
+    const stats = dispatcher.stats()
+    for (const counter of ['hits', 'misses', 'revalidations', 'bypasses']) {
+      cacheStats[counter] += stats.cache[counter]
+    }
+    if (stats.cache.store) {
+      storeStats.stores += stats.cache.store.stores
+      for (const counter of CACHE_STORE_COUNTERS) {
+        storeStats[counter] += stats.cache.store[counter]
+      }
+    }
+    pressure.push(...stats.pressure)
+  }
+
+  const lookups = cacheStats.hits + cacheStats.misses
+  cacheStats.hitRate = lookups === 0 ? 0 : cacheStats.hits / lookups
+  if (storeStats.stores > 0) {
+    storeStats.hitRate = storeStats.gets === 0 ? 0 : storeStats.hits / storeStats.gets
+    cacheStats.store = storeStats
+  }
+
+  return { cache: cacheStats, pressure }
+}
+
+globalThis[dispatcherStatsProviderSymbol] = getGlobalDispatcherStats
 
 function wrapDispatch(dispatcher) {
   let wrappedDispatcher = dispatcherCache.get(dispatcher)
   if (wrappedDispatcher == null) {
+    const cache = interceptors.cache()
+    const pressure = interceptors.pressure()
     wrappedDispatcher = compose(
       dispatcher,
       // The wrapped dispatcher is an arbitrary user boundary. It may retain or
@@ -125,11 +197,15 @@ function wrapDispatch(dispatcher) {
       proxyInterceptors.proxyRequest(),
       interceptors.responseRetry(),
       interceptors.responseVerify(),
+      // Observe logical-origin pressure outside retry but below the cache: a
+      // cache hit creates no upstream load, while retries share one lifecycle
+      // record and retain the caller-facing origin before DNS rewrites it.
+      pressure,
       // Keep response filtering outside responseRetry. Retry must observe the
       // upstream Trailer field before the proxy strips it so it can disable
       // unsafe buffering/resumption for responses that announce trailers.
       proxyInterceptors.proxyResponse(),
-      interceptors.cache(),
+      cache,
       interceptors.redirect(),
       // log also emits the undici:request trace start/end docs. Later entries
       // in this list wrap earlier ones, so it sits OUTSIDE everything that
@@ -251,6 +327,10 @@ function wrapDispatch(dispatcher) {
         )
       },
     )
+    wrappedDispatcher.stats = () => ({ cache: cache.stats(), pressure: pressure.stats() })
+    const statsRef = new WeakRef(wrappedDispatcher)
+    dispatcherStatsRegistry.add(statsRef)
+    dispatcherStatsFinalizer.register(wrappedDispatcher, statsRef)
     dispatcherCache.set(dispatcher, wrappedDispatcher)
   }
   return wrappedDispatcher

--- a/lib/interceptor/cache/index.js
+++ b/lib/interceptor/cache/index.js
@@ -18,6 +18,7 @@ import { InvalidationHandler } from './invalidation-handler.js'
 import { RevalidationHandler, backgroundRefresh, fastFailoverRetry } from './revalidation.js'
 import { serveFromCache, traceLookup } from './serve.js'
 import { cacheOptsOf, getStore, makeKey, normalizeOrigin, tryGetEntry } from './store.js'
+import { CacheStats } from './stats.js'
 
 /**
  * Validates the optional `origins` whitelist (undici PR #4739): undefined (the
@@ -93,8 +94,21 @@ function notModifiedEntry(entry) {
 
 export default ({ origins } = {}) => {
   assertCacheOrigins(origins, 'opts.origins')
-  return (dispatch) => (opts, handler) => {
-    if (!opts.cache || opts.upgrade) {
+  const stats = new CacheStats()
+  const hit = (...args) => {
+    stats.hit()
+    return serveFromCache(...args)
+  }
+  const miss = (...args) => {
+    stats.miss()
+    return serveFromCache(...args)
+  }
+  const interceptor = (dispatch) => (opts, handler) => {
+    if (!opts.cache) {
+      return dispatch(opts, handler)
+    }
+    if (opts.upgrade) {
+      stats.bypass()
       return dispatch(opts, handler)
     }
 
@@ -112,6 +126,7 @@ export default ({ origins } = {}) => {
     // configured, a request to any other origin bypasses the cache entirely —
     // neither stored/served nor invalidated.
     if (origins !== undefined && !originAllowed(opts.origin, origins)) {
+      stats.bypass()
       return dispatch(opts, handler)
     }
 
@@ -122,6 +137,7 @@ export default ({ origins } = {}) => {
     const write = traceWrite(opts.trace)
 
     if (opts.method !== 'GET' && opts.method !== 'HEAD') {
+      stats.bypass()
       // RFC 9110 §9.2.1: OPTIONS and TRACE are safe — never cached, but they
       // must not invalidate either. Every other method (POST/PUT/DELETE/...)
       // invalidates the target URI on a non-error response (RFC 9111 §4.4).
@@ -130,6 +146,7 @@ export default ({ origins } = {}) => {
       }
 
       const store = getStore(opts)
+      stats.trackStore(store)
       if (typeof store.delete !== 'function') {
         // User-supplied store without invalidation support.
         return dispatch(opts, handler)
@@ -179,6 +196,7 @@ export default ({ origins } = {}) => {
 
     const onlyIfCached = requestCacheControl['only-if-cached'] === true
     const store = getStore(opts)
+    stats.trackStore(store)
 
     // The lookup is timed only while tracing is on (performance.now() is not
     // free); a store get that throws settles as a miss inside tryGetEntry.
@@ -296,7 +314,7 @@ export default ({ origins } = {}) => {
         ? headers['if-none-match'].join(',')
         : headers['if-none-match']
       if (typeof ifNoneMatch === 'string' && entry.etag && weakMatch(ifNoneMatch, entry.etag)) {
-        return serveFromCache(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
+        return hit(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
       }
       // If-None-Match didn't match (RFC 9110 §13.1.2): "proceed as normal".
       // The entry is fresh, so serve the stored 200 below (fall through)
@@ -308,7 +326,7 @@ export default ({ origins } = {}) => {
         lastModified &&
         new Date(lastModified) <= new Date(headers['if-modified-since'])
       ) {
-        return serveFromCache(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
+        return hit(notModifiedEntry(entry), opts, handler, write, url, lookupMs)
       }
       // Modified since the caller's validator (or no comparable last-modified):
       // RFC 9110 §13.1.3 — proceed as normal. The entry is fresh, so serve the
@@ -344,6 +362,7 @@ export default ({ origins } = {}) => {
       if (write !== null) {
         traceLookup(write, opts, url, 'bypass', 'conditional', null, null, null, lookupMs)
       }
+      stats.bypass()
       return dispatch(opts, handler)
     }
 
@@ -375,9 +394,9 @@ export default ({ origins } = {}) => {
         // this key; otherwise the origin is off-limits and there is nothing to
         // write back → synthetic 504.
         if (entry != null && entry.statusCode !== 206 && fresh && !mustRevalidate) {
-          return serveFromCache(entry, opts, handler, write, url, lookupMs)
+          return hit(entry, opts, handler, write, url, lookupMs)
         }
-        return serveFromCache(
+        return miss(
           { statusCode: 504 },
           opts,
           handler,
@@ -391,6 +410,7 @@ export default ({ origins } = {}) => {
       if (write !== null) {
         traceLookup(write, opts, url, 'miss', 'conditional', null, null, null, lookupMs)
       }
+      stats.miss()
       return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
     }
 
@@ -398,7 +418,7 @@ export default ({ origins } = {}) => {
       if (onlyIfCached) {
         // RFC 9111 §5.2.1.7: no stored response usable without contacting the
         // origin — 504. Not a hit: it is a miss the request forbade origin for.
-        return serveFromCache(
+        return miss(
           { statusCode: 504 },
           opts,
           handler,
@@ -417,11 +437,12 @@ export default ({ origins } = {}) => {
       if (write !== null) {
         traceLookup(write, opts, url, 'miss', missReason, null, null, null, lookupMs)
       }
+      stats.miss()
       return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
     }
 
     if (fresh && !mustRevalidate) {
-      return serveFromCache(entry, opts, handler, write, url, lookupMs)
+      return hit(entry, opts, handler, write, url, lookupMs)
     }
 
     // RFC 9111 §5.2.1.2: the caller accepts staleness up to max-stale (bare
@@ -436,12 +457,12 @@ export default ({ origins } = {}) => {
       !forbidsRequestDrivenStale(entry) &&
       now <= entry.staleAt + requestCacheControl['max-stale'] * 1000
     ) {
-      return serveFromCache(entry, opts, handler, write, url, lookupMs, 'hit', 'max-stale')
+      return hit(entry, opts, handler, write, url, lookupMs, 'hit', 'max-stale')
     }
 
     if (onlyIfCached) {
       // Stale (or validation-demanding) entry and the origin is off-limits.
-      return serveFromCache(
+      return miss(
         { statusCode: 504 },
         opts,
         handler,
@@ -458,6 +479,7 @@ export default ({ origins } = {}) => {
       if (write !== null) {
         traceLookup(write, opts, url, 'miss', '206', null, null, null, lookupMs)
       }
+      stats.miss()
       return dispatch(opts, requestCacheControl['no-store'] ? handler : cacheHandler())
     }
 
@@ -472,6 +494,8 @@ export default ({ origins } = {}) => {
       typeof entry.cacheControlDirectives?.['stale-while-revalidate'] === 'number' &&
       now <= entry.staleAt + entry.cacheControlDirectives['stale-while-revalidate'] * 1000
     ) {
+      stats.hit()
+      stats.revalidate()
       try {
         serveFromCache(entry, opts, handler, write, url, lookupMs, 'hit', 'stale-while-revalidate')
       } finally {
@@ -507,6 +531,8 @@ export default ({ origins } = {}) => {
       staleIfError > 0 &&
       now <= entry.staleAt + staleIfError * 1000
 
+    stats.miss()
+    stats.revalidate()
     return dispatch(
       {
         ...opts,
@@ -541,4 +567,7 @@ export default ({ origins } = {}) => {
       }),
     )
   }
+
+  interceptor.stats = () => stats.snapshot()
+  return interceptor
 }

--- a/lib/interceptor/cache/stats.js
+++ b/lib/interceptor/cache/stats.js
@@ -1,0 +1,105 @@
+const STORE_COUNTERS = [
+  'gets',
+  'hits',
+  'sets',
+  'writes',
+  'deletes',
+  'flushes',
+  'gcs',
+  'clears',
+  'evictions',
+  'errors',
+  'pending',
+  'size',
+  'usedSize',
+  'maxSize',
+]
+
+export class CacheStats {
+  #hits = 0
+  #misses = 0
+  #revalidations = 0
+  #bypasses = 0
+  #storeRefs = new Set()
+  #stores = new WeakMap()
+  #registry = new FinalizationRegistry((ref) => this.#storeRefs.delete(ref))
+
+  hit() {
+    this.#hits++
+  }
+
+  miss() {
+    this.#misses++
+  }
+
+  revalidate() {
+    this.#revalidations++
+  }
+
+  bypass() {
+    this.#bypasses++
+  }
+
+  trackStore(store) {
+    if ((typeof store !== 'object' || store === null) && typeof store !== 'function') {
+      return
+    }
+    if (this.#stores.has(store)) {
+      return
+    }
+
+    const ref = new WeakRef(store)
+    this.#stores.set(store, ref)
+    this.#storeRefs.add(ref)
+    this.#registry.register(store, ref, store)
+  }
+
+  snapshot() {
+    const lookups = this.#hits + this.#misses
+    const snapshot = {
+      hits: this.#hits,
+      misses: this.#misses,
+      revalidations: this.#revalidations,
+      bypasses: this.#bypasses,
+      hitRate: lookups === 0 ? 0 : this.#hits / lookups,
+    }
+
+    const store = { stores: 0 }
+    for (const counter of STORE_COUNTERS) {
+      store[counter] = 0
+    }
+
+    for (const ref of this.#storeRefs) {
+      const target = ref.deref()
+      if (target === undefined) {
+        this.#storeRefs.delete(ref)
+        continue
+      }
+
+      let stats
+      try {
+        stats = target.stats
+      } catch {
+        continue
+      }
+      if (stats == null || typeof stats !== 'object') {
+        continue
+      }
+
+      store.stores++
+      for (const counter of STORE_COUNTERS) {
+        const value = stats[counter]
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          store[counter] += value
+        }
+      }
+    }
+
+    if (store.stores > 0) {
+      store.hitRate = store.gets === 0 ? 0 : store.hits / store.gets
+      snapshot.store = store
+    }
+
+    return snapshot
+  }
+}

--- a/lib/sqlite-cache-store.js
+++ b/lib/sqlite-cache-store.js
@@ -172,11 +172,37 @@ export class SqliteCacheStore {
    */
   #supersede206Query
 
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #pageCountQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #freelistCountQuery
+
   #insertBatch = []
   #insertSeq = 0
   #closed = false
   #maxEntrySize
   #maxEntryTTL
+  #maxSize
+  #pageSize
+  #pageCount = 0
+  #freelistCount = 0
+  #stats = {
+    gets: 0,
+    hits: 0,
+    sets: 0,
+    writes: 0,
+    deletes: 0,
+    flushes: 0,
+    gcs: 0,
+    clears: 0,
+    evictions: 0,
+    errors: 0,
+  }
 
   /**
    * @type {WeakRef<SqliteCacheStore>}
@@ -216,12 +242,14 @@ export class SqliteCacheStore {
     }
 
     const maxSize = opts?.maxSize ?? 256 * 1024 * 1024
+    this.#maxSize = maxSize
     // page_size is a persistent property fixed when the file's first page is
     // written; a pre-existing DB may not use 4096. max_page_count is the one
     // pragma denominated in pages, so compute it from the file's real page
     // size — hard-coding 4096 would cap a 1024-byte-page file at maxSize/4
     // (constant premature-FULL eviction churn) and a 8192 one at 2x maxSize.
     const pageSize = this.#withBusyRetry(() => this.#db.prepare('PRAGMA page_size').get().page_size)
+    this.#pageSize = pageSize
     // Multi-process cold start on a shared DB file: another process's flush
     // transaction or wal_checkpoint can hold the write lock while we run the
     // schema DDL, surfacing SQLITE_BUSY (sometimes immediately — DDL does not
@@ -366,6 +394,8 @@ export class SqliteCacheStore {
     this.#supersede206Query = this.#db.prepare(
       `DELETE FROM cacheInterceptorV${VERSION} WHERE url = ? AND method = ? AND vary IS ? AND statusCode = 206 AND start = ? AND end = ?`,
     )
+    this.#pageCountQuery = this.#db.prepare('PRAGMA page_count')
+    this.#freelistCountQuery = this.#db.prepare('PRAGMA freelist_count')
 
     this.#ref = new WeakRef(this)
     stores.add(this.#ref)
@@ -401,22 +431,53 @@ export class SqliteCacheStore {
     return this.#maxEntryTTL
   }
 
+  get stats() {
+    this.#refreshStorageStats()
+    const gets = this.#stats.gets
+    return {
+      ...this.#stats,
+      pending: this.#insertBatch.length,
+      hitRate: gets === 0 ? 0 : this.#stats.hits / gets,
+      size: this.#pageCount * this.#pageSize,
+      usedSize: (this.#pageCount - this.#freelistCount) * this.#pageSize,
+      maxSize: this.#maxSize,
+      closed: this.#closed,
+    }
+  }
+
+  #refreshStorageStats() {
+    if (this.#closed) {
+      return
+    }
+    try {
+      this.#pageCount = this.#pageCountQuery.get().page_count
+      this.#freelistCount = this.#freelistCountQuery.get().freelist_count
+    } catch {
+      // Stats are best-effort and must never disrupt the cache hot path. Keep
+      // the most recent page snapshot when another process temporarily owns
+      // the database lock or the store is closing.
+    }
+  }
+
   gc() {
     if (this.#closed) {
       return
     }
 
+    this.#stats.gcs++
     try {
       this.#db.exec('PRAGMA busy_timeout = 1000')
       this.#deleteExpiredValuesQuery.run(getFastNow())
       this.#db.exec('PRAGMA wal_checkpoint(TRUNCATE)')
       this.#db.exec('PRAGMA optimize')
     } catch (err) {
+      this.#stats.errors++
       process.emitWarning(err)
     } finally {
       try {
         this.#db.exec(`PRAGMA busy_timeout = ${this.#dbTimeout}`)
       } catch (err) {
+        this.#stats.errors++
         process.emitWarning(err)
       }
     }
@@ -429,17 +490,20 @@ export class SqliteCacheStore {
       return
     }
 
+    this.#stats.clears++
     try {
       this.#db.exec('PRAGMA busy_timeout = 1000')
       this.#db.exec(`DELETE FROM cacheInterceptorV${VERSION}`)
       this.#db.exec('PRAGMA wal_checkpoint(TRUNCATE)')
       this.#db.exec('PRAGMA optimize')
     } catch (err) {
+      this.#stats.errors++
       process.emitWarning(err)
     } finally {
       try {
         this.#db.exec(`PRAGMA busy_timeout = ${this.#dbTimeout}`)
       } catch (err) {
+        this.#stats.errors++
         process.emitWarning(err)
       }
     }
@@ -459,6 +523,7 @@ export class SqliteCacheStore {
     if (this.#insertBatch.length > 0) {
       this.#flush(true)
     }
+    this.#refreshStorageStats()
     this.#closed = true
     this.#db.close()
   }
@@ -474,7 +539,17 @@ export class SqliteCacheStore {
       return undefined
     }
 
-    const value = this.#findValue(key)
+    this.#stats.gets++
+    let value
+    try {
+      value = this.#findValue(key)
+    } catch (err) {
+      this.#stats.errors++
+      throw err
+    }
+    if (value) {
+      this.#stats.hits++
+    }
     return value ? makeResult(value) : undefined
   }
 
@@ -589,6 +664,7 @@ export class SqliteCacheStore {
     }
 
     this.#insertBatch.push(entry)
+    this.#stats.sets++
   }
 
   /**
@@ -609,6 +685,8 @@ export class SqliteCacheStore {
       return
     }
 
+    this.#stats.deletes++
+
     const url = makeValueUrl(key)
 
     for (let i = this.#insertBatch.length - 1; i >= 0; i--) {
@@ -626,6 +704,7 @@ export class SqliteCacheStore {
     try {
       this.#deleteByUrlQuery.run(url)
     } catch (err) {
+      this.#stats.errors++
       process.emitWarning(err)
     }
   }
@@ -701,6 +780,8 @@ export class SqliteCacheStore {
             }
           }
           this.#db.exec('COMMIT')
+          this.#stats.flushes++
+          this.#stats.writes += n
           this.#insertBatch.splice(0, n)
           break
         } catch (err) {
@@ -716,13 +797,14 @@ export class SqliteCacheStore {
             try {
               this.#db.exec('ROLLBACK')
             } catch (err) {
+              this.#stats.errors++
               process.emitWarning(err)
             }
           }
 
           if (err?.errcode === 13 /* SQLITE_FULL */ && retryCount < 3) {
             try {
-              this.#evictQuery.run(256)
+              this.#stats.evictions += this.#evictQuery.run(256).changes
             } catch (evictErr) {
               // The eviction itself failed (cross-process SQLITE_BUSY on a
               // shared file, genuinely full disk): retrying cannot make
@@ -731,6 +813,7 @@ export class SqliteCacheStore {
               // would make the setImmediate reschedule at the bottom
               // busy-loop forever, one warning per iteration.
               process.emitWarning(evictErr)
+              this.#stats.errors++
               this.#insertBatch.splice(0, n || this.#insertBatch.length)
               throw err
             }
@@ -744,6 +827,7 @@ export class SqliteCacheStore {
         }
       }
     } catch (err) {
+      this.#stats.errors++
       process.emitWarning(err)
     }
 

--- a/test/cache-stats.js
+++ b/test/cache-stats.js
@@ -1,0 +1,190 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { test } from 'tap'
+import undici from '@nxtedition/undici'
+import {
+  dispatch as nxtDispatch,
+  getGlobalDispatcherStats,
+  interceptors,
+  SqliteCacheStore,
+} from '../lib/index.js'
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(status) {
+        statusCode = status
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  return server
+}
+
+function makeKey(path = '/') {
+  return { origin: 'https://example.test', method: 'GET', path }
+}
+
+function makeValue() {
+  const now = Date.now()
+  return {
+    body: Buffer.from('cached'),
+    start: 0,
+    end: 6,
+    statusCode: 200,
+    statusMessage: 'OK',
+    cachedAt: now,
+    staleAt: now + 60e3,
+    deleteAt: now + 120e3,
+  }
+}
+
+test('cache interceptor exposes zero-cost disabled and cache-configured bypass stats', (t) => {
+  const cache = interceptors.cache()
+  let dispatched = 0
+  const dispatch = cache(() => {
+    dispatched++
+    return true
+  })
+
+  dispatch({ cache: false }, {})
+  dispatch({ cache: true, upgrade: 'websocket' }, {})
+
+  t.equal(dispatched, 2)
+  t.same(cache.stats(), {
+    hits: 0,
+    misses: 0,
+    revalidations: 0,
+    bypasses: 1,
+    hitRate: 0,
+  })
+  t.end()
+})
+
+test('cache interceptor reports useful hit, miss, revalidation, and store totals', async (t) => {
+  let requests = 0
+  const server = await startServer((req, res) => {
+    requests++
+    if (req.url === '/revalidate' && req.headers['if-none-match'] === '"v1"') {
+      res.writeHead(304, { etag: '"v1"', 'cache-control': 's-maxage=0' })
+      res.end()
+      return
+    }
+    const revalidate = req.url === '/revalidate'
+    res.writeHead(200, {
+      etag: '"v1"',
+      'cache-control': revalidate ? 's-maxage=0' : 's-maxage=60',
+    })
+    res.end(revalidate ? 'validate' : 'fresh')
+  })
+  t.teardown(() => server.close())
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const agent = new undici.Agent()
+  const cache = interceptors.cache()
+  const dispatch = cache(agent.dispatch.bind(agent))
+  t.teardown(() => store.close())
+  t.teardown(() => agent.close())
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const opts = (path) => ({ origin, path, method: 'GET', headers: {}, cache: { store } })
+
+  await rawRequest(dispatch, opts('/fresh'))
+  await rawRequest(dispatch, opts('/fresh'))
+  await rawRequest(dispatch, opts('/revalidate'))
+  await rawRequest(dispatch, opts('/revalidate'))
+
+  t.equal(requests, 3, 'one fresh response is served without upstream I/O')
+  t.match(cache.stats(), {
+    hits: 1,
+    misses: 3,
+    revalidations: 1,
+    bypasses: 0,
+    hitRate: 0.25,
+    store: {
+      stores: 1,
+      gets: 4,
+      hits: 2,
+      sets: 3,
+    },
+  })
+})
+
+test('SqliteCacheStore stats expose operations, queue depth, and capacity', async (t) => {
+  const store = new SqliteCacheStore({ location: ':memory:', maxSize: 1024 * 1024 })
+
+  store.set(makeKey(), makeValue())
+  t.match(store.stats, { sets: 1, writes: 0, pending: 1, maxSize: 1024 * 1024 })
+
+  await new Promise((resolve) => setImmediate(resolve))
+  t.equal(store.get(makeKey()).body.toString(), 'cached')
+  t.equal(store.get(makeKey('/missing')), undefined)
+  store.delete(makeKey())
+  store.gc()
+  store.clear()
+
+  t.match(store.stats, {
+    gets: 2,
+    hits: 1,
+    hitRate: 0.5,
+    writes: 1,
+    flushes: 1,
+    deletes: 1,
+    gcs: 1,
+    clears: 1,
+    pending: 0,
+    errors: 0,
+  })
+  t.ok(store.stats.size > 0)
+  t.ok(store.stats.usedSize > 0)
+
+  store.close()
+  t.equal(store.stats.closed, true)
+})
+
+test('wrapped dispatcher stats globally include cache and pressure snapshots', async (t) => {
+  const server = await startServer((_req, res) => {
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('global')
+  })
+  t.teardown(() => server.close())
+
+  const store = new SqliteCacheStore({ location: ':memory:' })
+  const agent = new undici.Agent()
+  t.teardown(() => store.close())
+  t.teardown(() => agent.close())
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const dispatch = (opts, handler) => nxtDispatch(agent, opts, handler)
+  const opts = { origin, path: '/', method: 'GET', headers: {}, cache: { store } }
+
+  await rawRequest(dispatch, opts)
+  await rawRequest(dispatch, opts)
+
+  const stats = getGlobalDispatcherStats()
+  t.match(stats.cache, { hits: 1, misses: 1, hitRate: 0.5 })
+  t.match(
+    stats.pressure.find((entry) => entry.origin === origin),
+    {
+      pending: 0,
+      running: 0,
+      completed: 1,
+    },
+  )
+})


### PR DESCRIPTION
## What

- expose cumulative hit, miss, revalidation, and bypass counters through `interceptors.cache().stats()`
- expose SQLite cache operation, queue, error, eviction, and capacity snapshots through `SqliteCacheStore.stats`
- aggregate cache plus pressure snapshots for all live wrapped dispatchers in the current thread through `getGlobalDispatcherStats()` and the global dispatcher-stats symbol provider

## Why

The proxy is currently the only cache-enabled production path. These counters make its effective cache hit rate, store lookup rate, revalidation load, write behavior, and capacity usage observable so cache sizing and policy can be tuned from production evidence.

Cache-disabled requests do not affect the cache counters. A hit means no foreground origin request was needed; a miss means foreground origin work was required or forbidden by `only-if-cached`.

## Impact

Counters are cumulative for the dispatcher or store lifetime and rates are calculated at scrape time. SQLite page usage is sampled only when stats are read, without scanning cache rows.

## Checks

- `node --test` cache, pressure, SQLite, and trace regression selection: 1499 passing
- `node --test test/cache-stats.js`: 13 passing
- `yarn test:types`
- ESLint and Prettier on changed files