### PR TITLE
perf: reduce header normalization allocations

### DIFF
--- a/bench/log-disabled.mjs
+++ b/bench/log-disabled.mjs
@@ -1,0 +1,106 @@
+// Compare log-interceptor mode costs: the explicit disabled fast path, the
+// common but still-active shape of a truthy pino logger configured at level
+// `silent`, trace-only, and enabled logging. Point BENCH_NXT_UNDICI_ROOT at
+// another checkout when a candidate changes this path.
+//
+// Run with:
+//   node --expose-gc bench/log-disabled.mjs
+//   BENCH_NXT_UNDICI_ROOT=/path/to/baseline node --expose-gc bench/log-disabled.mjs
+
+import path from 'node:path'
+import { Writable } from 'node:stream'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { bench, do_not_optimize, group, run, summary } from 'mitata'
+import pino from 'pino'
+
+const root = path.resolve(
+  process.env.BENCH_NXT_UNDICI_ROOT ?? fileURLToPath(new URL('..', import.meta.url)),
+)
+const { interceptors } = await import(pathToFileURL(path.join(root, 'lib/index.js')))
+
+console.log(`implementation: ${root}`)
+
+const sink = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback()
+  },
+})
+const silentLogger = pino({ level: 'silent' }, sink)
+const infoLogger = pino({ level: 'info' }, sink)
+const chunk = Buffer.alloc(1024)
+const requestHeaders = {
+  accept: 'application/json',
+  authorization: 'Bearer benchmark-token',
+  cookie: 'session=benchmark-secret',
+  host: 'api.example.test',
+  'user-agent': 'nxt-undici-benchmark',
+  'x-request-id': 'benchmark-request-id',
+}
+const responseHeaders = {
+  'cache-control': 'private, max-age=0',
+  'content-length': String(chunk.length),
+  'content-type': 'application/json',
+  'set-cookie': 'session=benchmark-secret; Secure; HttpOnly',
+  vary: 'accept-encoding',
+  'x-request-id': 'benchmark-request-id',
+}
+const downstreamHandler = {
+  onConnect() {},
+  onHeaders() {
+    return true
+  },
+  onData() {},
+  onComplete() {},
+  onError(err) {
+    throw err
+  },
+}
+
+function createDispatch(statusCode) {
+  return interceptors.log()((_opts, handler) => {
+    handler.onConnect(() => {})
+    handler.onHeaders(statusCode, responseHeaders, () => {})
+    handler.onData(chunk)
+    handler.onComplete([])
+    return true
+  })
+}
+
+const dispatch200 = createDispatch(200)
+const dispatch500 = createDispatch(500)
+const baseOpts = {
+  id: 'benchmark-request-id',
+  origin: 'https://api.example.test',
+  path: '/assets/123',
+  method: 'GET',
+  headers: requestHeaders,
+}
+const trace = { write() {} }
+const disabledOpts = { ...baseOpts, logger: null, trace: null }
+const silentOpts = { ...baseOpts, logger: silentLogger, trace: null }
+const traceOpts = { ...baseOpts, logger: null, trace }
+const infoOpts = { ...baseOpts, logger: infoLogger, trace: null }
+
+group('log interceptor lifecycle', () => {
+  summary(() => {
+    bench('explicitly disabled', () =>
+      do_not_optimize(dispatch200(disabledOpts, downstreamHandler)),
+    )
+      .gc('inner')
+      .baseline(true)
+    bench('pino silent (still active)', () =>
+      do_not_optimize(dispatch200(silentOpts, downstreamHandler)),
+    ).gc('inner')
+    bench('trace only', () => do_not_optimize(dispatch200(traceOpts, downstreamHandler))).gc(
+      'inner',
+    )
+    bench('pino info, 200', () => do_not_optimize(dispatch200(infoOpts, downstreamHandler))).gc(
+      'inner',
+    )
+    bench('pino info, 500', () => do_not_optimize(dispatch500(infoOpts, downstreamHandler))).gc(
+      'inner',
+    )
+  })
+})
+
+await run({ colors: false })

--- a/bench/parse-headers.mjs
+++ b/bench/parse-headers.mjs
@@ -2,11 +2,22 @@
 //
 // Run with:
 //   node --expose-gc bench/parse-headers.mjs
+//   BENCH_NXT_UNDICI_ROOT=/path/to/baseline node --expose-gc bench/parse-headers.mjs
 
 // Sizes cover a header-light request through a deliberately large request.
 
-import { bench, group, run, summary } from 'mitata'
-import { createNormalizedHeaders, parseHeaders } from '../lib/utils.js'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { bench, do_not_optimize, group, run, summary } from 'mitata'
+
+const root = path.resolve(
+  process.env.BENCH_NXT_UNDICI_ROOT ?? fileURLToPath(new URL('..', import.meta.url)),
+)
+const { createNormalizedHeaders, parseHeaders } = await import(
+  pathToFileURL(path.join(root, 'lib/utils.js'))
+)
+
+console.log(`implementation: ${root}`)
 
 for (const size of [0, 4, 16, 64]) {
   const headers = {}
@@ -17,10 +28,10 @@ for (const size of [0, 4, 16, 64]) {
 
   group(`${size} headers`, () => {
     summary(() => {
-      bench('untrusted copy', () => parseHeaders(headers))
+      bench('untrusted copy', () => do_not_optimize(parseHeaders(headers)))
         .gc('inner')
         .baseline(true)
-      bench('trusted no-op', () => parseHeaders(normalized)).gc('inner')
+      bench('trusted no-op', () => do_not_optimize(parseHeaders(normalized))).gc('inner')
     })
   })
 }

--- a/bench/proxy-forwarded.mjs
+++ b/bench/proxy-forwarded.mjs
@@ -1,0 +1,119 @@
+// Measure the production public proxy interceptor's combined request-header
+// path, including defensive normalization and Forwarded synthesis. Point
+// BENCH_NXT_UNDICI_ROOT at another checkout for a matched before/after
+// comparison.
+//
+// Run with:
+//   node --expose-gc bench/proxy-forwarded.mjs
+//   BENCH_NXT_UNDICI_ROOT=/path/to/baseline node --expose-gc bench/proxy-forwarded.mjs
+
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { bench, do_not_optimize, group, run, summary } from 'mitata'
+
+const root = path.resolve(
+  process.env.BENCH_NXT_UNDICI_ROOT ?? fileURLToPath(new URL('..', import.meta.url)),
+)
+const { interceptors } = await import(pathToFileURL(path.join(root, 'lib/index.js')))
+
+console.log(`implementation: ${root}`)
+
+const handler = {
+  onConnect() {},
+  onHeaders() {
+    return true
+  },
+  onData() {},
+  onComplete() {},
+  onError(err) {
+    throw err
+  },
+}
+
+function createCase(opts, expectedForwarded) {
+  const dispatch = interceptors.proxy()((innerOpts) => innerOpts.headers)
+  const invoke = () => dispatch(opts, handler)
+  assert.equal(invoke().forwarded, expectedForwarded)
+  return invoke
+}
+
+const cases = [
+  [
+    'sparse socket',
+    createCase(
+      {
+        origin: 'http://upstream.test',
+        path: '/',
+        method: 'GET',
+        headers: {},
+        proxy: { socket: { encrypted: false } },
+      },
+      'proto=http',
+    ),
+  ],
+  [
+    'IPv4 with host',
+    createCase(
+      {
+        origin: 'http://upstream.test',
+        path: '/assets/123',
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer benchmark-token',
+          host: 'api.example.test',
+          'x-request-id': 'benchmark-request-id',
+        },
+        proxy: {
+          socket: {
+            encrypted: true,
+            localAddress: '192.0.2.1',
+            localPort: 443,
+            remoteAddress: '198.51.100.2',
+            remotePort: 1234,
+          },
+        },
+      },
+      'by="192.0.2.1:443";for="198.51.100.2:1234";proto=https;host="api.example.test"',
+    ),
+  ],
+  [
+    'IPv6 with authority',
+    createCase(
+      {
+        origin: 'https://upstream.test',
+        path: '/search?q=benchmark',
+        method: 'POST',
+        headers: {
+          ':authority': '[2001:db8::3]:8443',
+          ':scheme': 'https',
+          accept: 'application/json',
+          connection: 'keep-alive',
+          forwarded: 'for=192.0.2.60;proto=http',
+          'x-request-id': 'benchmark-request-id',
+        },
+        proxy: {
+          socket: {
+            encrypted: true,
+            localAddress: '2001:db8::1',
+            localPort: 443,
+            remoteAddress: '2001:db8::2',
+            remotePort: 4321,
+          },
+        },
+      },
+      'for=192.0.2.60;proto=http, by="[2001:db8::1]:443";for="[2001:db8::2]:4321";proto=https;host="[2001:db8::3]:8443"',
+    ),
+  ],
+]
+
+group('proxy request headers', () => {
+  summary(() => {
+    for (const [name, invoke] of cases) {
+      bench(name, () => do_not_optimize(invoke())).gc('inner')
+    }
+  })
+})
+
+await run({ colors: false })

--- a/lib/interceptor/proxy.js
+++ b/lib/interceptor/proxy.js
@@ -714,18 +714,21 @@ function reduceHeaders(
     }
 
     const forwardedHost = authority || host
+    let currentForwarded = ''
+    if (socket.localAddress) {
+      currentForwarded = `by=${printIp(socket.localAddress, socket.localPort)};`
+    }
+    if (socket.remoteAddress) {
+      currentForwarded += `for=${printIp(socket.remoteAddress, socket.remotePort)};`
+    }
+    currentForwarded += `proto=${scheme ?? (socket.encrypted ? 'https' : 'http')}`
+    if (forwardedHost) {
+      currentForwarded += `;host=${quoteForwardedString(forwardedHost)}`
+    }
     acc = fn(
       acc,
       'forwarded',
-      (forwarded && !remove?.includes('forwarded') ? forwarded + ', ' : '') +
-        [
-          socket.localAddress && `by=${printIp(socket.localAddress, socket.localPort)}`,
-          socket.remoteAddress && `for=${printIp(socket.remoteAddress, socket.remotePort)}`,
-          `proto=${scheme ?? (socket.encrypted ? 'https' : 'http')}`,
-          forwardedHost && `host=${quoteForwardedString(forwardedHost)}`,
-        ]
-          .filter(Boolean)
-          .join(';'),
+      (forwarded && !remove?.includes('forwarded') ? forwarded + ', ' : '') + currentForwarded,
     )
   } else if (forwarded && !remove?.includes('forwarded')) {
     // Forwarded is a request-only header (RFC 7239): a proxy must neither emit

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -772,12 +772,16 @@ export class DecoratorHandler {
 }
 
 function setOwnHeader(obj, key, value) {
-  Object.defineProperty(obj, key, {
-    value,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  })
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  } else {
+    obj[key] = value
+  }
 }
 
 function headerValueToString(value) {
@@ -799,7 +803,7 @@ function appendHeader(obj, key2, val2) {
     let val = obj[key]
     if (!Array.isArray(val)) {
       val = [val]
-      setOwnHeader(obj, key, val)
+      obj[key] = val
     }
 
     if (Array.isArray(val2)) {

--- a/test/parse-headers-prototype-safety.js
+++ b/test/parse-headers-prototype-safety.js
@@ -19,5 +19,21 @@ test('parseHeaders treats prototype names as ordinary header names', (t) => {
   t.equal(Object.hasOwn(fromObject, 'constructor'), true)
   t.equal(fromObject.constructor, 'object-constructor')
 
+  let inheritedSetterCalls = 0
+  Object.defineProperty(Object.prototype, 'x-inherited-setter', {
+    configurable: true,
+    set() {
+      inheritedSetterCalls++
+    },
+  })
+  try {
+    const fromPollutedPrototype = parseHeaders({ 'x-inherited-setter': 'safe' })
+    t.equal(inheritedSetterCalls, 0)
+    t.equal(Object.hasOwn(fromPollutedPrototype, 'x-inherited-setter'), true)
+    t.equal(fromPollutedPrototype['x-inherited-setter'], 'safe')
+  } finally {
+    delete Object.prototype['x-inherited-setter']
+  }
+
   t.end()
 })

--- a/test/proxy-forwarded-scheme.js
+++ b/test/proxy-forwarded-scheme.js
@@ -1,7 +1,7 @@
 import { test } from 'tap'
 import { compose, interceptors } from '../lib/index.js'
 
-function forwardedHeader(scheme, encrypted) {
+function forwardedHeader(scheme, encrypted, socket = {}) {
   let forwarded
   const dispatch = compose((opts, handler) => {
     forwarded = opts.headers.forwarded
@@ -20,6 +20,7 @@ function forwardedHeader(scheme, encrypted) {
         socket: {
           localAddress: '192.0.2.1',
           encrypted,
+          ...socket,
         },
       },
     },
@@ -52,6 +53,20 @@ test('proxy: Forwarded proto prefers :scheme over an encrypted proxy socket', (t
 test('proxy: Forwarded proto falls back to the proxy socket', (t) => {
   t.equal(forwardedHeader(undefined, false), 'by=192.0.2.1;proto=http')
   t.equal(forwardedHeader(undefined, true), 'by=192.0.2.1;proto=https')
+  t.end()
+})
+
+test('proxy: Forwarded preserves field order for sparse and complete sockets', (t) => {
+  t.equal(forwardedHeader(undefined, false, { localAddress: undefined }), 'proto=http')
+  t.equal(
+    forwardedHeader(undefined, true, {
+      localAddress: '2001:db8::1',
+      localPort: 443,
+      remoteAddress: '198.51.100.2',
+      remotePort: 1234,
+    }),
+    'by="[2001:db8::1]:443";for="198.51.100.2:1234";proto=https',
+  )
   t.end()
 })
 


### PR DESCRIPTION
## Summary

- use ordinary assignment for new header names, with a descriptor fallback for own or inherited names so `__proto__`, `constructor`, and polluted-prototype setters remain safe
- build the RFC 7239 `Forwarded` value incrementally instead of allocating and filtering a temporary array
- add focused production-path benchmarks for header parsing, proxy header synthesis, and log-interceptor modes

## Containerized benchmark

Node 26.5.0 in `node:26.5.0-bookworm` (digest `sha256:465292e747f0124f074dc7d6e79dd38141d132d53d076b3ef0e0a43eea019e80`), CPU-pinned on an AMD EPYC 9355P. Baseline and candidate ran in three balanced rounds; values below are medians.

| Workload | Baseline | Candidate | Time | Allocation |
| --- | ---: | ---: | ---: | ---: |
| copy 4 headers | 600.7 ns | 186.8 ns | -68.9% | 488 B -> 264 B |
| copy 16 headers | 2.60 us | 779.8 ns | -70.0% | 1.90 KiB -> 1.02 KiB |
| copy 64 headers | 11.57 us | 4.82 us | -58.3% | 3.87 KiB -> 1.02 KiB |
| sparse proxy headers | 299.5 ns | 255.1 ns | -14.8% | about -26% |
| IPv4 + Host proxy headers | 1.91 us | 1.37 us | -28.3% | 1.90 KiB -> 1.46 KiB |
| IPv6 + Authority proxy headers | 3.17 us | 2.19 us | -30.9% | 2.46 KiB -> 1.88 KiB |

The branded normalized-header path remains a roughly 6 ns identity operation, so repeat internal normalization was already avoided.

A 20-second TLS fallback CPU profile reduced `setOwnHeader` from 1.10% to 0.31% active self and `reduceHeaders` from 1.67% to 0.94%: 2.77% -> 1.25% combined, a 55% reduction and 1.52 percentage points removed. Five balanced route pairs were throughput-inconclusive (median +0.3%, paired range -4.6% to +5.0%), so this PR does not claim an end-to-end throughput gain.

The proxy-path benchmark includes defensive normalization and `Forwarded` synthesis together; its full delta is not attributed to the string-construction change alone.

## Validation

- Prettier and ESLint on all changed files
- `yarn test:types`
- focused prototype-safety and Forwarded tests: 20 assertions passed
- `node bench/reduce-headers.mjs --check`: all 5 variants match across 17 fixtures
- the one unrelated redirect case that failed during a severely contended full-suite run passed 17/17 in isolation
