### PR TITLE
feat: expose retry interceptor statistics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -360,6 +360,28 @@ export interface RedirectInterceptor {
   stats(): RedirectStats
 }
 
+export interface RetryStats {
+  /** Counter: actual re-dispatches after the initial attempt. */
+  retries: number
+  /** Counter: retries before response headers were exposed. */
+  headerRetries: number
+  /** Counter: range-resume retries after response headers were exposed. */
+  bodyRetries: number
+  /** Counter: logical requests that succeeded after at least one retry. */
+  recovered: number
+  /** Counter: logical requests that still failed after at least one retry. */
+  failed: number
+  /** Counter: logical requests aborted by the caller after at least one retry. */
+  aborted: number
+  /** Gauge: retry decisions or backoff waits currently pending. */
+  pending: number
+}
+
+export interface RetryInterceptor {
+  (dispatch: DispatchFn): DispatchFn
+  stats(): RetryStats
+}
+
 export interface DnsStats {
   /** Counters: positive-cache hits and foreground cache misses. */
   hits: number
@@ -446,6 +468,7 @@ export interface DispatcherStats {
   redirect: RedirectStats
   dns: DnsStats
   lookup: LookupStats
+  retry: RetryStats
 }
 
 export type GlobalDispatcherStats = DispatcherStats
@@ -552,7 +575,7 @@ export const interceptors: {
   query: () => Interceptor
   requestBodyFactory: () => Interceptor
   responseError: () => Interceptor
-  responseRetry: () => Interceptor
+  responseRetry: () => RetryInterceptor
   responseVerify: () => Interceptor
   log: (opts?: LogInterceptorOptions) => Interceptor
   redirect: () => RedirectInterceptor

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,15 @@ const DNS_STATS = [
   'evictions',
   'pending',
 ]
+const RETRY_STATS = [
+  'retries',
+  'headerRetries',
+  'bodyRetries',
+  'recovered',
+  'failed',
+  'aborted',
+  'pending',
+]
 
 export function getGlobalDispatcherStats() {
   const cacheStats = {
@@ -153,6 +162,7 @@ export function getGlobalDispatcherStats() {
   const redirect = { followed: 0 }
   const dns = Object.fromEntries(DNS_STATS.map((counter) => [counter, 0]))
   const lookup = { lookups: 0, errors: 0, pending: 0 }
+  const retry = Object.fromEntries(RETRY_STATS.map((counter) => [counter, 0]))
 
   for (const ref of dispatcherStatsRegistry) {
     const dispatcher = ref.deref()
@@ -180,6 +190,9 @@ export function getGlobalDispatcherStats() {
     for (const counter of ['lookups', 'errors', 'pending']) {
       lookup[counter] += stats.lookup[counter]
     }
+    for (const counter of RETRY_STATS) {
+      retry[counter] += stats.retry[counter]
+    }
   }
 
   const lookups = cacheStats.hits + cacheStats.misses
@@ -189,7 +202,7 @@ export function getGlobalDispatcherStats() {
     cacheStats.store = storeStats
   }
 
-  return { cache: cacheStats, pressure, priority, redirect, dns, lookup }
+  return { cache: cacheStats, pressure, priority, redirect, dns, lookup, retry }
 }
 
 globalThis[dispatcherStatsProviderSymbol] = getGlobalDispatcherStats
@@ -207,6 +220,7 @@ function wrapDispatch(dispatcher) {
     const redirect = interceptors.redirect()
     const dns = interceptors.dns()
     const lookup = interceptors.lookup()
+    const retry = interceptors.responseRetry()
     wrappedDispatcher = compose(
       dispatcher,
       // The wrapped dispatcher is an arbitrary user boundary. It may retain or
@@ -225,7 +239,7 @@ function wrapDispatch(dispatcher) {
       // hop-by-hop fields removed. The proxy builds a fresh header map, which
       // also prevents Via/Forwarded from accumulating between attempts.
       proxyInterceptors.proxyRequest(),
-      interceptors.responseRetry(),
+      retry,
       interceptors.responseVerify(),
       // Observe logical-origin pressure outside retry but below the cache: a
       // cache hit creates no upstream load, while retries share one lifecycle
@@ -364,6 +378,7 @@ function wrapDispatch(dispatcher) {
       redirect: redirect.stats(),
       dns: dns.stats(),
       lookup: lookup.stats(),
+      retry: retry.stats(),
     })
     const statsRef = new WeakRef(wrappedDispatcher)
     dispatcherStatsRegistry.add(statsRef)

--- a/lib/interceptor/response-retry.js
+++ b/lib/interceptor/response-retry.js
@@ -241,10 +241,12 @@ export function backoffDelay(retryCount, maxDelay) {
 class Handler extends DecoratorHandler {
   #dispatch
   #opts
+  #stats
   #trace
 
   #retryCount = 0
   #retryError = null
+  #statsSettled = false
   #headersSent = false
   #errorSent = false
 
@@ -284,10 +286,11 @@ class Handler extends DecoratorHandler {
   #end
   #etag
 
-  constructor(opts, { handler, dispatch }) {
+  constructor(opts, { handler, dispatch, stats }) {
     super(handler)
 
     this.#dispatch = dispatch
+    this.#stats = stats
 
     if (typeof opts === 'number') {
       this.#opts = { count: opts }
@@ -307,6 +310,25 @@ class Handler extends DecoratorHandler {
     this.#body = null
     this.#bodySize = 0
     this.#trailers = null
+  }
+
+  #settleStats(outcome) {
+    if (this.#statsSettled || this.#retryCount === 0) {
+      return
+    }
+
+    this.#statsSettled = true
+    this.#stats[outcome]++
+  }
+
+  #complete(trailers) {
+    this.#settleStats(this.#statusCode < 400 ? 'recovered' : 'failed')
+    return super.onComplete(trailers)
+  }
+
+  #error(err) {
+    this.#settleStats(this.#aborted ? 'aborted' : 'failed')
+    return super.onError(err)
   }
 
   dispatch(opts) {
@@ -576,13 +598,13 @@ class Handler extends DecoratorHandler {
     this.#trailers = trailers
 
     if (this.#statusCode < 400) {
-      return super.onComplete(trailers)
+      return this.#complete(trailers)
     }
 
     if (this.#headersSent && !this.#errorSent) {
       // The >= 400 response was passed through (too large to buffer for
       // replay) — headers and data have already been forwarded downstream.
-      return super.onComplete(trailers)
+      return this.#complete(trailers)
     }
 
     this.#maybeRetry(null)
@@ -649,7 +671,7 @@ class Handler extends DecoratorHandler {
       // The transport completed before this buffered replay began. Downstream
       // completion is the sole terminal action; aborting the finished attempt
       // here would emit a second terminal signal with a null reason.
-      super.onComplete(replay.trailers)
+      this.#complete(replay.trailers)
     } else if (resumeTransport) {
       this.#resume?.()
     }
@@ -680,7 +702,7 @@ class Handler extends DecoratorHandler {
       this.#replay = null
       if (!this.#errorSent) {
         this.#errorSent = true
-        super.onError(err)
+        this.#error(err)
       }
     } else if (!this.#headersSent) {
       const body = this.#body ?? []
@@ -695,7 +717,7 @@ class Handler extends DecoratorHandler {
       // so the response stream doesn't hang.
       if (!this.#errorSent) {
         this.#errorSent = true
-        super.onError(new Error('Response retry failed'))
+        this.#error(new Error('Response retry failed'))
       }
     }
 
@@ -785,8 +807,18 @@ class Handler extends DecoratorHandler {
       retryPromise = Promise.reject(err)
     }
 
+    this.#stats.pending++
+    let pending = true
+    const settlePending = () => {
+      if (pending) {
+        pending = false
+        this.#stats.pending--
+      }
+    }
+
     retryPromise
       .then((shouldRetry) => {
+        settlePending()
         if (this.#aborted) {
           this.#maybeError(this.#reason)
         } else if (
@@ -799,6 +831,8 @@ class Handler extends DecoratorHandler {
           this.#opts.logger?.debug({ err, retryCount: this.#retryCount }, 'retry response headers')
 
           this.#retryCount++
+          this.#stats.retries++
+          this.#stats.headerRetries++
           this.#retryError = err
 
           this.dispatch(this.#opts)
@@ -835,6 +869,8 @@ class Handler extends DecoratorHandler {
           this.#opts.logger?.debug({ err, retryCount: this.#retryCount }, 'retry response body')
 
           this.#retryCount++
+          this.#stats.retries++
+          this.#stats.bodyRetries++
           this.#retryError = err
 
           this.dispatch(this.#opts)
@@ -842,6 +878,7 @@ class Handler extends DecoratorHandler {
         }
       })
       .catch((err) => {
+        settlePending()
         // When the downstream abort cancelled the backoff timer, the timer's
         // own AbortError rejection is just plumbing — deliver the recorded
         // abort reason instead (including a caller-provided falsy reason).
@@ -974,7 +1011,7 @@ class Handler extends DecoratorHandler {
   }
 }
 
-export default () => (dispatch) => (opts, handler) => {
+const makeInterceptor = (stats) => (dispatch) => (opts, handler) => {
   if (
     opts.retry === false ||
     opts.upgrade ||
@@ -984,5 +1021,20 @@ export default () => (dispatch) => (opts, handler) => {
     return dispatch(opts, handler)
   }
 
-  return new Handler(opts, { handler, dispatch }).dispatch(opts)
+  return new Handler(opts, { handler, dispatch, stats }).dispatch(opts)
+}
+
+export default () => {
+  const stats = {
+    retries: 0,
+    headerRetries: 0,
+    bodyRetries: 0,
+    recovered: 0,
+    failed: 0,
+    aborted: 0,
+    pending: 0,
+  }
+  const interceptor = makeInterceptor(stats)
+  interceptor.stats = () => ({ ...stats })
+  return interceptor
 }

--- a/test/cache-stats.js
+++ b/test/cache-stats.js
@@ -201,6 +201,44 @@ test('wrapped dispatcher stats globally include every interceptor snapshot', asy
     pending: 0,
   })
   t.match(stats.lookup, { lookups: 2, errors: 0, pending: 0 })
+  t.same(stats.retry, {
+    retries: 0,
+    headerRetries: 0,
+    bodyRetries: 0,
+    recovered: 0,
+    failed: 0,
+    aborted: 0,
+    pending: 0,
+  })
+})
+
+test('wrapped dispatcher stats globally include retry activity', async (t) => {
+  let requests = 0
+  const server = await startServer((_req, res) => {
+    requests++
+    res.writeHead(requests === 1 ? 503 : 200)
+    res.end()
+  })
+  t.teardown(() => server.close())
+
+  const agent = new undici.Agent()
+  t.teardown(() => agent.close())
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const before = getGlobalDispatcherStats().retry
+
+  await rawRequest((opts, handler) => nxtDispatch(agent, opts, handler), {
+    origin,
+    path: '/',
+    method: 'GET',
+    headers: {},
+    retry: 1,
+  })
+
+  const after = getGlobalDispatcherStats().retry
+  t.equal(after.retries, before.retries + 1)
+  t.equal(after.headerRetries, before.headerRetries + 1)
+  t.equal(after.recovered, before.recovered + 1)
+  t.equal(after.pending, 0)
 })
 
 test('wrapped dispatcher stats can be read for one dispatcher', async (t) => {

--- a/test/interceptor-stats.js
+++ b/test/interceptor-stats.js
@@ -103,6 +103,165 @@ test('redirect stats count accepted redirect hops', async (t) => {
   t.same(redirect.stats(), { followed: 1 })
 })
 
+test('retry stats count pending decisions, actual attempts, and outcomes', async (t) => {
+  const retry = interceptors.responseRetry()
+  let attempts = 0
+  let decide
+  const decision = new Promise((resolve) => {
+    decide = resolve
+  })
+  const dispatch = retry((_opts, handler) => {
+    attempts++
+    complete(handler, attempts === 1 ? 503 : 200)
+  })
+
+  const response = rawRequest(dispatch, {
+    origin: 'http://example.test',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    retry: () => decision,
+  })
+
+  await new Promise((resolve) => setImmediate(resolve))
+  t.same(retry.stats(), {
+    retries: 0,
+    headerRetries: 0,
+    bodyRetries: 0,
+    recovered: 0,
+    failed: 0,
+    aborted: 0,
+    pending: 1,
+  })
+
+  decide(true)
+  t.equal((await response).statusCode, 200)
+  t.same(retry.stats(), {
+    retries: 1,
+    headerRetries: 1,
+    bodyRetries: 0,
+    recovered: 1,
+    failed: 0,
+    aborted: 0,
+    pending: 0,
+  })
+
+  let failedAttempts = 0
+  const failedDispatch = retry((_opts, handler) => {
+    failedAttempts++
+    complete(handler, 503)
+  })
+  t.equal(
+    (
+      await rawRequest(failedDispatch, {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry: 1,
+      })
+    ).statusCode,
+    503,
+  )
+  t.equal(failedAttempts, 2)
+  t.match(retry.stats(), {
+    retries: 2,
+    headerRetries: 2,
+    recovered: 1,
+    failed: 1,
+    pending: 0,
+  })
+})
+
+test('retry stats distinguish body-resume retries', async (t) => {
+  const retry = interceptors.responseRetry()
+  let attempts = 0
+  const dispatch = retry((opts, handler) => {
+    attempts++
+    handler.onConnect(() => {})
+    if (attempts === 1) {
+      handler.onHeaders(200, { 'content-length': '5', etag: '"v1"' }, () => {})
+      handler.onData(Buffer.from('he'))
+      handler.onError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+      return
+    }
+
+    t.equal(opts.headers.range, 'bytes=2-4')
+    handler.onHeaders(
+      206,
+      { 'content-range': 'bytes 2-4/5', 'content-length': '3', etag: '"v1"' },
+      () => {},
+    )
+    handler.onData(Buffer.from('llo'))
+    handler.onComplete([])
+  })
+
+  const response = await rawRequest(dispatch, {
+    origin: 'http://example.test',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    retry: 1,
+  })
+
+  t.equal(response.body, 'hello')
+  t.same(retry.stats(), {
+    retries: 1,
+    headerRetries: 0,
+    bodyRetries: 1,
+    recovered: 1,
+    failed: 0,
+    aborted: 0,
+    pending: 0,
+  })
+})
+
+test('retry stats distinguish caller aborts after a retry', async (t) => {
+  const retry = interceptors.responseRetry()
+  const reason = new Error('stop')
+  const reset = Object.assign(new Error('reset'), { code: 'ECONNRESET' })
+  let attempts = 0
+  let abortRequest
+  const dispatch = retry((_opts, handler) => {
+    attempts++
+    handler.onConnect((abortReason) => handler.onError(abortReason))
+    if (attempts === 1) {
+      handler.onError(reset)
+    } else {
+      abortRequest(reason)
+    }
+  })
+
+  const err = await new Promise((resolve) => {
+    dispatch(
+      {
+        origin: 'http://example.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        retry: 1,
+      },
+      {
+        onConnect(abort) {
+          abortRequest = abort
+        },
+        onError: resolve,
+      },
+    )
+  })
+
+  t.equal(err, reason)
+  t.same(retry.stats(), {
+    retries: 1,
+    headerRetries: 1,
+    bodyRetries: 0,
+    recovered: 0,
+    failed: 0,
+    aborted: 1,
+    pending: 0,
+  })
+})
+
 test('dns stats distinguish cache hits, misses, negative hits, and resolver work', async (t) => {
   const dns = interceptors.dns()
   const dispatch = dns((_opts, handler) => complete(handler))

--- a/type-tests/interceptor-stats.ts
+++ b/type-tests/interceptor-stats.ts
@@ -7,12 +7,14 @@ import {
   type LookupStats,
   type PriorityStats,
   type RedirectStats,
+  type RetryStats,
 } from '../lib/index.js'
 
 const priority: PriorityStats[] = interceptors.priority().stats()
 const redirect: RedirectStats = interceptors.redirect().stats()
 const dns: DnsStats = interceptors.dns().stats()
 const lookup: LookupStats = interceptors.lookup().stats()
+const retry: RetryStats = interceptors.responseRetry().stats()
 const global = getGlobalDispatcherStats()
 const dispatcher = getDispatcherStats(new Agent())
 
@@ -20,9 +22,12 @@ priority[0]?.queues[0]?.completed
 redirect.followed
 dns.negativeHits
 lookup.pending
+retry.bodyRetries
 global.priority
 global.redirect
 global.dns
 global.lookup
+global.retry
 dispatcher.cache
 dispatcher.pressure
+dispatcher.retry


### PR DESCRIPTION
## What

Expose statistics from the response-retry interceptor and include them in both per-dispatcher and global dispatcher snapshots:

- actual retries, split into header retries and body range-resume retries
- recovered, failed, and caller-aborted logical requests after retrying
- retry decisions and backoff waits currently pending

The interceptor factory now exposes a typed `stats()` snapshot, matching the existing stats-bearing interceptor pattern.

## Why

Retries materially affect upstream traffic and latency, but callers could not distinguish retry amplification, successful recovery, terminal failure, caller aborts, or live backoff pressure.

## Impact

This is additive. Existing retry behavior is unchanged; the public stats shapes gain a `retry` field and `interceptors.responseRetry()` gains `stats()`.

## Checks

- `yarn tap test/interceptor-stats.js test/cache-stats.js` (56 assertions)
- `yarn tap test -Rterse` (4,046 passing assertions, 4 skips)
- `yarn test:types`
- ESLint on changed JavaScript
- Prettier check on changed files