### PR TITLE
feat: expose per-dispatcher statistics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -439,7 +439,7 @@ export interface CacheInterceptor {
   stats(): CacheStats
 }
 
-export interface GlobalDispatcherStats {
+export interface DispatcherStats {
   cache: CacheStats
   pressure: Array<PressureStats & { origin: string }>
   priority: PriorityStats[]
@@ -447,6 +447,8 @@ export interface GlobalDispatcherStats {
   dns: DnsStats
   lookup: LookupStats
 }
+
+export type GlobalDispatcherStats = DispatcherStats
 
 export interface CacheKey {
   origin: string
@@ -539,6 +541,10 @@ export function compose(
  * by this module in the current thread. Also exposed through the global
  * `Symbol.for('@nxtedition/nxt-undici/dispatcher-stats')` provider. */
 export function getGlobalDispatcherStats(): GlobalDispatcherStats
+
+/** Return the interceptor statistics for one dispatcher. Calling this before
+ * the first request initializes the same lazy wrapper used by dispatch(). */
+export function getDispatcherStats(dispatcher: Dispatcher): DispatcherStats
 
 export function parseHeaders(headers?: HeaderInput | null): Record<string, string | string[]>
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,6 +194,10 @@ export function getGlobalDispatcherStats() {
 
 globalThis[dispatcherStatsProviderSymbol] = getGlobalDispatcherStats
 
+export function getDispatcherStats(dispatcher) {
+  return wrapDispatch(dispatcher).stats()
+}
+
 function wrapDispatch(dispatcher) {
   let wrappedDispatcher = dispatcherCache.get(dispatcher)
   if (wrappedDispatcher == null) {

--- a/test/cache-stats.js
+++ b/test/cache-stats.js
@@ -4,6 +4,7 @@ import { test } from 'tap'
 import undici from '@nxtedition/undici'
 import {
   dispatch as nxtDispatch,
+  getDispatcherStats,
   getGlobalDispatcherStats,
   interceptors,
   SqliteCacheStore,
@@ -200,6 +201,51 @@ test('wrapped dispatcher stats globally include every interceptor snapshot', asy
     pending: 0,
   })
   t.match(stats.lookup, { lookups: 2, errors: 0, pending: 0 })
+})
+
+test('wrapped dispatcher stats can be read for one dispatcher', async (t) => {
+  const server = await startServer((_req, res) => {
+    res.writeHead(200, { 'cache-control': 's-maxage=60' })
+    res.end('dispatcher')
+  })
+  t.teardown(() => server.close())
+
+  const firstStore = new SqliteCacheStore({ location: ':memory:' })
+  const secondStore = new SqliteCacheStore({ location: ':memory:' })
+  const firstAgent = new undici.Agent()
+  const secondAgent = new undici.Agent()
+  t.teardown(() => firstStore.close())
+  t.teardown(() => secondStore.close())
+  t.teardown(() => firstAgent.close())
+  t.teardown(() => secondAgent.close())
+
+  t.match(getDispatcherStats(firstAgent), {
+    cache: { hits: 0, misses: 0 },
+    pressure: [],
+  })
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const request = (agent, store, path) =>
+    rawRequest((opts, handler) => nxtDispatch(agent, opts, handler), {
+      origin,
+      path,
+      method: 'GET',
+      headers: {},
+      cache: { store },
+    })
+
+  await request(firstAgent, firstStore, '/first')
+  await request(firstAgent, firstStore, '/first')
+  await request(secondAgent, secondStore, '/second')
+
+  t.match(getDispatcherStats(firstAgent), {
+    cache: { hits: 1, misses: 1, hitRate: 0.5, store: { stores: 1 } },
+    pressure: [{ origin, completed: 1 }],
+  })
+  t.match(getDispatcherStats(secondAgent), {
+    cache: { hits: 0, misses: 1, hitRate: 0, store: { stores: 1 } },
+    pressure: [{ origin, completed: 1 }],
+  })
 })
 
 test('global stats forward active priority, DNS, redirect, and lookup state', async (t) => {

--- a/type-tests/interceptor-stats.ts
+++ b/type-tests/interceptor-stats.ts
@@ -1,4 +1,6 @@
 import {
+  Agent,
+  getDispatcherStats,
   getGlobalDispatcherStats,
   interceptors,
   type DnsStats,
@@ -12,6 +14,7 @@ const redirect: RedirectStats = interceptors.redirect().stats()
 const dns: DnsStats = interceptors.dns().stats()
 const lookup: LookupStats = interceptors.lookup().stats()
 const global = getGlobalDispatcherStats()
+const dispatcher = getDispatcherStats(new Agent())
 
 priority[0]?.queues[0]?.completed
 redirect.followed
@@ -21,3 +24,5 @@ global.priority
 global.redirect
 global.dns
 global.lookup
+dispatcher.cache
+dispatcher.pressure


### PR DESCRIPTION
## Summary
- add `getDispatcherStats(dispatcher)` for the exact lazy wrapper used by `dispatch()`
- retain `getGlobalDispatcherStats()` for thread-wide aggregation
- verify two dispatchers keep cache and pressure counters isolated

## Validation
- direct full `test/*.js` suite
- `yarn test:types`
- ESLint
- Prettier

## Context
The proxy owns a dedicated upstream Agent and must forward that Agent's interceptor stats, rather than the aggregate of unrelated dispatchers in the same worker.