### PR TITLE
fix(types): require defined response headers

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -540,7 +540,7 @@ export interface RequestOptions extends Omit<DispatchOptions, 'upgrade'> {
 
 export interface ResponseData {
   statusCode: number
-  headers: Record<string, string | string[] | undefined>
+  headers: Record<string, string | string[]>
   body: BodyReadable
 }
 

--- a/type-tests/response-headers.ts
+++ b/type-tests/response-headers.ts
@@ -1,0 +1,10 @@
+import type { ServerResponse } from 'node:http'
+
+import { request } from '../lib/index.js'
+
+declare const response: ServerResponse
+
+const upstream = await request('http://example.com')
+const headers: Record<string, string | string[]> = upstream.headers
+
+response.writeHead(upstream.statusCode, headers)


### PR DESCRIPTION
## Summary

- narrow `ResponseData.headers` to `Record<string, string | string[]>`
- add a compile-time regression proving request response headers have defined values and can be passed to `ServerResponse.writeHead()`

## Root cause

The hand-written `ResponseData` declaration incorrectly carried the nullable input-header domain into the response type. The runtime response pipeline already exposes normalized header values and drops nullish input values, so consumers should not need to filter `undefined` before forwarding response headers.

## Validation

- `node --version` (`v26.5.0`)
- `yarn test:types`
- `npx --no-install prettier --check lib/index.d.ts type-tests/response-headers.ts`
- `git diff --check`
- `yarn test` (190 of 191 test files completed; `test/retry-deep.js` hit its full-suite timeout)
- isolated rerun of both timed-out retry cases passed: `npx --no-install tap --grep='mid-stream retry: (etag mismatch on retry aborts|no content-range in retry response aborts)' test/retry-deep.js`