### PR TITLE
feat: expose interceptor statistics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -322,6 +322,81 @@ export interface PressureInterceptor {
   [Symbol.dispose](): void
 }
 
+export interface SchedulerQueueStats {
+  /** Gauge: tasks currently queued at this priority. */
+  count: number
+  /** Counter: tasks ever queued at this priority. */
+  deferred: number
+  /** Counter: queued tasks ever admitted at this priority. */
+  completed: number
+}
+
+export interface PriorityStats {
+  origin: string
+  /** Gauge: scheduler slots currently held. */
+  running: number
+  concurrency: number
+  /** Gauge: tasks waiting for scheduler admission. */
+  pending: number
+  total: SchedulerQueueStats
+  /** Lowest through highest priority. */
+  queues: SchedulerQueueStats[]
+  shared: { running: number; waiters: number } | undefined
+}
+
+export interface PriorityInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  /** One live scheduler snapshot per canonical logical origin. */
+  stats(): PriorityStats[]
+}
+
+export interface RedirectStats {
+  /** Counter: accepted redirect hops. */
+  followed: number
+}
+
+export interface RedirectInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  stats(): RedirectStats
+}
+
+export interface DnsStats {
+  /** Counters: positive-cache hits and foreground cache misses. */
+  hits: number
+  misses: number
+  /** Counter: requests rejected from the negative cache. */
+  negativeHits: number
+  /** Counter: actual resolver calls, excluding callers joining in-flight work. */
+  lookups: number
+  /** Counter: pre-emptive refresh resolver calls. */
+  refreshes: number
+  /** Counter: failed resolver calls. */
+  errors: number
+  /** Counter: selected addresses evicted after connection failures. */
+  evictions: number
+  /** Gauge: resolver calls currently in flight. */
+  pending: number
+}
+
+export interface DnsInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  stats(): DnsStats
+}
+
+export interface LookupStats {
+  /** Counter: logical-origin lookup attempts. */
+  lookups: number
+  /** Counter: failed logical-origin lookups. */
+  errors: number
+  /** Gauge: logical-origin lookups currently in flight. */
+  pending: number
+}
+
+export interface LookupInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  stats(): LookupStats
+}
+
 export interface SqliteCacheStoreStats {
   gets: number
   hits: number
@@ -367,6 +442,10 @@ export interface CacheInterceptor {
 export interface GlobalDispatcherStats {
   cache: CacheStats
   pressure: Array<PressureStats & { origin: string }>
+  priority: PriorityStats[]
+  redirect: RedirectStats
+  dns: DnsStats
+  lookup: LookupStats
 }
 
 export interface CacheKey {
@@ -456,7 +535,7 @@ export function compose(
   ...interceptors: (Interceptor | null | undefined)[]
 ): DispatchFn
 
-/** Aggregate cache and pressure snapshots for every live dispatcher wrapped
+/** Aggregate interceptor snapshots for every live dispatcher wrapped
  * by this module in the current thread. Also exposed through the global
  * `Symbol.for('@nxtedition/nxt-undici/dispatcher-stats')` provider. */
 export function getGlobalDispatcherStats(): GlobalDispatcherStats
@@ -470,13 +549,13 @@ export const interceptors: {
   responseRetry: () => Interceptor
   responseVerify: () => Interceptor
   log: (opts?: LogInterceptorOptions) => Interceptor
-  redirect: () => Interceptor
+  redirect: () => RedirectInterceptor
   proxy: () => Interceptor
   cache: (opts?: CacheInterceptorOptions) => CacheInterceptor
   requestId: () => Interceptor
-  dns: () => Interceptor
-  lookup: () => Interceptor
-  priority: () => Interceptor
+  dns: () => DnsInterceptor
+  lookup: () => LookupInterceptor
+  priority: () => PriorityInterceptor
   pressure: (opts?: PressureInterceptorOptions) => PressureInterceptor
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,6 +125,16 @@ const CACHE_STORE_COUNTERS = [
   'usedSize',
   'maxSize',
 ]
+const DNS_STATS = [
+  'hits',
+  'misses',
+  'negativeHits',
+  'lookups',
+  'refreshes',
+  'errors',
+  'evictions',
+  'pending',
+]
 
 export function getGlobalDispatcherStats() {
   const cacheStats = {
@@ -139,6 +149,10 @@ export function getGlobalDispatcherStats() {
     storeStats[counter] = 0
   }
   const pressure = []
+  const priority = []
+  const redirect = { followed: 0 }
+  const dns = Object.fromEntries(DNS_STATS.map((counter) => [counter, 0]))
+  const lookup = { lookups: 0, errors: 0, pending: 0 }
 
   for (const ref of dispatcherStatsRegistry) {
     const dispatcher = ref.deref()
@@ -158,6 +172,14 @@ export function getGlobalDispatcherStats() {
       }
     }
     pressure.push(...stats.pressure)
+    priority.push(...stats.priority)
+    redirect.followed += stats.redirect.followed
+    for (const counter of DNS_STATS) {
+      dns[counter] += stats.dns[counter]
+    }
+    for (const counter of ['lookups', 'errors', 'pending']) {
+      lookup[counter] += stats.lookup[counter]
+    }
   }
 
   const lookups = cacheStats.hits + cacheStats.misses
@@ -167,7 +189,7 @@ export function getGlobalDispatcherStats() {
     cacheStats.store = storeStats
   }
 
-  return { cache: cacheStats, pressure }
+  return { cache: cacheStats, pressure, priority, redirect, dns, lookup }
 }
 
 globalThis[dispatcherStatsProviderSymbol] = getGlobalDispatcherStats
@@ -177,6 +199,10 @@ function wrapDispatch(dispatcher) {
   if (wrappedDispatcher == null) {
     const cache = interceptors.cache()
     const pressure = interceptors.pressure()
+    const priority = interceptors.priority()
+    const redirect = interceptors.redirect()
+    const dns = interceptors.dns()
+    const lookup = interceptors.lookup()
     wrappedDispatcher = compose(
       dispatcher,
       // The wrapped dispatcher is an arbitrary user boundary. It may retain or
@@ -187,8 +213,8 @@ function wrapDispatch(dispatcher) {
         invalidateNormalizedHeaders(opts.headers)
         return dispatch(opts, handler)
       },
-      interceptors.priority(),
-      interceptors.dns(),
+      priority,
+      dns,
       interceptors.requestBodyFactory(),
       // A retry strategy may legitimately mutate opts.headers, so every
       // actual attempt must cross the proxy's request boundary and have
@@ -206,7 +232,7 @@ function wrapDispatch(dispatcher) {
       // unsafe buffering/resumption for responses that announce trailers.
       proxyInterceptors.proxyResponse(),
       cache,
-      interceptors.redirect(),
+      redirect,
       // log also emits the undici:request trace start/end docs. Later entries
       // in this list wrap earlier ones, so it sits OUTSIDE everything that
       // does real work (redirect, cache, proxy, retry, dns) — durationMs
@@ -215,7 +241,7 @@ function wrapDispatch(dispatcher) {
       // the emitted docs correlate with logs and undici:retry docs by
       // request id.
       interceptors.log(),
-      interceptors.lookup(),
+      lookup,
       interceptors.requestId(),
       interceptors.responseError(),
       interceptors.query(),
@@ -327,7 +353,14 @@ function wrapDispatch(dispatcher) {
         )
       },
     )
-    wrappedDispatcher.stats = () => ({ cache: cache.stats(), pressure: pressure.stats() })
+    wrappedDispatcher.stats = () => ({
+      cache: cache.stats(),
+      pressure: pressure.stats(),
+      priority: priority.stats(),
+      redirect: redirect.stats(),
+      dns: dns.stats(),
+      lookup: lookup.stats(),
+    })
     const statsRef = new WeakRef(wrappedDispatcher)
     dispatcherStatsRegistry.add(statsRef)
     dispatcherStatsFinalizer.register(wrappedDispatcher, statsRef)

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -114,7 +114,7 @@ const CONNECTION_ERROR_CODES = new Set([
   'UND_ERR_SOCKET',
 ])
 
-export default () => (dispatch) => {
+const makeInterceptor = (stats) => (dispatch) => {
   // DNS options are per request, including a custom resolver. Keep every
   // resolver's positive, negative and in-flight state isolated: service
   // discovery clients commonly use the same logical hostname with different
@@ -188,6 +188,8 @@ export default () => (dispatch) => {
     const { cache, negatives, promises } = state
     let promise = promises.get(key)
     if (!promise) {
+      stats.lookups++
+      stats.pending++
       // A synchronous lookup callback (custom resolvers answering from a local
       // cache) runs inside the Promise executor, BEFORE the `promises.set`
       // below — its cleanup delete would be a no-op and the settled promise
@@ -207,6 +209,7 @@ export default () => (dispatch) => {
           }
           settled = true
           promises.delete(key)
+          stats.pending--
 
           let val = null
           let shouldCacheNegative = true
@@ -252,6 +255,7 @@ export default () => (dispatch) => {
           }
 
           if (err) {
+            stats.errors++
             // Negative cache: remember the failure for a short while so a hot
             // caller of an unresolvable host fails fast instead of issuing a
             // lookup storm (response-retry retries ENOTFOUND/EAI_AGAIN up to
@@ -358,6 +362,7 @@ export default () => (dispatch) => {
         // served from cache.
         const negative = negatives.get(key)
         if (negative != null && negative.expires >= now) {
+          stats.negativeHits++
           // Cold path (fail-fast) — resolve the writer per emission, like
           // response-retry's traceRetry.
           const write = traceWrite(opts.trace)
@@ -378,6 +383,7 @@ export default () => (dispatch) => {
           throw makeLookupError(negative.err)
         }
 
+        stats.misses++
         // Cold path (cache miss) — this request synchronously awaits the
         // (possibly shared in-flight) resolution, so attribute the wait to it;
         // concurrent awaiters each emit their own doc. The url tag is taken
@@ -403,6 +409,8 @@ export default () => (dispatch) => {
           throw makeLookupError(err)
         }
         records = val
+      } else {
+        stats.hits++
       }
 
       let record
@@ -453,11 +461,13 @@ export default () => (dispatch) => {
         // the same deduped lookup and would otherwise emit one doc each, with
         // attach-relative durations — the doc denotes the background lookup
         // itself, not a per-request wait (nothing awaits a refresh).
+        const refreshing = !promises.has(key)
+        if (refreshing) {
+          stats.refreshes++
+        }
         const write = traceWrite(opts.trace)
         const trace =
-          write !== null && !promises.has(key)
-            ? { write, id: opts.id ?? null, url: traceUrl(opts) }
-            : null
+          write !== null && refreshing ? { write, id: opts.id ?? null, url: traceUrl(opts) } : null
         const promise = resolve(key, hostname, { ttl, negativeTTL, lookup, state })
         if (trace !== null) {
           // Side-observe a copy of the chain: resolve() never rejects (it
@@ -512,6 +522,7 @@ export default () => (dispatch) => {
           if (err.code != null && CONNECTION_ERROR_CODES.has(err.code)) {
             // The IP is bad/unreachable — drop it from rotation immediately.
             record.expires = 0
+            stats.evictions++
 
             // Cold path (connection error) — opts is the dispatch closure's;
             // eviction stays allocation-free while tracing is off.
@@ -582,4 +593,20 @@ export default () => (dispatch) => {
       wrapped.onError(err)
     }
   }
+}
+
+export default () => {
+  const stats = {
+    hits: 0,
+    misses: 0,
+    negativeHits: 0,
+    lookups: 0,
+    refreshes: 0,
+    errors: 0,
+    evictions: 0,
+    pending: 0,
+  }
+  const interceptor = makeInterceptor(stats)
+  interceptor.stats = () => ({ ...stats })
+  return interceptor
 }

--- a/lib/interceptor/lookup.js
+++ b/lib/interceptor/lookup.js
@@ -70,7 +70,7 @@ function traceLookup(write, opts, start, resolved, err) {
   )
 }
 
-export default () => (dispatch) => async (opts, handler) => {
+const makeInterceptor = (stats) => (dispatch) => async (opts, handler) => {
   const lookup = opts.lookup
 
   if (!lookup) {
@@ -92,6 +92,19 @@ export default () => (dispatch) => async (opts, handler) => {
   // dispatch synchronously, DecoratorHandler's #errored/#completed guards
   // absorb the duplicate instead of violating the once-only onError contract.
   const wrapped = new DecoratorHandler(handler)
+  stats.lookups++
+  stats.pending++
+  let resolving = true
+  const finishLookup = (failed = false) => {
+    if (!resolving) {
+      return
+    }
+    resolving = false
+    stats.pending--
+    if (failed) {
+      stats.errors++
+    }
+  }
 
   try {
     const origin = await new Promise((resolve, reject) => {
@@ -180,6 +193,7 @@ export default () => (dispatch) => async (opts, handler) => {
     if (!origin) {
       throw new Error('invalid origin: ' + origin)
     }
+    finishLookup()
 
     if (write !== null && resolvedAsync) {
       traceLookup(write, opts, start, String(origin).slice(0, 256), null)
@@ -198,6 +212,16 @@ export default () => (dispatch) => async (opts, handler) => {
     if (write !== null && !dispatched) {
       traceLookup(write, opts, start, null, traceErr(err))
     }
+    if (!dispatched) {
+      finishLookup(true)
+    }
     wrapped.onError(err)
   }
+}
+
+export default () => {
+  const stats = { lookups: 0, errors: 0, pending: 0 }
+  const interceptor = makeInterceptor(stats)
+  interceptor.stats = () => ({ ...stats })
+  return interceptor
 }

--- a/lib/interceptor/priority.js
+++ b/lib/interceptor/priority.js
@@ -217,10 +217,10 @@ class Handler extends DecoratorHandler {
   }
 }
 
-export default () => (dispatch) => {
+const makeInterceptor = (register) => (dispatch) => {
   const schedulers = new Map()
 
-  return (opts, handler) => {
+  const wrapped = (opts, handler) => {
     if (opts.priority == null || !opts.origin) {
       return dispatch(opts, handler)
     }
@@ -333,4 +333,34 @@ export default () => (dispatch) => {
     // handler.onError, so the queued path intentionally returns undefined.
     return dispatchResult
   }
+
+  register(wrapped, schedulers)
+  return wrapped
+}
+
+export default () => {
+  const schedulerMapRefs = new Set()
+  const schedulerMapFinalizer = new FinalizationRegistry((ref) => schedulerMapRefs.delete(ref))
+  const interceptor = makeInterceptor((wrapped, schedulers) => {
+    const ref = new WeakRef(schedulers)
+    schedulerMapRefs.add(ref)
+    schedulerMapFinalizer.register(wrapped, ref)
+  })
+
+  interceptor.stats = () => {
+    const result = []
+    for (const ref of schedulerMapRefs) {
+      const schedulers = ref.deref()
+      if (schedulers === undefined) {
+        schedulerMapRefs.delete(ref)
+        continue
+      }
+      for (const [origin, scheduler] of schedulers) {
+        result.push({ origin, ...scheduler.stats })
+      }
+    }
+    return result
+  }
+
+  return interceptor
 }

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -72,6 +72,7 @@ function isOneShotIterable(body) {
 class Handler extends DecoratorHandler {
   #dispatch
   #opts
+  #stats
   #trace
   #originBoundHeaders
 
@@ -83,11 +84,12 @@ class Handler extends DecoratorHandler {
   #location
   #history = []
 
-  constructor(opts, { dispatch, handler }) {
+  constructor(opts, { dispatch, handler, stats }) {
     super(handler)
 
     this.#dispatch = dispatch
     this.#opts = opts
+    this.#stats = stats
     // Redirect policy is live and may replace opts.proxy. Snapshot the
     // security boundary before the first callback so it cannot weaken which
     // credentials are removed on a later cross-origin hop.
@@ -256,6 +258,8 @@ class Handler extends DecoratorHandler {
       }
     }
 
+    this.#stats.followed++
+
     if (trace !== null) {
       traceSafe(
         trace.write,
@@ -388,5 +392,13 @@ function cleanRequestHeaders(headers, removeContent, unknownOrigin, originBoundH
   return ret
 }
 
-export default () => (dispatch) => (opts, handler) =>
-  opts.follow ? dispatch(opts, new Handler(opts, { handler, dispatch })) : dispatch(opts, handler)
+export default () => {
+  const stats = { followed: 0 }
+  const interceptor = (dispatch) => (opts, handler) =>
+    opts.follow
+      ? dispatch(opts, new Handler(opts, { handler, dispatch, stats }))
+      : dispatch(opts, handler)
+
+  interceptor.stats = () => ({ ...stats })
+  return interceptor
+}

--- a/test/cache-stats.js
+++ b/test/cache-stats.js
@@ -158,7 +158,7 @@ test('SqliteCacheStore stats expose operations, queue depth, and capacity', asyn
   t.equal(store.stats.closed, true)
 })
 
-test('wrapped dispatcher stats globally include cache and pressure snapshots', async (t) => {
+test('wrapped dispatcher stats globally include every interceptor snapshot', async (t) => {
   const server = await startServer((_req, res) => {
     res.writeHead(200, { 'cache-control': 's-maxage=60' })
     res.end('global')
@@ -187,4 +187,73 @@ test('wrapped dispatcher stats globally include cache and pressure snapshots', a
       completed: 1,
     },
   )
+  t.same(stats.priority, [])
+  t.same(stats.redirect, { followed: 0 })
+  t.same(stats.dns, {
+    hits: 0,
+    misses: 0,
+    negativeHits: 0,
+    lookups: 0,
+    refreshes: 0,
+    errors: 0,
+    evictions: 0,
+    pending: 0,
+  })
+  t.match(stats.lookup, { lookups: 2, errors: 0, pending: 0 })
+})
+
+test('global stats forward active priority, DNS, redirect, and lookup state', async (t) => {
+  const calls = []
+  const dispatcher = {
+    dispatch(opts, handler) {
+      calls.push({ opts, handler })
+    },
+  }
+  const origin = 'http://stats.test'
+  const response = rawRequest((opts, handler) => nxtDispatch(dispatcher, opts, handler), {
+    origin,
+    path: '/start',
+    method: 'GET',
+    headers: {},
+    priority: 'high',
+    follow: 1,
+    retry: 0,
+    dns: {
+      ttl: 60e3,
+      lookup(_hostname, _opts, callback) {
+        callback(null, [{ address: '127.0.0.1', family: 4 }])
+      },
+    },
+  })
+
+  await new Promise((resolve) => setImmediate(resolve))
+  t.equal(calls.length, 1)
+
+  let stats = getGlobalDispatcherStats()
+  t.match(
+    stats.priority.find((entry) => entry.origin === origin),
+    { running: 1, pending: 0 },
+  )
+  t.ok(stats.dns.misses >= 1)
+  t.ok(stats.dns.lookups >= 1)
+  t.ok(stats.lookup.lookups >= 1)
+
+  calls[0].handler.onConnect(() => {})
+  calls[0].handler.onHeaders(302, { location: '/next' }, () => {})
+  calls[0].handler.onComplete([])
+
+  await new Promise((resolve) => setImmediate(resolve))
+  t.equal(calls.length, 2)
+  stats = getGlobalDispatcherStats()
+  t.ok(stats.redirect.followed >= 1)
+  t.ok(stats.dns.hits >= 1)
+  t.match(
+    stats.priority.find((entry) => entry.origin === origin),
+    { running: 1, pending: 0 },
+  )
+
+  calls[1].handler.onConnect(() => {})
+  calls[1].handler.onHeaders(200, {}, () => {})
+  calls[1].handler.onComplete([])
+  await response
 })

--- a/test/interceptor-stats.js
+++ b/test/interceptor-stats.js
@@ -1,0 +1,167 @@
+import { test } from 'tap'
+import { interceptors } from '../lib/index.js'
+
+function rawRequest(dispatch, opts) {
+  return new Promise((resolve, reject) => {
+    let statusCode
+    const chunks = []
+    dispatch(opts, {
+      onConnect() {},
+      onHeaders(status) {
+        statusCode = status
+        return true
+      },
+      onData(chunk) {
+        chunks.push(Buffer.from(chunk))
+      },
+      onComplete() {
+        resolve({ statusCode, body: Buffer.concat(chunks).toString() })
+      },
+      onError: reject,
+    })
+  })
+}
+
+function complete(handler, statusCode = 200, headers = {}) {
+  handler.onConnect(() => {})
+  handler.onHeaders(statusCode, headers, () => {})
+  handler.onComplete([])
+}
+
+function noopHandler() {
+  return {
+    onConnect() {},
+    onHeaders() {
+      return true
+    },
+    onData() {},
+    onComplete() {},
+    onError(err) {
+      throw err
+    },
+  }
+}
+
+test('priority stats expose live per-origin scheduler queues', (t) => {
+  const priority = interceptors.priority()
+  const handlers = []
+  const dispatch = priority((_opts, handler) => handlers.push(handler))
+  const opts = {
+    origin: 'http://example.test',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    priority: 'high',
+  }
+
+  dispatch(opts, noopHandler())
+  dispatch(opts, noopHandler())
+
+  t.match(priority.stats(), [
+    {
+      origin: 'http://example.test',
+      running: 1,
+      concurrency: 1,
+      pending: 1,
+      total: { count: 1, deferred: 1, completed: 0 },
+    },
+  ])
+
+  handlers[0].onConnect(() => {})
+  t.match(priority.stats(), [
+    {
+      running: 1,
+      pending: 0,
+      total: { count: 0, deferred: 1, completed: 1 },
+    },
+  ])
+
+  handlers[1].onConnect(() => {})
+  t.same(priority.stats(), [], 'idle schedulers are still evicted')
+  t.end()
+})
+
+test('redirect stats count accepted redirect hops', async (t) => {
+  const redirect = interceptors.redirect()
+  const dispatch = redirect((opts, handler) => {
+    if (opts.path === '/start') {
+      complete(handler, 302, { location: '/next' })
+    } else {
+      complete(handler)
+    }
+  })
+
+  const result = await rawRequest(dispatch, {
+    origin: 'http://example.test',
+    path: '/start',
+    method: 'GET',
+    headers: {},
+    follow: 1,
+  })
+
+  t.equal(result.statusCode, 200)
+  t.same(redirect.stats(), { followed: 1 })
+})
+
+test('dns stats distinguish cache hits, misses, negative hits, and resolver work', async (t) => {
+  const dns = interceptors.dns()
+  const dispatch = dns((_opts, handler) => complete(handler))
+  const lookup = (hostname, _opts, callback) => {
+    if (hostname === 'missing.test') {
+      callback(Object.assign(new Error('not found'), { code: 'ENOTFOUND', hostname }))
+    } else {
+      callback(null, [{ address: '127.0.0.1', family: 4 }])
+    }
+  }
+  const opts = (hostname) => ({
+    origin: `http://${hostname}`,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    dns: { lookup, ttl: 60e3, negativeTTL: 60e3 },
+  })
+
+  await rawRequest(dispatch, opts('service.test'))
+  await rawRequest(dispatch, opts('service.test'))
+  await t.rejects(rawRequest(dispatch, opts('missing.test')), { code: 'ENOTFOUND' })
+  await t.rejects(rawRequest(dispatch, opts('missing.test')), { code: 'ENOTFOUND' })
+
+  t.same(dns.stats(), {
+    hits: 1,
+    misses: 2,
+    negativeHits: 1,
+    lookups: 2,
+    refreshes: 0,
+    errors: 1,
+    evictions: 0,
+    pending: 0,
+  })
+})
+
+test('lookup stats expose in-flight and failed logical-origin resolutions', async (t) => {
+  const lookup = interceptors.lookup()
+  const dispatch = lookup((_opts, handler) => complete(handler))
+  let callback
+  const pending = rawRequest(dispatch, {
+    origin: 'http://service.test',
+    lookup(_origin, _opts, cb) {
+      callback = cb
+    },
+  })
+
+  t.same(lookup.stats(), { lookups: 1, errors: 0, pending: 1 })
+  callback(null, 'http://127.0.0.1')
+  await pending
+
+  await t.rejects(
+    rawRequest(dispatch, {
+      origin: 'http://missing.test',
+      lookup(_origin, _opts, cb) {
+        cb(new Error('lookup failed'))
+      },
+    }),
+    { message: 'lookup failed' },
+  )
+
+  t.same(lookup.stats(), { lookups: 2, errors: 1, pending: 0 })
+})

--- a/type-tests/interceptor-stats.ts
+++ b/type-tests/interceptor-stats.ts
@@ -1,0 +1,23 @@
+import {
+  getGlobalDispatcherStats,
+  interceptors,
+  type DnsStats,
+  type LookupStats,
+  type PriorityStats,
+  type RedirectStats,
+} from '../lib/index.js'
+
+const priority: PriorityStats[] = interceptors.priority().stats()
+const redirect: RedirectStats = interceptors.redirect().stats()
+const dns: DnsStats = interceptors.dns().stats()
+const lookup: LookupStats = interceptors.lookup().stats()
+const global = getGlobalDispatcherStats()
+
+priority[0]?.queues[0]?.completed
+redirect.followed
+dns.negativeHits
+lookup.pending
+global.priority
+global.redirect
+global.dns
+global.lookup


### PR DESCRIPTION
## What

- expose live per-origin scheduler snapshots through `interceptors.priority().stats()`
- expose redirect, DNS, and logical lookup counters and gauges through their interceptor stats APIs
- forward priority, redirect, DNS, and lookup snapshots through wrapped dispatchers, `getGlobalDispatcherStats()`, and the global stats provider
- add runtime, integration, and TypeScript coverage for the new surfaces

## Why

The dispatcher stats provider currently forwards cache and pressure observability only. That hides scheduler queue depth and the redirect and resolution behavior needed to explain request latency and upstream routing.

## Impact

Priority stats include only live per-origin schedulers and preserve idle scheduler eviction. Redirect, DNS, and lookup counters are cumulative for the interceptor lifetime; DNS and lookup `pending` values are current gauges. Global stats aggregate counters and gauges across all live wrapped dispatchers in the current thread.

## Checks

- `yarn test` — 4,030 passing, 4 skipped
- focused priority/DNS/lookup/redirect/trace suite — 530 passing
- ESLint on all changed JavaScript files
- Prettier and `git diff --check`